### PR TITLE
HxMultiSelect - ToggleTemplate?

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/Pages/Components/HxMultiSelectDoc/HxMultiSelect_Demo_CustomToggle.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/Pages/Components/HxMultiSelectDoc/HxMultiSelect_Demo_CustomToggle.razor
@@ -1,0 +1,35 @@
+﻿<HxMultiSelect Label="Band members"
+               TItem="Person"
+               TValue="string"
+               Data="@people"
+               @bind-Value="@selectedPersonsInitials"
+               TextSelector="@(p => p.Name)"
+               ValueSelector="@(p => p.Initials)"
+               EmptyText="-select values-"
+               NullDataText="Loading band members...">
+               <ToggleTemplate>
+                   <HxButton Color="ThemeColor.Primary" Outline="true" Icon="BootstrapIcon.PeopleFill" />
+               </ToggleTemplate>
+           </HxMultiSelect>
+
+<p class="mt-3">Selected initials: @String.Join(' ', selectedPersonsInitials)</p>
+
+@code {
+    private List<Person> people;
+    private List<string> selectedPersonsInitials { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+		await Task.Delay(1000); // simulates slow server API call
+
+        people = new List<Person>
+        {
+            new Person("Starr Ringo", "RS"),
+            new Person("Lennon John", "JL"),
+            new Person("McCartney Paul", "PMC"),
+            new Person("Harrison George", "GH")
+        };
+    }
+
+    private record Person(string Name, string Initials);
+}

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/Pages/Components/HxMultiSelectDoc/HxMultiSelect_Documentation.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/Pages/Components/HxMultiSelectDoc/HxMultiSelect_Documentation.razor
@@ -6,6 +6,10 @@
         <SectionTitle Id="basic-usage" Title="Basic Usage" />
         <Demo Type="typeof(HxMultiSelect_Demo_BasicUsage)" Tabs="false" />
 
+        <SectionTitle Id="CustomToggle" />
+        <p>Define a custom template for toggling the dropdown. When specified, the default <code>input</code> element is not rendered.</p>
+        <Demo Type="typeof(HxMultiSelect_Demo_CustomToggle)" />
+
     </MainContent>
     <CssVariables>
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/Shared/Components/Search/Search.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/Shared/Components/Search/Search.razor.cs
@@ -80,7 +80,9 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Documentation.Shared.Components
 			new("/components/HxRadioButtonList", "HxRadioButtonList", "multiselect"),
 
 			new("/components/HxSelect", "HxSelect", "dropdownlist picker"),
+
 			new("/components/HxMultiSelect", "HxMultiSelect", "dropdownlist picker checkbox multiple"),
+			new("/components/HxMultiSelect#CustomToggle", "HxMultiSelect > Custom toggle", ""),
 
 			new("/components/HxFilterForm", "HxFilterForm", "HxListLayout"),
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -3849,6 +3849,12 @@
             Input-group at the end of the input.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMultiSelect`2.InputText">
+            <summary>
+            Text content of the input.
+            If set, overrides default behavior, which is displaying selected items' texts separated by a comma.
+            </summary>
+        </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxMultiSelect`2.FocusAsync">
             <inheritdoc cref="M:Havit.Blazor.Components.Web.Bootstrap.HxInputBase`1.FocusAsync"/>
         </member>

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2439,6 +2439,11 @@
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxInputDateRangeInternal.DisposeAsync">
             <inheritdoc />
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxMultiSelectInternal`2.ToggleTemplate">
+            <summary>
+            Set the content of the element used to toggle the dropdown.
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxMultiSelectInternal`2.InputGroupCssClass">
             <summary>
             Custom CSS class to render with input-group span.
@@ -3853,6 +3858,11 @@
             <summary>
             Text content of the input.
             If set, overrides default behavior, which is displaying selected items' texts separated by a comma.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMultiSelect`2.ToggleTemplate">
