### PR TITLE
[HxAutosuggest][HxInputTags]: fix null reference exception

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInternal.razor.cs
@@ -361,7 +361,7 @@ public partial class HxAutosuggestInternal<TItem, TValue> : IAsyncDisposable
 		else if (keyboardEventArgs.Code == ArrowDownKeyCode)
 		{
 			int nextItemIndex = focusedItemIndex + 1;
-			if (nextItemIndex < suggestions.Count)
+			if (nextItemIndex < suggestions?.Count)
 			{
 				focusedItemIndex = nextItemIndex;
 			}

--- a/Havit.Blazor.Components.Web.Bootstrap/Tags/Internal/HxInputTagsInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tags/Internal/HxInputTagsInternal.razor.cs
@@ -396,7 +396,7 @@ public partial class HxInputTagsInternal
 		else if (keyboardEventArgs.Code == ArrowDownKeyCode)
 		{
 			int nextItemIndex = focusedItemIndex + 1;
-			if (nextItemIndex < suggestions.Count)
+			if (nextItemIndex < suggestions?.Count)
 			{
 				focusedItemIndex = nextItemIndex;
 			}


### PR DESCRIPTION
problem reproduce:
1. goto https://havit.blazor.eu/components/HxInputTags
2. in `Basic usage` demo, do not enter anything, press down key, error will occur

same step with `HxAutosuggest`.

this PR fix above issues