### PR TITLE
Fix DictionaryStaticDataStore_ManyParallelCallsShouldNotReloadData

### DIFF
--- a/Havit.Blazor.Components.Web.Tests/DataStores/DictionaryStaticDataStoreTests.cs
+++ b/Havit.Blazor.Components.Web.Tests/DataStores/DictionaryStaticDataStoreTests.cs
@@ -106,7 +106,7 @@ namespace Havit.Blazor.Components.Web.Tests.DataStores
 			CollectionAssert.AreEqual(new[] { "Adam", "Barbora", "Cyril" }, result.ToList());
 		}
 
-		//[TestMethod] - This test fails and should NOT!
+		[TestMethod]
 		public void DictionaryStaticDataStore_ManyParallelCallsShouldNotReloadData()
 		{
 			// arrange
@@ -116,10 +116,11 @@ namespace Havit.Blazor.Components.Web.Tests.DataStores
 			sut.Setup(s => s.LoadDataAsync()).ReturnsAsync(new[] { "Adam", "Barbora", "Cyril" }, TimeSpan.FromMilliseconds(50));
 			sut.Setup(s => s.ShouldRefresh()).Returns(false);
 
+			var store = sut.Object;
 			// act
 			Parallel.For(0, 1000, async (int i) =>
 			{
-				_ = await sut.Object.GetAllAsync();
+				_ = await store.GetAllAsync();
 			});
 
 			// assert

--- a/Havit.Blazor.Components.Web/Services/DataStores/DictionaryStaticDataStore.cs
+++ b/Havit.Blazor.Components.Web/Services/DataStores/DictionaryStaticDataStore.cs
@@ -107,6 +107,6 @@ namespace Havit.Blazor.Components.Web.Services.DataStores
 				}
 			}
 		}
-		private readonly SemaphoreSlim loadLock = new SemaphoreSlim(1);
+		private readonly SemaphoreSlim loadLock = new SemaphoreSlim(1, 1);
 	}
 }


### PR DESCRIPTION
 Getting the `Object` from `Mock` must be thread safe. Hence doing it before spinning up testing