### PR TITLE
[HxMultiSelect] Select all synchronisation

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
@@ -101,7 +101,7 @@
                     var item = filteredItems[i];
                     TValue value = SelectorHelpers.GetValue<TItem, TValue>(ValueSelector, item);
 
-                    bool itemSelected = DoSelectedValuesContainValue(value);
+                    bool itemSelected = currentSelectedValues.Contains(value);
 
                     <li>
                         <button type="button" class="dropdown-item" role="option" @onclick="async () => await HandleItemSelectionChangedAsync(!itemSelected, item)">

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -245,12 +245,6 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		return StringLocalizer["SelectAllDefaultText"];
 	}
 
-	private bool ShouldCheckSelectAll()
-	{
-		var filteredItems = GetFilteredItems();
-		return filteredItems is null || (filteredItems.Count == 1 && SelectedValues is null) || (SelectedValues is not null && filteredItems.Count == SelectedValues.Count + 1);
-	}
-
 	private string GetFilterEmptyResultText()
 	{
 		if (FilterEmptyResultText is not null)

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -43,10 +43,6 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 
 	[Parameter] public bool ClearFilterOnHide { get; set; }
 
-	[Parameter] public EventCallback<string> OnShown { get; set; }
-
-	[Parameter] public EventCallback<string> OnHidden { get; set; }
-
 	[Parameter] public RenderFragment FilterEmptyResultTemplate { get; set; }
 
 	[Parameter] public string FilterEmptyResultText { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -84,6 +84,15 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		dotnetObjectReference = DotNetObjectReference.Create(this);
 	}
 
+	protected override void OnInitialized()
+	{
+		// If all items are currently selected then check select all
+		if (ItemsToRender is not null && SelectedValues is not null && ItemsToRender.Count == SelectedValues.Count)
+		{
+			selectAllChecked = true;
+		}
+	}
+
 	/// <inheritdoc cref="ComponentBase.OnAfterRenderAsync(bool)" />
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
@@ -96,13 +105,6 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 			}
 
 			await jsModule.InvokeVoidAsync("initialize", elementReference, dotnetObjectReference);
-
-			// If all items are currently selected then check select all
-			if (ItemsToRender is not null && SelectedValues is not null && ItemsToRender.Count == SelectedValues.Count)
-			{
-				selectAllChecked = true;
-				StateHasChanged();
-			}
 		}
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -96,6 +96,13 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 			}
 
 			await jsModule.InvokeVoidAsync("initialize", elementReference, dotnetObjectReference);
+
+			// If all items are currently selected then check select all
+			if (ItemsToRender is not null && SelectedValues is not null && ItemsToRender.Count == SelectedValues.Count)
+			{
+				selectAllChecked = true;
+				StateHasChanged();
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary of changes
As per #638
- Select all now syncs upon item selection and filter input changes
-  Select all now automatically checks if `Value` contains all items

Missed code from #617
- Removed unwanted event callbacks