### PR TITLE
#816 Add ThemeColor classes to toast-header

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToast.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToast.cs
@@ -104,7 +104,7 @@ public partial class HxToast : ComponentBase, IAsyncDisposable
 		if (renderHeader)
 		{
 			builder.OpenElement(200, "div");
-			builder.AddAttribute(201, "class", "toast-header");
+			builder.AddAttribute(201, "class", CssClassHelper.Combine("toast-header", Color?.ToBackgroundColorCss(), HasContrastColor() ? "text-white" : "text-dark"));
 
 			if (HeaderIcon != null)
 			{


### PR DESCRIPTION
Fixes visual discrepancy between toast header and body reported in #816.