### PR TITLE
[HxSwitch] Classes form-check form-switch missing

### DIFF
--- a/BlazorAppTest/Pages/HxCheckbox_Issue742_Test.razor
+++ b/BlazorAppTest/Pages/HxCheckbox_Issue742_Test.razor
@@ -1,0 +1,46 @@
+﻿@page "/HxCheckbox_Issue742_Test"
+
+<h1>Issue 742</h1>
+
+<h2>HxSwitch</h2>
+
+<HxSwitch @bind-Value="valueBool" />
+
+<HxSwitch @bind-Value="valueBool" Text="Switch without label" />
+
+<HxSwitch Label="Switch with label" @bind-Value="valueBool" />
+
+<HxSwitch Label="Switch with label" Text="And text" @bind-Value="valueBool" />
+
+<HxInputText Label="Input groups (template with switch)" @bind-Value="@value">
+	<InputGroupStartTemplate>
+		<div class="input-group-text">
+			<HxSwitch @bind-Value="@valueBool" CssClass="mt-0" />
+		</div>
+	</InputGroupStartTemplate>
+</HxInputText>
+
+<h2>HxCheckbox</h2>
+
+<HxCheckbox @bind-Value="valueBool" />
+
+<HxCheckbox @bind-Value="valueBool" Text="Checkbox without label" />
+
+<HxCheckbox Label="Checkbox with label" @bind-Value="valueBool" />
+
+<HxCheckbox Label="Checkbox with label" Text="And text" @bind-Value="valueBool" />
+
+
+<HxInputText Label="Input groups (template with checkbox)" @bind-Value="@value">
+	<InputGroupStartTemplate>
+		<div class="input-group-text">
+			<HxCheckbox @bind-Value="@valueBool" CssClass="mt-0" />
+		</div>
+	</InputGroupStartTemplate>
+</HxInputText>
+
+@code
+{
+	private string value;
+	private bool valueBool;
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckbox.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckbox.cs
@@ -35,7 +35,7 @@ public class HxCheckbox : HxInputBase<bool>
 	[Parameter] public string TextCssClass { get; set; }
 
 	/// <summary>
-	/// Allows grouping checkboxes on the same horizontal row by rendering them inline. The default value is <c>false</c>.		
+	/// Allows grouping checkboxes on the same horizontal row by rendering them inline. The default value is <c>false</c>.
 	/// This only works when there is no label, no hint, and no validation message.
 	/// </summary>
 	[Parameter] public bool Inline { get; set; }
@@ -53,13 +53,14 @@ public class HxCheckbox : HxInputBase<bool>
 	/// <inheritdoc cref="HxInputBase{TValue}.CoreCssClass" />
 	private protected override string CoreCssClass => CssClassHelper.Combine(
 		base.CoreCssClass,
-		NeedsFormCheckOuter ? CssClassHelper.Combine(this.CoreFormElementCssClass, Inline ? "form-check-inline" : null) : null,
+		NeedsInnerDiv ? null : AdditionalFormElementCssClass,
+		NeedsFormCheckOuter ? CssClassHelper.Combine("form-check", Inline ? "form-check-inline" : null) : null,
 		Reverse ? "form-check-reverse" : null);
 
 	/// <summary>
-	/// CSS class for the <c>form-check</c> element (e.g., allows adding <c>form-switch</c> in derived <see cref="HxSwitch"/>).
+	/// CSS class that allows adding <c>form-switch</c> in derived <see cref="HxSwitch"/>.
 	/// </summary>
-	private protected virtual string CoreFormElementCssClass => "form-check";
+	private protected virtual string AdditionalFormElementCssClass => null;
 
 	/// <summary>
 	/// For a naked checkbox without Label/LabelTemplate, we add form-check, form-check-inline to the parent div (allows combining with CssClass etc.).
@@ -69,21 +70,25 @@ public class HxCheckbox : HxInputBase<bool>
 	/// Siblings label, input, label do not work well and there is nowhere to add form-check.
 	/// Therefore, we wrap the input and label in the additional div.
 	/// </summary>
-	private protected bool NeedsFormCheckInnerDiv => !String.IsNullOrWhiteSpace(this.Label) || (this.LabelTemplate is not null);
+	private protected bool NeedsInnerDiv => !string.IsNullOrWhiteSpace(this.Label) || (this.LabelTemplate is not null);
+
+	/// <summary>
+	/// For checkbox without any Text/TextTemplate we do not add form-check class.
+	/// </summary>
+	private protected bool NeedsFormCheck => !string.IsNullOrWhiteSpace(this.Text) || (this.TextTemplate is not null);
 
 	/// <summary>
 	/// For checkbox without any Label/LabelTemplate and without Text/TextTemplate we do not add form-check to the parent div.
 	/// </summary>
-	private protected bool NeedsFormCheckOuter => !NeedsFormCheckInnerDiv
-												  && (!string.IsNullOrWhiteSpace(this.Text) || (this.TextTemplate is not null));
+	private protected bool NeedsFormCheckOuter => !NeedsInnerDiv && NeedsFormCheck;
 
 	/// <inheritdoc />
 	protected override void BuildRenderInput(RenderTreeBuilder builder)
 	{
-		if (NeedsFormCheckInnerDiv)
+		if (NeedsInnerDiv)
 		{
 			builder.OpenElement(-2, "div");
-			builder.AddAttribute(-1, "class", this.CoreFormElementCssClass);
+			builder.AddAttribute(-1, "class", CssClassHelper.Combine(NeedsFormCheck ? "form-check" : null, AdditionalFormElementCssClass));
 		}
 
 		EnsureInputId(); // must be called before the input is rendered
@@ -109,7 +114,7 @@ public class HxCheckbox : HxInputBase<bool>
 		builder.AddContent(2004, TextTemplate);
 		builder.CloseElement(); // label
 
-		if (NeedsFormCheckInnerDiv)
+		if (NeedsInnerDiv)
 		{
 			builder.CloseElement(); // div
 		}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSwitch.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSwitch.cs
@@ -7,6 +7,6 @@
 /// </summary>
 public class HxSwitch : HxCheckbox
 {
-	/// <inheritdoc cref="HxCheckbox.CoreFormElementCssClass" />
-	private protected override string CoreFormElementCssClass => "form-check form-switch";
+	/// <inheritdoc cref="HxCheckbox.AdditionalFormElementCssClass" />
+	private protected override string AdditionalFormElementCssClass => "form-switch";
 }

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -3339,7 +3339,7 @@
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.Inline">
             <summary>
-            Allows grouping checkboxes on the same horizontal row by rendering them inline. The default value is <c>false</c>.		
+            Allows grouping checkboxes on the same horizontal row by rendering them inline. The default value is <c>false</c>.
             This only works when there is no label, no hint, and no validation message.
             </summary>
         </member>
@@ -3354,12 +3354,12 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.CoreCssClass">
             <inheritdoc cref="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBase`1.CoreCssClass" />
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.CoreFormElementCssClass">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.AdditionalFormElementCssClass">
             <summary>
-            CSS class for the <c>form-check</c> element (e.g., allows adding <c>form-switch</c> in derived <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxSwitch"/>).
+            CSS class that allows adding <c>form-switch</c> in derived <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxSwitch"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.NeedsFormCheckInnerDiv">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.NeedsInnerDiv">
             <summary>
             For a naked checkbox without Label/LabelTemplate, we add form-check, form-check-inline to the parent div (allows combining with CssClass etc.).
             It is expected that there is just the parent div, input, and label for Text/TextTemplate.
@@ -3367,6 +3367,11 @@
             For a checkbox with Label, there is a parent div followed by a label for Label/LabelTemplate.
             Siblings label, input, label do not work well and there is nowhere to add form-check.
             Therefore, we wrap the input and label in the additional div.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.NeedsFormCheck">
+            <summary>
+            For checkbox without any Text/TextTemplate we do not add form-check class.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.NeedsFormCheckOuter">
@@ -4910,8 +4915,8 @@
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxSwitch">https://havit.blazor.eu/components/HxSwitch</see>
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSwitch.CoreFormElementCssClass">
-            <inheritdoc cref="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.CoreFormElementCssClass" />
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSwitch.AdditionalFormElementCssClass">
+            <inheritdoc cref="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.AdditionalFormElementCssClass" />
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxValidationMessage`1">
             <summary>


### PR DESCRIPTION
I totally missed the scenario of HxSwitch that is built upon the logic of **HxCheckbox**. I have adjusted the logic as follows:

- Created a separate property for a CSS class named **AdditionalFormElementCssClass** which is always applied and allows **HxSwitch** to apply it's _form-switch_ class.
- Adjusted the structure of the private properties and logic of when and where the _form-check_ CSS class is applied.
- When no Text is present the _form-check_ CSS class should be omitted according to https://getbootstrap.com/docs/5.3/forms/checks-radios/#without-labels