### PR TITLE
[HxSidebarItem] Provide a context to the ContentTemplate indicating whether the item is expanded or collapsed #257

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -7280,6 +7280,16 @@
             Pills <see href="https://getbootstrap.com/docs/5.1/components/navs-tabs/#pills">https://getbootstrap.com/docs/5.1/components/navs-tabs/#pills</see>.
             </summary>
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.SidebarItemContentTemplateContext">
+            <summary>
+            Context provided to the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSidebarItem.ContentTemplate" />.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SidebarItemContentTemplateContext.Collapsed">
+            <summary>
+            Indicates whether a <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxSidebarItem"/> is collapsed or expanded. Is <c>null</c> when item has no expandable content.
+            </summary>
+        </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.SidebarResponsiveBreakpoint.None">
             <summary>
             Mobile mode disabled, allways render as sidebar.

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -7300,7 +7300,7 @@
             Context provided to the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSidebarItem.ContentTemplate" />.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SidebarItemContentTemplateContext.Collapsed">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SidebarItemContentTemplateContext.ItemExpanded">
             <summary>
             Indicates whether a <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxSidebarItem"/> is collapsed or expanded. Is <c>null</c> when item has no expandable content.
             </summary>

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -1259,6 +1259,11 @@
             Additional attributes to be splatted onto an underlying <c>div</c> element.
             </summary>
         </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.HxCollapse.shouldToggle">
+            <summary>
+            Indicates ShowAsync() was called before OnAfterRenderAsync (DOM not initialized). Therefor we will remember the request for Show and initialize the collapse with toggle=true.
+            </summary>
+        </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxCollapse.OnAfterRenderAsync(System.Boolean)">
             <inheritdoc cref="M:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync(System.Boolean)" />
         </member>

--- a/Havit.Blazor.Components.Web.Bootstrap/Collapse/HxCollapse.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Collapse/HxCollapse.razor.cs
@@ -75,6 +75,12 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		private bool isShown;
 		private bool showInProgress;
 		private bool hideInProgress;
+		private bool initialized;
+
+		/// <summary>
+		/// Indicates ShowAsync() was called before OnAfterRenderAsync (DOM not initialized). Therefor we will remember the request for Show and initialize the collapse with toggle=true.
+		/// </summary>
+		private bool shouldToggle;
 
 		public HxCollapse()
 		{
@@ -92,6 +98,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		/// <inheritdoc cref="ComponentBase.OnAfterRenderAsync(bool)" />
 		protected override async Task OnAfterRenderAsync(bool firstRender)
 		{
+
 			await base.OnAfterRenderAsync(firstRender);
 
 			if (firstRender)
@@ -101,7 +108,8 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 				{
 					return;
 				}
-				await jsModule.InvokeVoidAsync("initialize", collapseHtmlElement, dotnetObjectReference);
+				await jsModule.InvokeVoidAsync("initialize", collapseHtmlElement, dotnetObjectReference, shouldToggle);
+				initialized = true;
 			}
 		}
 
@@ -118,9 +126,16 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		/// </summary>
 		public async Task ShowAsync()
 		{
-			await EnsureJsModuleAsync();
-			showInProgress = true;
-			await jsModule.InvokeVoidAsync("show", collapseHtmlElement);
+			if (initialized)
+			{
+				await EnsureJsModuleAsync();
+				showInProgress = true;
+				await jsModule.InvokeVoidAsync("show", collapseHtmlElement);
+			}
+			else
+			{
+				shouldToggle = true;
+			}
 		}
 
 		/// <summary>

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
@@ -17,7 +17,10 @@
                         }
 
                         <span class="hx-sidebar-item-navlink-content-inner">
-                            @ContentTemplate
+                            @if (ContentTemplate is not null)
+                            {
+                                @ContentTemplate(new(){ Collapsed = null })
+                            }
                             @Text
                         </span>
                     </div>
