### PR TITLE
 [HxInputFileDropZone] Implement cascading enabled pattern

### DIFF
--- a/BlazorAppTest/Pages/HxInputFileDropZoneTest.razor
+++ b/BlazorAppTest/Pages/HxInputFileDropZoneTest.razor
@@ -9,6 +9,15 @@
 <HxInputFileDropZone @ref="component" Multiple />
 <HxButton Text="Clear" OnClick="@(async () => await component.ResetAsync())" Color="ThemeColor.Secondary" />
 
+<h3>Enabled="false"</h3>
+<HxInputFileDropZone Enabled="false" />
+
+<h3>HxFormState</h3>
+<HxSwitch Text="Enabled" @bind-Value="@enabled" />
+<HxFormState Enabled="@enabled">
+	<HxInputFileDropZone />
+</HxFormState>
+
 <h3>Custom NoFilesTemplate</h3>
 <HxInputFileDropZone Multiple>
 	<NoFilesTemplate>
@@ -19,5 +28,6 @@
 
 @code
 {
+	private bool enabled = true;
 	private HxInputFileDropZone component;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/Pages/Components/HxInputFileDropZoneDoc/HxInputFileDropZone_Documentation.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/Pages/Components/HxInputFileDropZoneDoc/HxInputFileDropZone_Documentation.razor
@@ -35,6 +35,12 @@
         <ComponentApiDocCssVariable Name="--hx-input-file-drop-zone-hover-border-color" Default="var(--bs-primary)">
             Border color on hover.
         </ComponentApiDocCssVariable>
+        <ComponentApiDocCssVariable Name="--hx-input-file-drop-zone-disabled-background-color" Default="var(--bs-gray-200)">
+            Background color when disabled.
+        </ComponentApiDocCssVariable>
+        <ComponentApiDocCssVariable Name="--hx-input-file-drop-zone-disabled-color" Default="var(--bs-gray-400)">
+            Color when disabled.
+        </ComponentApiDocCssVariable>
         <ComponentApiDocCssVariable Name="--hx-input-file-drop-zone-border-radius" Default=".3rem">
             Border radius.
         </ComponentApiDocCssVariable>

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2202,6 +2202,12 @@
             Custom CSS class to render with the input element.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputFileDropZone.Enabled">
+            <inheritdoc cref="P:Havit.Blazor.Components.Web.Infrastructure.ICascadeEnabledComponent.Enabled" />
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputFileDropZone.FormState">
+            <inheritdoc cref="T:Havit.Blazor.Components.Web.FormState" />
+        </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxInputFileDropZone.GetFilesAsync">
             <summary>
             Gets list of files chosen.

--- a/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.xml
+++ b/Havit.Blazor.Components.Web.Bootstrap.Documentation/XmlDoc/Havit.Blazor.Components.Web.xml
@@ -219,6 +219,12 @@
             Single <c>false</c> or multiple <c>true</c> files upload.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.HxInputFileCore.Enabled">
+            <summary>
+            Make the item appear disabled by setting to <c>false</c>.
+            Default is <c>true</c>.
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.HxInputFileCore.Accept">
             <summary>
             Takes as its value a comma-separated list of one or more file types, or unique file type specifiers, describing which file types to allow.

--- a/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFile.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFile.cs
@@ -228,7 +228,7 @@ public partial class HxInputFile : ComponentBase, ICascadeEnabledComponent, IFor
 		builder.AddAttribute(1009, nameof(HxInputFileCore.MaxFileSize), this.MaxFileSize);
 		builder.AddAttribute(1010, nameof(HxInputFileCore.MaxParallelUploads), this.MaxParallelUploads);
 		builder.AddAttribute(1011, "class", CssClassHelper.Combine(this.CoreInputCssClass, this.InputCssClass, (this is IInputWithSize inputWithSize) ? inputWithSize.GetInputSizeCssClass() : null));
-		builder.AddAttribute(1012, "disabled", !CascadeEnabledComponent.EnabledEffective(this));
+		builder.AddAttribute(1012, nameof(HxInputFileCore.Enabled), CascadeEnabledComponent.EnabledEffective(this));
 		builder.AddComponentReferenceCapture(1013, r => hxInputFileCoreComponentReference = (HxInputFileCore)r);
 		builder.CloseComponent();
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
-<div class="@CssClassHelper.Combine("hx-input-file-drop-zone", this.CssClass)">
+<div class="@CssClassHelper.Combine("hx-input-file-drop-zone", EnabledEffective ? null : "disabled", this.CssClass)">
 	<HxInputFileCore @ref="hxInputFileCoreComponentReference"
 					 UploadUrl="@this.UploadUrl"
 					 OnChange="HandleOnChange"
@@ -7,6 +7,7 @@
 					 OnFileUploaded="InvokeOnFileUploadedAsync"
 					 OnUploadCompleted="InvokeOnUploadCompletedAsync"
 					 Multiple="this.Multiple"
+					 Enabled="EnabledEffective"
 					 MaxFileSize="this.MaxFileSize"
 					 Accept="@this.Accept"/>
 	@if (fileCount == 0)

--- a/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.cs
@@ -125,8 +125,6 @@ public partial class HxInputFileDropZone : ICascadeEnabledComponent
 	/// <param name="accessToken">Authorization Bearer Token to be used for upload (i.e. use IAccessTokenProvider).</param>
 	public Task<UploadCompletedEventArgs> UploadAsync(string accessToken = null) => hxInputFileCoreComponentReference?.UploadAsync(accessToken);
 
-	protected bool EnabledEffective => CascadeEnabledComponent.EnabledEffective(this);
-
 	protected Task HandleOnChange(InputFileChangeEventArgs args)
 	{
 		fileCount = args.FileCount;
@@ -152,4 +150,6 @@ public partial class HxInputFileDropZone : ICascadeEnabledComponent
 			return result;
 		}
 	}
