### PR TITLE
HxPopover Dismiss on next click docs update

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_Dismissible.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_Dismissible.razor
@@ -1,3 +1,3 @@
 ﻿<HxPopover Trigger="PopoverTrigger.Focus" Title="Dismissible popover" Content="And here's some amazing content. It's very engaging. Right?">
-	<HxButton Color="ThemeColor.Primary">Dismissible popover</HxButton>
+	<a tabindex="0" class="btn btn-lg btn-danger">Dismissible popover</a>
 </HxPopover>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_Dismissible.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_Dismissible.razor
@@ -1,3 +1,3 @@
 ﻿<HxPopover Trigger="PopoverTrigger.Focus" Title="Dismissible popover" Content="And here's some amazing content. It's very engaging. Right?">
-	<a tabindex="0" class="btn btn-lg btn-danger">Dismissible popover</a>
+	<a tabindex="0" class="btn btn-primary">Dismissible popover</a>
 </HxPopover>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Documentation.razor
@@ -24,6 +24,9 @@
 
     <DocHeading Title="Dismiss on next click" />
 	<p>Use the <code>Trigger="PopoverTrigger.Focus"</code> to dismiss popovers on the user’s next click of a different element than the toggle element.</p>
+	<DocAlert Type="DocAlertType.Warning">
+		Dismissing on next click requires specific HTML for proper cross-browser and cross-platform behavior. You can only use <code>a</code> elements, not <code>button</code>, and you must include a tabindex.
+	</DocAlert>
 	<Demo Type="typeof(HxPopover_Demo_Dismissible)" />
 
     <DocHeading Title="Programmability" />


### PR DESCRIPTION
Fixes #611 [HxPopover] Dismiss on next click is not working on macOS
Aligns the demo with the Bootstrap docs.