@@ -35,7 +38,10 @@
                     }
 
                     <span class="hx-sidebar-item-navlink-content-inner">
-                        @ContentTemplate
+                        @if (ContentTemplate is not null)
+                        {
+                            @ContentTemplate(new(){ Collapsed = this.Collapsed })
+                        }
                         @Text
                     </span>
 
@@ -80,11 +86,16 @@
 
                 </HxNavLink>
 
-                <div class="@CssClassHelper.Combine("hx-sidebar-subitems collapse", this.ShouldBeExpanded ? "show" : null)" id="@id">
+                <HxCollapse
+                    Id="@id"
+                    @ref="collapseComponent"
+                    CssClass="hx-sidebar-subitems"
+                    OnShown="() => collapsed = false"
+                    OnHidden="() => collapsed = true"> @* Add following attribute: InitiallyExpanded="ShouldBeExpanded" (waiting for https://github.com/havit/Havit.Blazor/pull/246) *@
                     <nav class="nav hx-sidebar-collapsed-nav">
                         @ChildContent
                     </nav>
-                </div>
+                </HxCollapse>
             }
         }
     </div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
@@ -19,7 +19,7 @@
                         <span class="hx-sidebar-item-navlink-content-inner">
                             @if (ContentTemplate is not null)
                             {
-                                @ContentTemplate(new(){ Collapsed = null })
+                                @ContentTemplate(new(){ ItemExpanded = null })
                             }
                             @Text
                         </span>
@@ -40,7 +40,7 @@
                     <span class="hx-sidebar-item-navlink-content-inner">
                         @if (ContentTemplate is not null)
                         {
-                            @ContentTemplate(new(){ Collapsed = this.Collapsed })
+                            @ContentTemplate(new(){ ItemExpanded = this.expanded })
                         }
                         @Text
                     </span>
@@ -90,8 +90,8 @@
                     Id="@id"
                     @ref="collapseComponent"
                     CssClass="hx-sidebar-subitems"
-                    OnShown="() => collapsed = false"
-                    OnHidden="() => collapsed = true"
+                    OnShown="() => expanded = true"
+                    OnHidden="() => expanded = false"
                     InitiallyExpanded="ShouldBeExpanded">
                     <nav class="nav hx-sidebar-collapsed-nav">
                         @ChildContent

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
@@ -40,7 +40,7 @@
                     <span class="hx-sidebar-item-navlink-content-inner">
                         @if (ContentTemplate is not null)
                         {
-                            @ContentTemplate(new(){ ItemExpanded = this.expanded })
+                            @ContentTemplate(new() { ItemExpanded = this.expanded })
                         }
                         @Text
                     </span>
@@ -58,7 +58,7 @@
                            Enabled="this.Enabled"
                            role="button"
                            data-bs-toggle="dropdown"
-                           aria-expanded="@(this.ShouldBeExpanded ? "true" : "false")">
+                           aria-expanded="@(this.expanded ? "true" : "false")">
                         
                            @itemNavLinkContent
 
@@ -80,7 +80,7 @@
                         role="button"
                         data-bs-toggle="collapse"
                         data-bs-target="@("#" + id)"
-                        aria-expanded="@(this.ShouldBeExpanded ? "true" : "false")">
+                        aria-expanded="@(this.expanded ? "true" : "false")">
 
                         @itemNavLinkContent
 
@@ -90,9 +90,8 @@
                     Id="@id"
                     @ref="collapseComponent"
                     CssClass="hx-sidebar-subitems"
-                    OnShown="() => expanded = true"
-                    OnHidden="() => expanded = false"
-                    InitiallyExpanded="ShouldBeExpanded">
+                    OnShown="HandleCollapseShown"
+                    OnHidden="HandleCollapseHidden">
                     <nav class="nav hx-sidebar-collapsed-nav">
                         @ChildContent
                     </nav>

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor
@@ -91,7 +91,8 @@
                     @ref="collapseComponent"
                     CssClass="hx-sidebar-subitems"
                     OnShown="() => collapsed = false"
