### PR TITLE
JSRuntime.ImportModule() extension method

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Havit.Blazor.Components.Web.Bootstrap.csproj
+++ b/Havit.Blazor.Components.Web.Bootstrap/Havit.Blazor.Components.Web.Bootstrap.csproj
@@ -6,6 +6,12 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Havit.Blazor.Components.Web.Bootstrap.Tests" />
+		<InternalsVisibleTo Include="Havit.Blazor.Components.Web.Bootstrap.Documentation" />
+	</ItemGroup>
+
+
 	<!-- NuGet -->
 	<Import Project="../NuGet.targets" />
 	<PropertyGroup>

--- a/Havit.Blazor.Components.Web.Bootstrap/JSRuntimeExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/JSRuntimeExtensions.cs
@@ -1,19 +1,14 @@
-﻿using System.Reflection;
-using Microsoft.JSInterop;
+﻿using Microsoft.JSInterop;
 
 namespace Havit.Blazor.Components.Web.Bootstrap;
 public static class JSRuntimeExtensions
 {
-	public static ValueTask<IJSObjectReference> ImportHavitBlazorBootstrapModule(this IJSRuntime jsRuntime, string moduleNameWithoutExtension)
+	internal static ValueTask<IJSObjectReference> ImportHavitBlazorBootstrapModule(this IJSRuntime jsRuntime, string moduleNameWithoutExtension)
 	{
-		var path = "./_content/Havit.Blazor.Components.Web.Bootstrap/" + moduleNameWithoutExtension + ".js?v=" + GetVersionIdentifier();
+		versionIdentifierHavitBlazorBootstrap ??= Havit.Blazor.Components.Web.JSRuntimeExtensions.GetAssemblyVersionIdentifierForUri(typeof(ThemeColor).Assembly);
+
+		var path = "./_content/Havit.Blazor.Components.Web.Bootstrap/" + moduleNameWithoutExtension + ".js?v=" + versionIdentifierHavitBlazorBootstrap;
 		return jsRuntime.InvokeAsync<IJSObjectReference>("import", path);
 	}
-
-	private static string GetVersionIdentifier()
-	{
-		versionIdentifier ??= Uri.EscapeDataString(((AssemblyInformationalVersionAttribute)Attribute.GetCustomAttribute(typeof(ThemeColor).Assembly, typeof(AssemblyInformationalVersionAttribute), false)).InformationalVersion);
-		return versionIdentifier;
-	}
-	private static string versionIdentifier;
+	private static string versionIdentifierHavitBlazorBootstrap;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Properties/AssemblyInfo.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Properties/AssemblyInfo.cs
@@ -1,11 +1,5 @@
-﻿using System.Runtime.CompilerServices;
-
-// In a class library there must be present ResourceLocationAttribute otherwise developer can change where resources should be located.
+﻿// In a class library there must be present ResourceLocationAttribute otherwise developer can change where resources should be located.
 // To understand this well see comment in ResourceManagerStringLocalizerFactory.GetResourcePath (https://github.com/aspnet/Localization/blob/c283dfb56cd9620edfae644f1229d8231e9cfc0e/src/Microsoft.Extensions.Localization/ResourceManagerStringLocalizerFactory.cs#L249).
 // We would like to share resources near classes, unfortunatelly we cannot use ResourceLocationAttribute with an empty string (https://github.com/aspnet/Localization/blob/43b974482c7b703c92085c6f68b3b23d8fe32720/src/Microsoft.Extensions.Localization/ResourceLocationAttribute.cs#L22).
 // Thus we are forced to use some namespace.
-[assembly: Microsoft.Extensions.Localization.ResourceLocation("Resources")]
-
-[assembly: InternalsVisibleTo("Havit.Blazor.Components.Web.Bootstrap.Documentation")]
-[assembly: InternalsVisibleTo("Havit.Blazor.Components.Web.Bootstrap.Tests")]
-
+[assembly: Microsoft.Extensions.Localization.ResourceLocation("Resources")] 

--- a/Havit.Blazor.Components.Web/GlobalUsings.cs
+++ b/Havit.Blazor.Components.Web/GlobalUsings.cs
@@ -4,6 +4,8 @@ global using System.Linq;
 global using System.Text;
 global using System.Threading.Tasks;
 
+global using Havit.Diagnostics.Contracts;
+
 global using Microsoft.AspNetCore.Components;
 global using Microsoft.AspNetCore.Components.Rendering;
 global using Microsoft.AspNetCore.Components.Web;

--- a/Havit.Blazor.Components.Web/Havit.Blazor.Components.Web.csproj
+++ b/Havit.Blazor.Components.Web/Havit.Blazor.Components.Web.csproj
@@ -8,6 +8,8 @@
 
 	<ItemGroup>
 		<SupportedPlatform Include="browser" />
+		<InternalsVisibleTo Include="Havit.Blazor.Components.Web.Tests" />
+		<InternalsVisibleTo Include="Havit.Blazor.Components.Web.Bootstrap" />
 	</ItemGroup>
 
 	<!-- NuGet -->

--- a/Havit.Blazor.Components.Web/Properties/AssemblyInfo.cs
+++ b/Havit.Blazor.Components.Web/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Havit.Blazor.Components.Web.Tests")]


### PR DESCRIPTION
@jirikanda Take a look at `GetAssemblyVersionIdentifierForUri()` please. Is it the approach we want to use to get the right version info?