### PR TITLE
[docs] Fix links to defaults

### DIFF
--- a/Havit.Blazor.Documentation/Model/MemberModel.cs
+++ b/Havit.Blazor.Documentation/Model/MemberModel.cs
@@ -112,7 +112,7 @@ public abstract class MemberModel
 
 		if (splitLink[^1] == "Defaults")
 		{
-			string internalTypeLink = ApiRenderer.GenerateLinkForInternalType($"{splitLink[^2].Remove(0, 2)}{splitLink[^1]}", false, $"{splitLink[^2]}.{splitLink[^1]}"); // We have to generate a type name suitable for the support type page.
+			string internalTypeLink = ApiRenderer.GenerateLinkForInternalType($"{splitLink[^2].Remove(0, 2)}Settings", false, $"{splitLink[^2]}.{splitLink[^1]}"); // We have to generate a type name suitable for the support type page.
 			if (internalTypeLink is not null)
 			{
 				return internalTypeLink;


### PR DESCRIPTION
@hakenr currently, `HxGrid.Defaults` leads to a non-existent page, this commit adjusts the URL, so that it leads to the `GridSettings` type definition.

However, to be consistent with other links to properties, we should change the link to lead to the page of the type where the property is defined, in this example `HxGrid`.

And since we gained the support for hashed routing to named elements in .NET 8, I suggest we consider setting the Ids of members (properties, methods, ...) in the API documentation section to increase the usefulness of the links to component members.

![image](https://github.com/havit/Havit.Blazor/assets/62853076/0e87f0d8-1f68-4875-b6e7-07c6059d6152)