### PR TITLE
[HxAccordion] [Possible Bug] Accordion Collapses When It Should Stay Open

### DIFF
--- a/BlazorAppTest/Pages/HxAccordion_Issue685_Test.razor
+++ b/BlazorAppTest/Pages/HxAccordion_Issue685_Test.razor
@@ -1,11 +1,11 @@
-﻿@page "/HxAccordion_Issue685_test"
+﻿@page "/HxAccordion_Issue685_Test"
 <h3>HxAccordion_Issue685_test</h3>
 
 <HxAccordion @bind-ExpandedItemId="@expandedItemId" CssClass="mb-3">
 	<HxAccordionItem Id="1">
 
 		<HeaderTemplate>
-			Accordition Item 1 (Id="1") with LazyLoaded content
+			Accordion Item 1 (Id="1") with LazyLoaded content
 		</HeaderTemplate>
 
 		<BodyTemplate>
@@ -35,7 +35,7 @@
 
 	private int? selectedEmployeeId = 1;
 
-	private async Task<AutosuggestDataProviderResult<EmployeeDto>> ProvideSuggestions(AutosuggestDataProviderRequest request)
+	private Task<AutosuggestDataProviderResult<EmployeeDto>> ProvideSuggestions(AutosuggestDataProviderRequest request)
 	{
 		var matchingEmployees = new List<EmployeeDto>()
 		{
@@ -43,17 +43,17 @@
 			new EmployeeDto { Id = 2, Name = "Bob" }
 		};
 
-		return new AutosuggestDataProviderResult<EmployeeDto> { Data = matchingEmployees };
+		return Task.FromResult(new AutosuggestDataProviderResult<EmployeeDto> { Data = matchingEmployees });
 	}
 
-	private async Task<EmployeeDto> ResolveAutosuggestItemFromValue(int? value)
+	private Task<EmployeeDto> ResolveAutosuggestItemFromValue(int? value)
 	{
 		if (value is null)
 		{
 			return null;
 		}
 
-		return new EmployeeDto();
+		return Task.FromResult(new EmployeeDto());
 	}
 
 	public class EmployeeDto

--- a/BlazorAppTest/Pages/HxAccordion_Issue685_test.razor
+++ b/BlazorAppTest/Pages/HxAccordion_Issue685_test.razor
@@ -1,0 +1,64 @@
+﻿@page "/HxAccordion_Issue685_test"
+<h3>HxAccordion_Issue685_test</h3>
+
+<HxAccordion @bind-ExpandedItemId="@expandedItemId" CssClass="mb-3">
+	<HxAccordionItem Id="1">
+
+		<HeaderTemplate>
+			Accordition Item 1 (Id="1") with LazyLoaded content
+		</HeaderTemplate>
+
+		<BodyTemplate>
+			<HxAutosuggest TItem="EmployeeDto"
+			               TValue="int?"
+			               Label="Employee"
+			               Placeholder="Start typing to search by name"
+			               @bind-Value="@selectedEmployeeId"
+			               DataProvider="ProvideSuggestions"
+			               ValueSelector="employee => employee.Id"
+			               TextSelector="employee => employee.Name"
+			               ItemFromValueResolver="ResolveAutosuggestItemFromValue">
+
+				<EmptyTemplate>
+					<span class="p-2">Couldn't find any matching employee</span>
+				</EmptyTemplate>
+
+			</HxAutosuggest>
+		</BodyTemplate>
+
+	</HxAccordionItem>
+</HxAccordion>
+
+@code
+{
+	private string expandedItemId = "1"; // you can se the initial value here, if binding to ExpandedItemId
+
+	private int? selectedEmployeeId = 1;
+
+	private async Task<AutosuggestDataProviderResult<EmployeeDto>> ProvideSuggestions(AutosuggestDataProviderRequest request)
+	{
+		var matchingEmployees = new List<EmployeeDto>()
+		{
+			new EmployeeDto { Id = 1 , Name = "Jim" },
+			new EmployeeDto { Id = 2, Name = "Bob" }
+		};
+
+		return new AutosuggestDataProviderResult<EmployeeDto> { Data = matchingEmployees };
+	}
+
+	private async Task<EmployeeDto> ResolveAutosuggestItemFromValue(int? value)
+	{
+		if (value is null)
+		{
+			return null;
+		}
+
+		return new EmployeeDto();
+	}
+
+	public class EmployeeDto
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordionItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordionItem.razor
@@ -13,7 +13,8 @@
     <HxCollapse @ref="collapseComponent"
                 Id="@("collapse-" + idEffective)"
                 Parent="@(!ParentAccordion.StayOpen ? $"#{ParentAccordion.Id}" : null)"
-                CssClass="@CssClassHelper.Combine("accordion-collapse", !isInitialized && IsSetToBeExpanded() ? "show" : null)"
+                CssClass="accordion-collapse"
+                InitiallyExpanded="IsSetToBeExpanded()"
                 OnShown="HandleCollapseShown"
                 OnHidden="HandleCollapseHidden"
                 aria-labelledby="@("header-" + idEffective)">


### PR DESCRIPTION
Resolves: #685

I believe the issue was caused by `HxAccordion` attempting to manually control the `show` CSS class on `HxCollapse` which is used to hide the element when not present instead of relying on `HxCollapse` to manage it on it's own. (It is likely that the `InitiallyExpanded` parameter did not exist on `HxCollapse` at the time.)