### PR TITLE
To allow using CalendarIcon with InputGroups on HxInputDate

### DIFF
--- a/BlazorAppTest/Pages/HxInputDateTest.razor
+++ b/BlazorAppTest/Pages/HxInputDateTest.razor
@@ -11,12 +11,29 @@
 	<HxInputDate Label="HxInputDate (default, DateTime?)" @bind-Value="@model.NullableDateTime" Placeholder="Datum narození" />
 	<HxInputDate Label="HxInputDate (default, DateTimeOffset)" @bind-Value="@model.DateTimeOffset" />
 	<HxInputDate Label="HxInputDate (default, DateTimeOffset?)" @bind-Value="@model.NullableDateTimeOffset" />
-	<HxInputDate Label="HxInputDate (DisplayName)" @bind-Value="@model.DateTime" />
+	<HxInputDate Label="HxInputDate (InputGroupStart, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime" >
+	<InputGroupStartTemplate>
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+	</InputGroupStartTemplate>
+	</HxInputDate>
+	<HxInputDate Label="HxInputDate (InputGroupEnd, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime" >
+	<InputGroupEndTemplate>
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+	</InputGroupEndTemplate>
+	</HxInputDate>
+	<HxInputDate Label="HxInputDate (InputGroups, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime" >
+	<InputGroupStartTemplate>
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+	</InputGroupStartTemplate>
+	<InputGroupEndTemplate>
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+	</InputGroupEndTemplate>
+	</HxInputDate>
 	<HxInputDate Label="HxInputDate (wo/ PredefinedDates, wo/ validation)" @bind-Value="@model.DateTime" ShowPredefinedDates="false" ValidationMessageMode="ValidationMessageMode.None" />
 	<HxInputDate Label="HxInputDate (custom PredefinedDates)" @bind-Value="@model.DateTime" PredefinedDates="@GetPredefinedDates()" />
 	<HxInputDate Label="HxInputDate (disabled)" @bind-Value="@model.DateTime" PredefinedDates="@GetPredefinedDates()" Enabled="false" />
 	<HxInputDate Label="HxInputDate (w/ CalendarIcon)" @bind-Value="@model.DateTime" CalendarIcon="BootstrapIcon.Calendar" />
-	<HxInputDate Label="HxInputDate (w/ CalendarIcon)" @bind-Value="@model.DateTime" CalendarIcon="BootstrapIcon.Calendar" Enabled="false" />
+	<HxInputDate Label="HxInputDate (w/ CalendarIcon, disabled)" @bind-Value="@model.DateTime" CalendarIcon="BootstrapIcon.Calendar" Enabled="false" />
 	<HxInputDate Label="HxInputDate (w/ CalendarIcon, wo/ PredefinedDates)" @bind-Value="@model.DateTime" CalendarIcon="BootstrapIcon.Calendar" ShowPredefinedDates="false" />
 	<HxInputDate Label="HxInputDate (w/ MinDate, MaxDate)" @bind-Value="@model.DateTime" MinDate="new DateTime(1920, 3, 5)" MaxDate="new DateTime(1999, 6, 15)" ShowPredefinedDates="false" CalendarDateCustomizationProvider="GetCalendarDateCustomization" />
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor
@@ -5,23 +5,25 @@
 @if (FieldIdentifier.Model != null)
 {
 	<div class="@CssClassHelper.Combine(
-		            "hx-input-date-wrapper input-group",
+		            "hx-input-date-wrapper",
 		            ((IInputWithSize)this).GetInputGroupSizeCssClass(),
 		            InputSizeEffective.AsInputGroupCssClass(),
-		            (ShowPredefinedDatesEffective && (PredefinedDatesEffective?.Any() ?? false)) ? "hx-input-date-predefined-dates" : null,
+					HasInputGroupsEffective ? "input-group" : null,
+					HasEndInputGroupEffective ? "input-group-end" : null,
+					HasStartInputGroupEffective ? "input-group-start" : null,
 		            (CalendarIconEffective is not null) ? "hx-input-date-has-calendar-icon" : null)">
+		@if (InputGroupStartText is not null)
+		{
+			<span class="input-group-text">@InputGroupStartText</span>
+		}
+
+		@InputGroupStartTemplate
 		<HxDropdown CssClass="@CssClassHelper.Combine(
 					     "hx-input-date",
 					     (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null,
 					     InputGroupCssClass)"
 					AutoClose="DropdownAutoClose.Outside">
 
