### PR TITLE
[HxMessenger] OnMessageClosed #288

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -8411,6 +8411,11 @@
             Position of the messages. Default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ToastContainerPosition.None"/>.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMessenger.OnMessageClosed">
+            <summary>
+            Fires when a message (a toast) is hidden by close-button click or through auto-hide.
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMessenger.CssClass">
             <summary>
             Additional CSS class.

--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessenger.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessenger.razor
@@ -5,13 +5,12 @@
         @foreach (MessengerMessage message in messages)
         {
             // @key is used to pair messages to HxToasts when some message disappers.
+            // We are not passing the Title and Text properties of the MessengerMessage to the HxToast because we are using them to build the ContentTemplate.
             <HxToast @key="@message.Key"
                         Color="@((message as BootstrapMessengerMessage)?.Color)"
                     CssClass="@message.CssClass"
                     HeaderIcon="@message.Icon"
-                    HeaderText="@message.Title"
                     HeaderTemplate="@message.HeaderTemplate"
-                    ContentText="@message.Text"
                     ContentTemplate="@message.ContentTemplate"
                     AutohideDelay="@message.AutohideDelay"
                     OnToastHidden="() => HandleToastHidden(message)" />

--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessenger.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessenger.razor.cs
@@ -12,6 +12,11 @@
 		[Parameter] public ToastContainerPosition Position { get; set; } = ToastContainerPosition.None;
 
 		/// <summary>
+		/// Fires when a message (a toast) is hidden by close-button click or through auto-hide.
+		/// </summary>
+		[Parameter] public EventCallback<MessengerMessage> OnMessageClosed { get; set; }
+
+		/// <summary>
 		/// Additional CSS class.
 		/// </summary>
 		[Parameter] public string CssClass { get; set; }
@@ -50,9 +55,10 @@
 		/// <summary>
 		/// Receive notification from <see cref="HxToast"/> when message is hidden.
 		/// </summary>
-		private void HandleToastHidden(MessengerMessage message)
+		private async void HandleToastHidden(MessengerMessage message)
 		{
 			messages.Remove(message);
+			await OnMessageClosed.InvokeAsync(message);
 		}
 
 		public void Dispose()

--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessengerServiceExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessengerServiceExtensions.cs
@@ -29,7 +29,9 @@
 			{
 				Color = Defaults.InformationColor,
 				AutohideDelay = Defaults.InformationAutohideDelay,
-				ContentTemplate = BuildContentTemplate(title, message)
+				ContentTemplate = BuildContentTemplate(title, message),
+				Title = title,
+				Text = message
 			});
 		}
 
@@ -52,9 +54,10 @@
 			{
 				Color = Defaults.WarningColor,
 				AutohideDelay = Defaults.WarningAutohideDelay,
-				ContentTemplate = BuildContentTemplate(title, message)
+				ContentTemplate = BuildContentTemplate(title, message),
+				Title = title,
+				Text = message
 			});
-
 		}
 
 		/// <summary>
@@ -76,7 +79,9 @@
 			{
 				Color = Defaults.ErrorColor,
 				AutohideDelay = Defaults.ErrorAutohideDelay,
-				ContentTemplate = BuildContentTemplate(title, message)
+				ContentTemplate = BuildContentTemplate(title, message),
+				Title = title,
+				Text = message
 			});
 		}
 


### PR DESCRIPTION
I considered adding the `OnMessageClosed` event to the `IHxMessengerService`, however, I concluded that it would be quite chaotic to intermingle our internal logic for adding messages with events users may subscribe to and that's why I decided to simply add an `EventCallback` parameter to the `HxMessenger` component.