### PR TITLE
HxMessenger - Added CssClasses to Defaults for Info, Warning and Error

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessengerServiceExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxMessengerServiceExtensions.cs
@@ -30,6 +30,7 @@ public static class HxMessengerServiceExtensions
 		messenger.AddMessage(new BootstrapMessengerMessage()
 		{
 			Color = Defaults.InformationColor,
+			CssClass = Defaults.InformationCssClass,
 			AutohideDelay = Defaults.InformationAutohideDelay,
 			ContentTemplate = BuildContentTemplate(title, message)
 		});
@@ -53,6 +54,7 @@ public static class HxMessengerServiceExtensions
 		messenger.AddMessage(new BootstrapMessengerMessage()
 		{
 			Color = Defaults.WarningColor,
+			CssClass = Defaults.WarningCssClass,
 			AutohideDelay = Defaults.WarningAutohideDelay,
 			ContentTemplate = BuildContentTemplate(title, message)
 		});
@@ -77,6 +79,7 @@ public static class HxMessengerServiceExtensions
 		messenger.AddMessage(new BootstrapMessengerMessage()
 		{
 			Color = Defaults.ErrorColor,
+			CssClass = Defaults.ErrorCssClass,
 			AutohideDelay = Defaults.ErrorAutohideDelay,
 			ContentTemplate = BuildContentTemplate(title, message)
 		});

--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/MessengerServiceExtensionsSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/MessengerServiceExtensionsSettings.cs
@@ -11,6 +11,11 @@ public record MessengerServiceExtensionsSettings
 	public ThemeColor InformationColor { get; set; } = ThemeColor.Primary;
 
 	/// <summary>
+	/// CssClass of informational messages.
+	/// </summary>
+	public string InformationCssClass { get; set; } = string.Empty;
+
+	/// <summary>
 	/// Default autohide delay for information (in milliseconds). Default is <c>5000</c> ms.
 	/// </summary>
 	public int? InformationAutohideDelay { get; set; } = 5000;
@@ -21,6 +26,11 @@ public record MessengerServiceExtensionsSettings
 	public ThemeColor WarningColor { get; set; } = ThemeColor.Warning;
 
 	/// <summary>
+	/// CssClass of warning messages.
+	/// </summary>
+	public string WarningCssClass { get; set; } = string.Empty;
+
+	/// <summary>
 	/// Default autohide delay for warnings (in milliseconds). Default is <c>null</c> (do not autohide).
 	/// </summary>
 	public int? WarningAutohideDelay { get; set; } = null;
@@ -29,6 +39,11 @@ public record MessengerServiceExtensionsSettings
 	/// Color scheme of error messages.
 	/// </summary>
 	public ThemeColor ErrorColor { get; set; } = ThemeColor.Danger;
+
+	/// <summary>
+	/// CssClass of error messages.
+	/// </summary>
+	public string ErrorCssClass { get; set; } = string.Empty;
 
 	/// <summary>
 	/// Default autohide delay for errors (in milliseconds). Default is <c>null</c> (do not autohide).


### PR DESCRIPTION
Pull request na základě tasku z Autronicu pro možnost přidávat CssClasses i pro Warning, Error, a Info messages.
Kvůli kaskádový posloupnosti stylů z bootstrapu bohužel třeba barva textu (text-dark) nelze přepsat další bootstrapí třídou (text-white), ale musí být použita třída z konkrétního projektu, uložená například v site.css.

Asi by to šlo vyřešit i líp, kdyby se s TemeColor přidala i text-class pouze v případě, kdy jí nepředáme v CssClass, ale nepřišel jsem na to, jak toho docílit.  