-			@if (InputGroupStartText is not null)
-			{
-				<span class="input-group-text">@InputGroupStartText</span>
-			}
-
-			@InputGroupStartTemplate
 
 			<HxDropdownToggleElement @ref="_hxDropdownToggleElement"
 									 ElementName="input"
@@ -37,12 +39,6 @@
 									 onfocus="this.select();"
 									 @attributes="AdditionalAttributes" />
 
-			@InputGroupEndTemplate
-
-			@if (InputGroupEndText is not null)
-			{
-				<span class="@CssClassHelper.Combine("input-group-text", RenderPredefinedDates ? null : " rounded-end")">@InputGroupEndText</span>
-			}
 
 			@if (LabelTypeEffective == LabelType.Floating)
 			{
@@ -70,12 +66,18 @@
 					</div>
 				}
 			</HxDropdownContent>
-			@if (RenderIcon)
+			@if (HasCalendarIcon)
 			{
 				<div @ref="_iconWrapperElement" class="hx-input-date-icon">
 					<HxIcon Icon="CalendarIconEffective" />
 				</div>
 			}
 		</HxDropdown>
+		@InputGroupEndTemplate
+
+		@if (InputGroupEndText is not null)
+		{
+			<span class="@CssClassHelper.Combine("input-group-text", RenderPredefinedDates ? null : " rounded-end")">@InputGroupEndText</span>
+		}
 	</div>
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
@@ -67,9 +67,10 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 
 	protected bool HasInputGroupsEffective => !String.IsNullOrWhiteSpace(InputGroupStartText) || !String.IsNullOrWhiteSpace(InputGroupEndText) || (InputGroupStartTemplate is not null) || (InputGroupEndTemplate is not null);
 	protected bool HasEndInputGroupEffective => !String.IsNullOrWhiteSpace(InputGroupEndText) || (InputGroupEndTemplate is not null);
+	protected bool HasStartInputGroupEffective => !String.IsNullOrWhiteSpace(InputGroupStartText) || (InputGroupStartTemplate is not null);
 
 	protected bool RenderPredefinedDates => ShowPredefinedDatesEffective && (PredefinedDatesEffective != null) && PredefinedDatesEffective.Any();
-	protected bool RenderIcon => CalendarIconEffective is not null && !HasInputGroupsEffective;
+	protected bool HasCalendarIcon => CalendarIconEffective is not null;
 
 	protected DateTime GetCalendarDisplayMonthEffective => GetDateTimeFromValue(CurrentValue) ?? CalendarDisplayMonth;
 
@@ -158,7 +159,7 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 
 		await base.OnAfterRenderAsync(firstRender);
 
-		if (RenderIcon)
+		if (HasCalendarIcon)
 		{
 			_jsModule ??= await JSRuntime.ImportHavitBlazorBootstrapModuleAsync(nameof(HxInputDate));
 			await _jsModule.InvokeVoidAsync("addOpenAndCloseEventListeners", _hxDropdownToggleElement.ElementReference, (CalendarIconEffective is not null) ? _iconWrapperElement : null);

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.css
@@ -32,15 +32,15 @@
 	background-position: right calc(0.375em + 2rem) center;
 }
 
-.hx-input-date-has-calendar-icon .form-control {
+.hx-input-date-has-calendar-icon ::deep .form-control {
 	padding-right: 4.25rem;
 }
 
-.hx-input-date-has-calendar-icon.input-group-lg .form-control {
+.hx-input-date-has-calendar-icon.input-group-lg ::deep .form-control {
 	padding-right: 4.75rem;
 }
 
-.hx-input-date-has-calendar-icon.input-group-sm .form-control {
+.hx-input-date-has-calendar-icon.input-group-sm ::deep .form-control {
 	padding-right: 4rem;
 }
 
@@ -63,4 +63,18 @@
 
 ::deep .dropdown:focus-within {
     z-index: 6; /* Assures that the inputs' box shadows are always fully visible (rendered on top). Must be larger than 5 because otherwise the validation message is rendered on top. */
+}
+
+.input-group-start ::deep .form-control {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+
+.input-group-end ::deep .form-control {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+}
+/* Invalid left/right input borders need to be over the input group borders in invalid state. */
+.input-group ::deep .hx-input-date:has(.is-invalid):not(:focus-within) {
+	z-index: 3;
 }


### PR DESCRIPTION
This PR implements changes needed for #773.

1) Adjusted component structure
2) Added styles needed for removing borders on input if InputGroup is used
3) Added HasStartInputGroupEffective bool to control the rendering of css classes needed for styling
4) Removed "hx-input-date-predefined-dates" css calss as no usage found