+            <summary>
+            Set the content of the element used to toggle the dropdown.
             </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxMultiSelect`2.FocusAsync">

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
@@ -106,6 +106,12 @@ public class HxMultiSelect<TValue, TItem> : HxInputBase<List<TValue>>, IInputWit
 	/// </summary>
 	[Parameter] public RenderFragment InputGroupEndTemplate { get; set; }
 
+	/// <summary>
+	/// Text content of the input.
+	/// If set, overrides default behavior, which is displaying selected items' texts separated by a comma.
+	/// </summary>
+	[Parameter] public string InputText { get; set; }
+
 	private List<TItem> itemsToRender;
 	private HxMultiSelectInternal<TValue, TItem> hxMultiSelectInternalComponent;
 
@@ -171,7 +177,7 @@ public class HxMultiSelect<TValue, TItem> : HxInputBase<List<TValue>>, IInputWit
 		builder.OpenComponent<HxMultiSelectInternal<TValue, TItem>>(100);
 		builder.AddAttribute(101, nameof(HxMultiSelectInternal<TValue, TItem>.InputId), InputId);
 		builder.AddAttribute(102, nameof(HxMultiSelectInternal<TValue, TItem>.InputCssClass), GetInputCssClassToRender());
-		builder.AddAttribute(103, nameof(HxMultiSelectInternal<TValue, TItem>.InputText), CurrentValueAsString);
+		builder.AddAttribute(103, nameof(HxMultiSelectInternal<TValue, TItem>.InputText), InputText ?? CurrentValueAsString);
 		builder.AddAttribute(104, nameof(HxMultiSelectInternal<TValue, TItem>.EnabledEffective), EnabledEffective);
 		builder.AddAttribute(105, nameof(HxMultiSelectInternal<TValue, TItem>.ItemsToRender), itemsToRender);
 		builder.AddAttribute(106, nameof(HxMultiSelectInternal<TValue, TItem>.TextSelector), TextSelector);

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
@@ -112,6 +112,11 @@ public class HxMultiSelect<TValue, TItem> : HxInputBase<List<TValue>>, IInputWit
 	/// </summary>
 	[Parameter] public string InputText { get; set; }
 
+	/// <summary>
+	/// Set the content of the element used to toggle the dropdown.
+	/// </summary>
+	[Parameter] public RenderFragment ToggleTemplate { get; set; }
+
 	private List<TItem> itemsToRender;
 	private HxMultiSelectInternal<TValue, TItem> hxMultiSelectInternalComponent;
 
@@ -189,6 +194,7 @@ public class HxMultiSelect<TValue, TItem> : HxInputBase<List<TValue>>, IInputWit
 		builder.AddAttribute(112, nameof(HxMultiSelectInternal<TValue, TItem>.InputGroupStartTemplate), InputGroupStartTemplate);
 		builder.AddAttribute(113, nameof(HxMultiSelectInternal<TValue, TItem>.InputGroupEndText), InputGroupEndText);
 		builder.AddAttribute(114, nameof(HxMultiSelectInternal<TValue, TItem>.InputGroupEndTemplate), InputGroupEndTemplate);
+		builder.AddAttribute(115, nameof(HxMultiSelectInternal<TValue, TItem>.ToggleTemplate), ToggleTemplate);
 
 		builder.AddMultipleAttributes(200, this.AdditionalAttributes);
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
@@ -15,15 +15,22 @@
     
         @InputGroupStartTemplate
         
-        <input
-            @ref="inputElement"
-            type="text"
-            id="@InputId"
-            class="@InputCssClass"
-            value="@(((ItemsToRender == null) && !String.IsNullOrEmpty(NullDataText)) ? NullDataText : InputText)"
-            disabled="@(!enabled)"
-            readonly="true"
-            @attributes="this.AdditionalAttributes" />
+        @if (ToggleTemplate is null)
+        {
+            <input
+                @ref="inputElement"
+                type="text"
+                id="@InputId"
+                class="@InputCssClass"
+                value="@(((ItemsToRender == null) && !String.IsNullOrEmpty(NullDataText)) ? NullDataText : InputText)"
+                disabled="@(!enabled)"
+                readonly="true"
+                @attributes="this.AdditionalAttributes" />
+        }
+        else
+        {
+            @ToggleTemplate
+        }
 
         @InputGroupEndTemplate
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -27,6 +27,11 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal
 
 		[Parameter] public string NullDataText { get; set; }
 
+		/// <summary>
+		/// Set the content of the element used to toggle the dropdown.
+		/// </summary>
+		[Parameter] public RenderFragment ToggleTemplate { get; set; }
+
 		[Parameter] public EventCallback<SelectionChangedArgs> ItemSelectionChanged { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
@crdo I'm suggesting adding the possibility to define custom content for the element that is used for opening the HxMultiSelect. An example use-case would be if we'd want to let the user show/hide grid columns using HxMultiSelect and show only a button with an icon to open the dropdown menu.

If we want to render a RenderFragment as the content, then we are going to have to use a different element than "input".

Thanks for considering.