### PR TITLE
Fix popover on safari

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Tooltips/Internal/HxTooltipInternalBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tooltips/Internal/HxTooltipInternalBase.cs
@@ -96,11 +96,10 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal
 			{
 				builder.OpenElement(1, "span");
 				builder.AddAttribute(2, "class", WrapperCssClass);
-				builder.AddAttribute(3, "data-bs-container", "body");
-				builder.AddAttribute(4, "data-bs-trigger", GetTriggers());
-				builder.AddAttribute(5, "data-bs-placement", PlacementInternal.ToString().ToLower());
-				builder.AddAttribute(6, "data-bs-custom-class", CssClass);
-				builder.AddAttribute(7, "title", TitleInternal);
+				builder.AddAttribute(3, "data-bs-trigger", GetTriggers().Replace("hover", "hover focus"));
+				builder.AddAttribute(4, "data-bs-placement", PlacementInternal.ToString().ToLower());
+				builder.AddAttribute(5, "data-bs-custom-class", CssClass);
+				builder.AddAttribute(6, "title", TitleInternal);
 				if (!String.IsNullOrWhiteSpace(ContentInternal))
 				{
 					// used only by HxPopover
@@ -136,6 +135,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal
 					result = result + " " + flag.ToString().ToLower();
 				}
 			}
+
 			return result?.Trim();
 		}
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Tooltips/Internal/HxTooltipInternalBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tooltips/Internal/HxTooltipInternalBase.cs
@@ -135,7 +135,6 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal
 					result = result + " " + flag.ToString().ToLower();
 				}
 			}
-
 			return result?.Trim();
 		}
 


### PR DESCRIPTION
Using data-bs-container breaks support on safari.
Furthermore, trigger hover only works when used in conjunction with focus.