### PR TITLE
[HxGrid] OnDataItemClicked

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -5299,6 +5299,18 @@
             Triggers the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.SelectedDataItemsChanged"/> event. Allows interception of the event in derived components.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.OnDataItemClicked">
+            <summary>
+            Event fires when an item (row) is clicked.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.InvokeOnDataItemClickedAsync(`0)">
+            <summary>
+            Triggers the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.OnDataItemClicked"/> event. Allows interception of the event in derived components.
+            </summary>
+            <param name="item"></param>
+            <returns></returns>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.ContentNavigationMode">
             <summary>
             Strategy how data are displayed in the grid (and loaded to the grid).

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -115,6 +115,17 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 		protected virtual Task InvokeSelectedDataItemsChangedAsync(HashSet<TItem> selectedDataItems) => SelectedDataItemsChanged.InvokeAsync(selectedDataItems);
 
 		/// <summary>
+		/// Event fires when an item (row) is clicked.
+		/// </summary>
+		[Parameter] public EventCallback<TItem> OnDataItemClicked { get; set; }
+		/// <summary>
+		/// Triggers the <see cref="OnDataItemClicked"/> event. Allows interception of the event in derived components.
+		/// </summary>
+		/// <param name="item"></param>
+		/// <returns></returns>
+		protected virtual Task InvokeOnDataItemClickedAsync(TItem item) => OnDataItemClicked.InvokeAsync(item);
+
+		/// <summary>
 		/// Strategy how data are displayed in the grid (and loaded to the grid).
 		/// </summary>
 		[Parameter] public GridContentNavigationMode? ContentNavigationMode { get; set; }
@@ -423,7 +434,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 
 		private async Task HandleSelectOrMultiSelectDataItemClick(TItem clickedDataItem)
 		{
-			Contract.Requires(SelectionEnabled || MultiSelectionEnabled);
+			await InvokeOnDataItemClickedAsync(clickedDataItem);
 
 			if (SelectionEnabled)
 			{


### PR DESCRIPTION
Handling the OnClick event on grid items (rows) is crucial for features such as [this task](https://dev.azure.com/havit/DEV/_workitems/edit/63065/) on Goran - when we want to for example edit a grid item in an offcanvas or anywhere outside the grid, we need a way to find out if an item has been clicked.