-                    OnHidden="() => collapsed = true"> @* Add following attribute: InitiallyExpanded="ShouldBeExpanded" (waiting for https://github.com/havit/Havit.Blazor/pull/246) *@
+                    OnHidden="() => collapsed = true"
+                    InitiallyExpanded="ShouldBeExpanded">
                     <nav class="nav hx-sidebar-collapsed-nav">
                         @ChildContent
                     </nav>

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
@@ -65,20 +65,19 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		[Inject] protected NavigationManager NavigationManager { get; set; }
 
 		private string id = "hx" + Guid.NewGuid().ToString("N");
-		private HxCollapse collapseComponent;
 
 		protected List<HxSidebarItem> childItems;
 		internal CollectionRegistration<HxSidebarItem> ChildItemsRegistration { get; }
 
-		protected bool isDisposed;
+		protected HxCollapse collapseComponent;
+		protected bool disposed;
 		protected bool isMatch;
-
 		protected bool expanded;
 
 		public HxSidebarItem()
 		{
 			childItems = new();
-			ChildItemsRegistration = new(childItems, async () => await InvokeAsync(this.StateHasChanged), () => isDisposed);
+			ChildItemsRegistration = new(childItems, async () => await InvokeAsync(this.StateHasChanged), () => disposed);
 		}
 
 		protected override void OnInitialized()
@@ -97,18 +96,23 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		protected bool ShouldBeExpanded => ExpandOnMatch && this.childItems.Any(i => i.isMatch && i.ExpandOnMatch);
 		protected bool HasExpandableContent => (this.ChildContent is not null);
 
-		/*
-		 * Explicit StateHasChanged() not needed as there is one already in ChildItemsRegistration.Register()? 
-		 * 
-		protected override void OnAfterRender(bool firstRender)
+		protected override async Task OnAfterRenderAsync(bool firstRender)
 		{
-			if (firstRender)
+			if (firstRender && ShouldBeExpanded)
 			{
-				// re-render to allow child-parent propagation of IsMatch logic for initial expansion
-				StateHasChanged();
+				await collapseComponent.ShowAsync();
 			}
 		}
-		*/
+
+		private void HandleCollapseShown()
+		{
+			expanded = true;
+		}
+
+		private void HandleCollapseHidden()
+		{
+			expanded = false;
+		}
 
 		public async ValueTask DisposeAsync()
 		{
@@ -116,7 +120,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 
 			//Dispose(disposing: false);
 
-			isDisposed = true;
+			disposed = true;
 		}
 
 		protected virtual async ValueTask DisposeAsyncCore()

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
@@ -64,15 +64,16 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 
 		[Inject] protected NavigationManager NavigationManager { get; set; }
 
-		public bool Collapsed => collapsed;
-		protected bool collapsed;
-
 		private string id = "hx" + Guid.NewGuid().ToString("N");
 		private HxCollapse collapseComponent;
+
 		protected List<HxSidebarItem> childItems;
 		internal CollectionRegistration<HxSidebarItem> ChildItemsRegistration { get; }
+
 		protected bool isDisposed;
 		protected bool isMatch;
+
+		protected bool expanded;
 
 		public HxSidebarItem()
 		{

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
@@ -109,12 +109,12 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		}
 		*/
 
-		public async Task Expand()
+		public async Task ExpandAsync()
 		{
 			await collapseComponent?.ShowAsync();
 		}
 
-		public async Task Collapse()
+		public async Task CollapseAsync()
 		{
 			await collapseComponent?.HideAsync();
 		}

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
@@ -51,7 +51,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		/// <summary>
 		/// Inner custom content for the <see cref="HxSidebarItem"/>.
 		/// </summary>
-		[Parameter] public RenderFragment ContentTemplate { get; set; }
+		[Parameter] public RenderFragment<SidebarItemContentTemplateContext> ContentTemplate { get; set; }
 
 		/// <summary>
 		/// Sub-items (not intended to be used for any other purpose).
@@ -64,7 +64,11 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 
 		[Inject] protected NavigationManager NavigationManager { get; set; }
 
+		public bool Collapsed => collapsed;
+		protected bool collapsed;
+
 		private string id = "hx" + Guid.NewGuid().ToString("N");
+		private HxCollapse collapseComponent;
 		protected List<HxSidebarItem> childItems;
 		internal CollectionRegistration<HxSidebarItem> ChildItemsRegistration { get; }
 		protected bool isDisposed;
@@ -104,6 +108,16 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 			}
 		}
 		*/