+
+	protected bool EnabledEffective => CascadeEnabledComponent.EnabledEffective(this);
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components.Forms;
+﻿using Havit.Blazor.Components.Web.Infrastructure;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.Localization;
 
 namespace Havit.Blazor.Components.Web.Bootstrap;
@@ -8,7 +9,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap;
 /// For custom drag&amp;drop UX, use <see cref="HxInputFileCore"/> and <see href="https://github.com/havit/Havit.Blazor/blob/728567c9c83a0b4ab7fe2e031bf1ff378f1b1ce7/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.css#L20-L26">a little bit of HTML/CSS</see>.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputFileDropZone">https://havit.blazor.eu/components/HxInputFileDropZone</see>
 /// </summary>
-public partial class HxInputFileDropZone
+public partial class HxInputFileDropZone : ICascadeEnabledComponent
 {
 	private const int FirstFileNamesMaxCount = 3; // Might be converted to parameter if needed.
 
@@ -86,7 +87,12 @@ public partial class HxInputFileDropZone
 	/// </summary>
 	[Parameter] public string InputCssClass { get; set; }
 
+	/// <inheritdoc cref="ICascadeEnabledComponent.Enabled" />
 	[Parameter] public bool? Enabled { get; set; }
+
+	/// <inheritdoc cref="Web.FormState" />
+	[CascadingParameter] protected FormState FormState { get; set; }
+	FormState ICascadeEnabledComponent.FormState { get => this.FormState; set => this.FormState = value; }
 
 	[Inject] protected IStringLocalizer<HxInputFileDropZone> Localizer { get; set; }
 
@@ -118,6 +124,8 @@ public partial class HxInputFileDropZone
 	/// </summary>
 	/// <param name="accessToken">Authorization Bearer Token to be used for upload (i.e. use IAccessTokenProvider).</param>
 	public Task<UploadCompletedEventArgs> UploadAsync(string accessToken = null) => hxInputFileCoreComponentReference?.UploadAsync(accessToken);
+
+	protected bool EnabledEffective => CascadeEnabledComponent.EnabledEffective(this);
 
 	protected Task HandleOnChange(InputFileChangeEventArgs args)
 	{

--- a/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Files/HxInputFileDropZone.razor.css
@@ -11,10 +11,16 @@
     padding: var(--hx-input-file-drop-zone-padding);
 }
 
-.hx-input-file-drop-zone:hover, .hx-input-file-drop-zone:focus {
+.hx-input-file-drop-zone.disabled {
+	cursor: not-allowed;
+	background-color: var(--hx-input-file-drop-zone-disabled-background-color);
+	color: var(--hx-input-file-drop-zone-disabled-color);
+}
+
+.hx-input-file-drop-zone:not(.disabled):hover, .hx-input-file-drop-zone:not(.disabled):focus {
 	background-color: var(--hx-input-file-drop-zone-hover-background-color);
 	border-color: var(--hx-input-file-drop-zone-hover-border-color);
-    box-shadow: var(--hx-input-file-drop-zone-hover-box-shadow);
+	box-shadow: var(--hx-input-file-drop-zone-hover-box-shadow);
 }
 
 .hx-input-file-drop-zone ::deep input[type=file] {
@@ -23,4 +29,8 @@
 	height: 100%;
 	opacity: 0;
 	cursor: pointer;
+}
+
+.hx-input-file-drop-zone.disabled ::deep input[type=file] {
+	cursor: not-allowed;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.css
@@ -80,6 +80,8 @@
 	--hx-input-file-drop-zone-box-shadow: 				none;
 	--hx-input-file-drop-zone-hover-box-shadow: 			0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
 	--hx-input-file-drop-zone-border-color: 				var(--bs-gray-400);
+	--hx-input-file-drop-zone-disabled-color:				var(--bs-gray-400);
+	--hx-input-file-drop-zone-disabled-background-color:	var(--bs-gray-200);
 	--hx-input-file-drop-zone-background-color: 			transparent;
 	--hx-input-file-drop-zone-hover-background-color: 	rgba(var(--bs-primary-rgb), .05);
 	--hx-input-file-drop-zone-hover-border-color: 		var(--bs-primary);

--- a/Havit.Blazor.Components.Web/Files/HxInputFileCore.cs
+++ b/Havit.Blazor.Components.Web/Files/HxInputFileCore.cs
@@ -82,6 +82,12 @@ public class HxInputFileCore : InputFile, IAsyncDisposable
 	[Parameter] public bool Multiple { get; set; }
 
 	/// <summary>
+	/// Make the item appear disabled by setting to <c>false</c>.
+	/// Default is <c>true</c>.
+	/// </summary>
+	[Parameter] public bool Enabled { get; set; } = true;
+
+	/// <summary>
 	/// Takes as its value a comma-separated list of one or more file types, or unique file type specifiers, describing which file types to allow.
 	/// <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept">MDN Web Docs - HTML attribute: accept</see>.
 	/// </summary>
@@ -135,6 +141,7 @@ public class HxInputFileCore : InputFile, IAsyncDisposable
 
 		AdditionalAttributes["multiple"] = this.Multiple;
 		AdditionalAttributes["accept"] = this.Accept;
+		AdditionalAttributes["disabled"] = !this.Enabled;
 	}
 
 	/// <summary>


### PR DESCRIPTION
In some scenarios it may be useful to disable HxInputFileDropZone inputs whilst doing background checks/custom posts/general state management of a form, where allowing a user to re-select files would not be appropriate.

This PR implements the common cascading approach (including respecting HxFormState).