### PR TITLE
[HxSearchBox] Confirm text query with enter key using KeyboardEventArgs

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor
@@ -14,63 +14,63 @@
                                  id="@dropdownToggleElementId">
 
             <div class="position-relative">
-                <form @onsubmit="HandleTextQueryTriggered" @onfocusin="HandleInputFocus" @onfocusout="HandleInputBlur">
-                    @if (!string.IsNullOrEmpty(Label))
-                    {
-                        <label class="form-label">@Label</label>
-                    }
-                    <span class="@CssClassHelper.Combine(
-                                    (HasInputGroupsEffective ? "input-group" : null),
-                                    (LabelType == Havit.Blazor.Components.Web.Bootstrap.LabelType.Floating) ? "form-floating" : null,
-                                    InputSizeEffective.AsInputGroupCssClass(),
-                                    InputGroupCssClass)">
+                @if (!string.IsNullOrEmpty(Label))
+                {
+                    <label class="form-label">@Label</label>
+                }
+                <span class="@CssClassHelper.Combine(
+                                (HasInputGroupsEffective ? "input-group" : null),
+                                (LabelType == Havit.Blazor.Components.Web.Bootstrap.LabelType.Floating) ? "form-floating" : null,
+                                InputSizeEffective.AsInputGroupCssClass(),
+                                InputGroupCssClass)">
                     
-                        @if (InputGroupStartText is not null)
-                        {
-                            <span class="input-group-text">@InputGroupStartText</span>
-                        }
-
-                        @InputGroupStartTemplate
-
-                        <input
-                            value="@TextQuery"
-                            @oninput="(eventArgs) => HandleTextQueryValueChanged(eventArgs.Value.ToString())"
-                            @onkeydown="HandleInputKeyDown"
-                            inputmode="search"
-                            enabled="@Enabled"
-                            placeholder="@Placeholder"
-                            class="@CssClassHelper.Combine("form-control", InputCssClassEffective)" />
-                            
-                        @InputGroupEndTemplate
-
-                        @if (InputGroupEndText is not null)
-                        {
-                            <span class="input-group-text">@InputGroupEndText</span>
-                        }
-                    </span>
-
-                    @if (InputGroupEndText is null && InputGroupEndTemplate is null)
+                    @if (InputGroupStartText is not null)
                     {
-                        if (dataProviderInProgress)
-                        {
-                            <div class="hx-search-box-input-icon hx-search-box-input-icon-end">
-                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                            </div>
-                        }
-                        else if (!string.IsNullOrEmpty(TextQuery) && (ClearIconEffective is not null))
-                        {
-                            <div role="button" class="hx-search-box-input-icon hx-search-box-input-icon-end" @onclick="ClearInputAsync">
-                                <HxIcon Icon="ClearIconEffective" />
-                            </div>
-                        }
-                        else if (SearchIconEffective is not null)
-                        {
-                            <div class="hx-search-box-input-icon hx-search-box-input-icon-end">
-                                <HxIcon Icon="SearchIconEffective" />
-                            </div>
-                        }
+                        <span class="input-group-text">@InputGroupStartText</span>
                     }
-                </form>
+
+                    @InputGroupStartTemplate
+
+                    <input
+                        value="@TextQuery"
+                        @oninput="(eventArgs) => HandleTextQueryValueChanged(eventArgs.Value.ToString())"
+                        @onkeydown="HandleInputKeyDown"
+                        @onfocus="HandleInputFocus"
+                        @onblur="HandleInputBlur"
+                        inputmode="search"
+                        enabled="@Enabled"
+                        placeholder="@Placeholder"
+                        class="@CssClassHelper.Combine("form-control", InputCssClassEffective)" />
+                            
+                    @InputGroupEndTemplate
+
+                    @if (InputGroupEndText is not null)
+                    {
+                        <span class="input-group-text">@InputGroupEndText</span>
+                    }
+                </span>
+
+                @if (InputGroupEndText is null && InputGroupEndTemplate is null)
+                {
+                    if (dataProviderInProgress)
+                    {
+                        <div class="hx-search-box-input-icon hx-search-box-input-icon-end">
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        </div>
+                    }
+                    else if (!string.IsNullOrEmpty(TextQuery) && (ClearIconEffective is not null))
+                    {
+                        <div role="button" class="hx-search-box-input-icon hx-search-box-input-icon-end" @onclick="ClearInputAsync">
+                            <HxIcon Icon="ClearIconEffective" />
+                        </div>
+                    }
+                    else if (SearchIconEffective is not null)
+                    {
+                        <div class="hx-search-box-input-icon hx-search-box-input-icon-end">
+                            <HxIcon Icon="SearchIconEffective" />
+                        </div>
+                    }
+                }
             </div>
         </HxDropdownToggleElement>
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor.cs
@@ -379,7 +379,7 @@ public partial class HxSearchBox<TItem> : IAsyncDisposable
 			{
 				await HandleItemSelected(focusedItem);
 			}
-			else if (focusedItemIndex == GetFreeTextItemIndex())
+			else if (focusedItemIndex == InputKeyboardNavigationIndex || focusedItemIndex == GetFreeTextItemIndex()) // Confirm freetext (text query) if the input or the freetext item is focused and the enter key is pressed.
 			{
 				await HandleTextQueryTriggered();
 			}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor.cs
@@ -429,12 +429,12 @@ public partial class HxSearchBox<TItem> : IAsyncDisposable
 		});
 	}
 
-	private void HandleInputFormFocusIn()
+	private void HandleInputFocus()
 	{
 		inputformHasFocus = true;
 	}
 
-	private void HandleInputFormFocusOut()
+	private void HandleInputBlur()
 	{
 		inputformHasFocus = false;
 


### PR DESCRIPTION
Noticed that the text query confirmation was detected by `@onsubmit` on a `<form>` wrapping the `<input>`, which may cause issues, therefore I have modified it to confirm the text query `oninput` by checking whether the `enter` key has been pressed.

Dependant on #376.