### PR TITLE
Bump NuGet packages. Fix versions for .NET 6 and 7.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,41 +6,47 @@
 	<ItemGroup>
 		<PackageVersion Include="Blazored.FluentValidation" Version="2.1.0" />
 		<PackageVersion Include="bunit.web" Version="1.27.17" />
-		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.61.0" />
-		<PackageVersion Include="Grpc.Net.Client" Version="2.61.0" />
-		<PackageVersion Include="Grpc.Net.Client.Web" Version="2.61.0" />
+		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.62.0" />
+		<PackageVersion Include="Grpc.Net.Client" Version="2.62.0" />
+		<PackageVersion Include="Grpc.Net.Client.Web" Version="2.62.0" />
 		<PackageVersion Include="Havit.Core" Version="2.0.29" />
 		<PackageVersion Include="Havit.AspNetCore" Version="2.0.12" />
-		<PackageVersion Include="LoxSmoke.DocXml" Version="3.6.0" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="7.0.17" Condition="'$(TargetFramework)' == 'net7.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="6.0.28" Condition="'$(TargetFramework)' == 'net6.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.17" Condition="'$(TargetFramework)' == 'net7.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.28" Condition="'$(TargetFramework)' == 'net6.0'" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.3" />
+		<PackageVersion Include="LoxSmoke.DocXml" Version="3.6.1" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="7.0.18" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="6.0.29" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.18" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.29" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.18" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.29" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.18" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.29" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.18" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.29" Condition="'$(TargetFramework)' == 'net6.0'" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-		<PackageVersion Include="Microsoft.Extensions.Localization" Version="8.0.3" />
-		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.3" />
-		<PackageVersion Include="Microsoft.Bcl.TimeProvider"  Version="8.0.1" Condition="'$(TargetFramework)' != 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Localization" Version="8.0.4" />
+		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.4" />
+		<PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" Condition="'$(TargetFramework)' != 'net8.0'" />
 		<PackageVersion Include="Moq" Version="4.20.70" />
-		<PackageVersion Include="MSTest" Version="3.2.2" />
+		<PackageVersion Include="MSTest" Version="3.3.1" />
 		<PackageVersion Include="protobuf-net" Version="3.2.30" />
 		<PackageVersion Include="protobuf-net.Grpc" Version="1.1.1" />
 		<PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.1.1" />
 		<PackageVersion Include="protobuf-net.Grpc.ClientFactory" Version="1.1.1" />
-		<PackageVersion Include="SmartComponents.AspNetCore" Version="0.1.0-preview10141" />
-		<PackageVersion Include="SmartComponents.AspNetCore.Components" Version="0.1.0-preview10141" />
-		<PackageVersion Include="SmartComponents.Inference.OpenAI" Version="0.1.0-preview10141" />
-		<PackageVersion Include="SmartComponents.LocalEmbeddings" Version="0.1.0-preview10141" />
+		<PackageVersion Include="SmartComponents.AspNetCore" Version="0.1.0-preview10148" />
+		<PackageVersion Include="SmartComponents.AspNetCore.Components" Version="0.1.0-preview10148" />
+		<PackageVersion Include="SmartComponents.Inference.OpenAI" Version="0.1.0-preview10148" />
+		<PackageVersion Include="SmartComponents.LocalEmbeddings" Version="0.1.0-preview10148" />
 		<PackageVersion Include="System.Text.Json" Version="8.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<!-- https://github.com/microsoft/MSBuildSdks/tree/main/src/CopyOnWrite -->
-		<GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.302">
+		<GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.315">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</GlobalPackageReference>


### PR DESCRIPTION
I noticed that NuGet package restore would fail for .NET 6 and 7 due to some package references not having framework targets set, in addition to dependencies being out of date. This change fixes that.