+
+		public async Task Expand()
+		{
+			await collapseComponent?.ShowAsync();
+		}
+
+		public async Task Collapse()
+		{
+			await collapseComponent?.HideAsync();
+		}
 
 		public async ValueTask DisposeAsync()
 		{

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.cs
@@ -110,16 +110,6 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		}
 		*/
 
-		public async Task ExpandAsync()
-		{
-			await collapseComponent?.ShowAsync();
-		}
-
-		public async Task CollapseAsync()
-		{
-			await collapseComponent?.HideAsync();
-		}
-
 		public async ValueTask DisposeAsync()
 		{
 			await DisposeAsyncCore();

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.css
@@ -19,7 +19,8 @@
 	gap: .75rem;
 }
 
-::deep .hx-sidebar-subitems .nav-link {
+::deep .hx-sidebar-subitems.collapse .nav-link,
+::deep .hx-sidebar-subitems.collapsing .nav-link {
 	margin: var(--hx-sidebar-subitem-margin);
 	padding: var(--hx-sidebar-subitem-padding);
 	font-size: var(--hx-sidebar-subitem-font-size);

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.css
@@ -19,7 +19,7 @@
 	gap: .75rem;
 }
 
-.hx-sidebar-subitems ::deep .nav-link {
+::deep .hx-sidebar-subitems .nav-link {
 	margin: var(--hx-sidebar-subitem-margin);
 	padding: var(--hx-sidebar-subitem-padding);
 	font-size: var(--hx-sidebar-subitem-font-size);

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarItemContentTemplateContext.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarItemContentTemplateContext.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Context provided to the <see cref="HxSidebarItem.ContentTemplate" />.
+/// </summary>
+public class SidebarItemContentTemplateContext
+{
+	/// <summary>
+	/// Indicates whether a <see cref="HxSidebarItem"/> is collapsed or expanded. Is <c>null</c> when item has no expandable content.
+	/// </summary>
+	public bool? Collapsed { get; set; }
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarItemContentTemplateContext.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarItemContentTemplateContext.cs
@@ -14,5 +14,5 @@ public class SidebarItemContentTemplateContext
 	/// <summary>
 	/// Indicates whether a <see cref="HxSidebarItem"/> is collapsed or expanded. Is <c>null</c> when item has no expandable content.
 	/// </summary>
-	public bool? Collapsed { get; set; }
+	public bool? ItemExpanded { get; set; }
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxCollapse.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxCollapse.js
@@ -1,4 +1,4 @@
-﻿export function initialize(element, hxCollapseDotnetObjectReference) {
+﻿export function initialize(element, hxCollapseDotnetObjectReference, shouldToggle) {
 	if (!element) {
 		return;
 	}
@@ -10,7 +10,7 @@
 	element.addEventListener('hidden.bs.collapse', handleCollapseHidden);
 
 	var c = new bootstrap.Collapse(element, {
-		toggle: false,
+		toggle: shouldToggle,
 	});
 }
 


### PR DESCRIPTION
Feature is complete except a part in `HxSidebarItem.razor` which has to be uncommented - it uses functionality that is not in master yet but resides in https://github.com/havit/Havit.Blazor/pull/246.