### PR TITLE
ComponentApiDocModelBuilder - fix enum summary order

### DIFF
--- a/Havit.Blazor.Documentation/Services/ComponentApiDocModelBuilder.cs
+++ b/Havit.Blazor.Documentation/Services/ComponentApiDocModelBuilder.cs
@@ -149,7 +149,7 @@ public class ComponentApiDocModelBuilder : IComponentApiDocModelBuilder
 			try
 			{
 				var enumValueComment = enumComments.ValueComments
-					.Where(o => o.Value == i)
+					.Where(o => o.Name == enumMember.Name)
 					.FirstOrDefault(c => !string.IsNullOrEmpty(c.Summary));
 
 				if (enumValueComment is not null)


### PR DESCRIPTION
The summaries for the enum members weren't being retrieved according to a reliable key - the correct summaries were matched only if the enum values started from 0 and inscreased by one. In most cases it resulted in the following.

![image](https://github.com/havit/Havit.Blazor/assets/62853076/37b687e4-c06e-4a7e-bc05-9146a29848b8)