### PR TITLE
doc - HxInputTextArea - don't display link to documentation page on the documentation page

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -3930,7 +3930,7 @@
             <summary>
             <see href="https://getbootstrap.com/docs/5.0/forms/floating-labels/#textareas" target="_blank">Textarea</see>.
             To set a custom height, do not use the rows attribute. Instead, set an explicit height (either inline or via custom CSS).<br />
-            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputTextArea">https://havit.blazor.eu/components/HxInputTextArea</see>.
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputTextArea">https://havit.blazor.eu/components/HxInputTextArea</see>
             </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxInputTextArea.GetElementName">

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputTextArea.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputTextArea.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// <see href="https://getbootstrap.com/docs/5.0/forms/floating-labels/#textareas" target="_blank">Textarea</see>.
 	/// To set a custom height, do not use the rows attribute. Instead, set an explicit height (either inline or via custom CSS).<br />
-	/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputTextArea">https://havit.blazor.eu/components/HxInputTextArea</see>.
+	/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputTextArea">https://havit.blazor.eu/components/HxInputTextArea</see>
 	/// </summary>
 	public class HxInputTextArea : HxInputText
 	{


### PR DESCRIPTION
This link is intended for IntelliSense.