### PR TITLE
[HxGrid] InfiniteScroll + synchronous DataProvider returning empty da…

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor
@@ -59,7 +59,7 @@
 	<HxProgressIndicator InProgress="@(InProgress ?? (dataProviderInProgress /* indicates data loading */ && !shouldRenderLoadingDataWithPlaceholders /* but not when placeholders are used - in such case we are indicating data loading using the placeholders */))">
 
 		<div class="@CssClassHelper.Combine(ResponsiveEffective ? "table-responsive" : null, TableContainerCssClassEffective)">
-			<table class="@GetTableElementCssClass(shouldRenderData)">
+			<table class="@GetTableElementCssClass(totalCount > 0)">
 				<thead>
 					<tr class="@HeaderRowCssClassEffective">
 						@{

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor
@@ -42,7 +42,7 @@
 			break;
 
 		case GridContentNavigationMode.InfiniteScroll:
-			shouldRenderData = (totalCount == null) || (totalCount > 0); // null: we need to render Virtualize even when we have no data yet - Virtalize ensures data load
+			shouldRenderData = true; // we cannot remove the Virtualize when there are no data, see #303 (https://github.com/havit/Havit.Blazor/issues/303)
 			break;
 
 		default: throw new InvalidOperationException(ContentNavigationModeEffective.ToString());

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading;
-using Havit.Diagnostics.Contracts;
-using Microsoft.Extensions.Localization;
+﻿using Microsoft.Extensions.Localization;
 
 namespace Havit.Blazor.Components.Web.Bootstrap
 {
@@ -566,7 +564,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 				CancellationToken = request.CancellationToken
 			};
 
-			GridDataProviderResult<TItem> gridDataProviderResponse = await InvokeDataProviderInternal(gridDataProviderRequest);			
+			GridDataProviderResult<TItem> gridDataProviderResponse = await InvokeDataProviderInternal(gridDataProviderRequest);
 
 			if (!request.CancellationToken.IsCancellationRequested)
 			{

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -566,8 +566,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap
 				CancellationToken = request.CancellationToken
 			};
 
-			GridDataProviderResult<TItem> gridDataProviderResponse = await InvokeDataProviderInternal(gridDataProviderRequest);
-			await Task.Yield(); // fixed issue 303 (https://github.com/havit/Havit.Blazor/issues/303)
+			GridDataProviderResult<TItem> gridDataProviderResponse = await InvokeDataProviderInternal(gridDataProviderRequest);			
 
 			if (!request.CancellationToken.IsCancellationRequested)
 			{


### PR DESCRIPTION
…ta => DOMException: Failed to execute 'setStartAfter' on 'Range': the given Node has no parent. #303 (alternative approach)