### PR TITLE
Support multiple assemblies in Grpc extensions

### DIFF
--- a/Havit.Blazor.Grpc.Client/GrpcClientServiceCollectionExtensions.cs
+++ b/Havit.Blazor.Grpc.Client/GrpcClientServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Havit.Blazor.Grpc.Client.Infrastructure;
 using Havit.Blazor.Grpc.Client.ServerExceptions;
 using Havit.Blazor.Grpc.Core;
 using Havit.ComponentModel;
+using Havit.Diagnostics.Contracts;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -21,7 +22,7 @@ namespace Havit.Blazor.Grpc.Client;
 public static class GrpcClientServiceCollectionExtensions
 {
 	/// <summary>
-	/// <see cref="AddGrpcClientInfrastructure(IServiceCollection, Assembly[])"/>
+	/// Adds the necessary infrastructure for gRPC clients.
 	/// </summary>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
 	/// <param name="assemblyToScanForDataContracts">Assembly to scan for data contracts.</param>
@@ -91,7 +92,7 @@ public static class GrpcClientServiceCollectionExtensions
 		Action<IHttpClientBuilder> configureGrpClientAll = null,
 		Action<IServiceProvider, GrpcClientFactoryOptions> configureGrpcClientFactory = null)
 	{
-		ArgumentNullException.ThrowIfNull(assembliesToScan, nameof(assembliesToScan));
+		Contract.Requires<ArgumentNullException>(assembliesToScan is not null);
 
 		var interfacesAndAttributes = (from assembly in assembliesToScan
 									   from type in assembly.GetTypes()

--- a/Havit.Blazor.Grpc.Server/EndpointRouteBuilderGrpcExtensions.cs
+++ b/Havit.Blazor.Grpc.Server/EndpointRouteBuilderGrpcExtensions.cs
@@ -9,7 +9,7 @@ namespace Havit.Blazor.Grpc.Server;
 public static class EndpointRouteBuilderGrpcExtensions
 {
 	/// <summary>
-	/// <see cref="MapGrpcServicesByApiContractAttributes(IEndpointRouteBuilder, Assembly[], Action{GrpcServiceEndpointConventionBuilder}, Action{GrpcServiceEndpointConventionBuilder})"
+	/// Maps gRPC services with <see cref="ApiContractAttribute"/> as route endpoints.
 	/// </summary>
 	/// <param name="builder">Endpoint route builder.</param>
 	/// <param name="assemblyToScan">Assembly to scan for interfaces with <see cref="ApiContractAttribute"/>.</param>

--- a/Havit.Blazor.Grpc.Server/EndpointRouteBuilderGrpcExtensions.cs
+++ b/Havit.Blazor.Grpc.Server/EndpointRouteBuilderGrpcExtensions.cs
@@ -9,7 +9,7 @@ namespace Havit.Blazor.Grpc.Server;
 public static class EndpointRouteBuilderGrpcExtensions
 {
 	/// <summary>
-	/// Maps gRPC services with <see cref="ApiContractAttribute"/> as route endpoints.
+	/// <see cref="MapGrpcServicesByApiContractAttributes(IEndpointRouteBuilder, Assembly[], Action{GrpcServiceEndpointConventionBuilder}, Action{GrpcServiceEndpointConventionBuilder})"
 	/// </summary>
 	/// <param name="builder">Endpoint route builder.</param>
 	/// <param name="assemblyToScan">Assembly to scan for interfaces with <see cref="ApiContractAttribute"/>.</param>
@@ -21,10 +21,27 @@ public static class EndpointRouteBuilderGrpcExtensions
 		Action<GrpcServiceEndpointConventionBuilder> configureEndpointWithAuthorization = null,
 		Action<GrpcServiceEndpointConventionBuilder> configureEndpointAll = null)
 	{
-		Contract.Requires<ArgumentNullException>(builder is not null, nameof(builder));
-		Contract.Requires<ArgumentNullException>(assemblyToScan is not null, nameof(assemblyToScan));
+		MapGrpcServicesByApiContractAttributes(builder, [assemblyToScan], configureEndpointWithAuthorization, configureEndpointAll);
+	}
 
-		var interfacesAndAttributes = (from type in assemblyToScan.GetTypes()
+	/// <summary>
+	/// Maps gRPC services with <see cref="ApiContractAttribute"/> as route endpoints.
+	/// </summary>
+	/// <param name="builder">Endpoint route builder.</param>
+	/// <param name="assembliesToScan">Assemblies to scan for interfaces with <see cref="ApiContractAttribute"/>.</param>
+	/// <param name="configureEndpointWithAuthorization">Optional configuration for endpoints with authorization (all except <c>[ApiContract(RequireAuthorization = false)]</c>). Usually you want to setup <c>endpoint.RequireAuthorization(...)</c> here."/></param>
+	/// <param name="configureEndpointAll">Optional configuration for all endpoints.</param>
+	public static void MapGrpcServicesByApiContractAttributes(
+		this IEndpointRouteBuilder builder,
+		Assembly[] assembliesToScan,
+		Action<GrpcServiceEndpointConventionBuilder> configureEndpointWithAuthorization = null,
+		Action<GrpcServiceEndpointConventionBuilder> configureEndpointAll = null)
+	{
+		Contract.Requires<ArgumentNullException>(builder is not null, nameof(builder));
+		Contract.Requires<ArgumentNullException>(assembliesToScan is not null, nameof(assembliesToScan));
+
+		var interfacesAndAttributes = (from assembly in assembliesToScan
+									   from type in assembly.GetTypes()
 									   from apiContractAttribute in type.GetCustomAttributes(typeof(ApiContractAttribute), false).Cast<ApiContractAttribute>()
 									   select new { Interface = type, Attribute = apiContractAttribute }).ToArray();
 

--- a/Havit.Blazor.Grpc.Server/GrpcServerServiceCollectionExtensions.cs
+++ b/Havit.Blazor.Grpc.Server/GrpcServerServiceCollectionExtensions.cs
@@ -12,14 +12,38 @@ namespace Havit.Blazor.Grpc.Server;
 
 public static class GrpcServerServiceCollectionExtensions
 {
+	/// <summary>
+	/// <see cref="AddGrpcServerInfrastructure(IServiceCollection, Assembly[], Action{GrpcServiceOptions})"/>
+	/// </summary>
+	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+	/// <param name="assembliesToScanForDataContracts">Assembly to scan for data contracts</param>
+	/// <param name="configureOptions">gRPC Service options</param>
 	public static void AddGrpcServerInfrastructure(
 		this IServiceCollection services,
 		Assembly assemblyToScanForDataContracts,
 		Action<GrpcServiceOptions> configureOptions = null)
 	{
+		AddGrpcServerInfrastructure(services, [assemblyToScanForDataContracts], configureOptions);
+	}
+
+	/// <summary>
+	/// Adds the necessary infrastructure for gRPC servers.
+	/// </summary>
+	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+	/// <param name="assembliesToScanForDataContracts">Assemblies to scan for data contracts</param>
+	/// <param name="configureOptions">gRPC Service options</param>
+	public static void AddGrpcServerInfrastructure(
+		this IServiceCollection services,
+		Assembly[] assembliesToScanForDataContracts,
+		Action<GrpcServiceOptions> configureOptions = null)
+	{
+		ArgumentNullException.ThrowIfNull(assembliesToScanForDataContracts, nameof(assembliesToScanForDataContracts));
+
 		services.AddSingleton<GlobalizationLocalizationGrpcServerInterceptor>();
 		services.AddSingleton<ServerExceptionsGrpcServerInterceptor>();
-		services.AddSingleton(BinderConfiguration.Create(marshallerFactories: new[] { ProtoBufMarshallerFactory.Create(RuntimeTypeModel.Create().RegisterApplicationContracts(assemblyToScanForDataContracts)) }, binder: new ServiceBinderWithServiceResolutionFromServiceCollection(services)));
+		services.AddSingleton(BinderConfiguration.Create(
+			marshallerFactories: CreateMarshallerFactories(assembliesToScanForDataContracts),
+			binder: new ServiceBinderWithServiceResolutionFromServiceCollection(services)));
 
 		services.AddCodeFirstGrpc(options =>
 		{
@@ -30,4 +54,13 @@ public static class GrpcServerServiceCollectionExtensions
 			configureOptions?.Invoke(options);
 		});
 	}
+
+	/// <summary>
+	/// Creates marshaller factories for the specified assemblies.
+	/// Each assembly has its own marshaller factory.
+	/// </summary>
+	private static List<MarshallerFactory> CreateMarshallerFactories(Assembly[] assembliesToScanForDataContracts) =>
+		assembliesToScanForDataContracts
+			.Select(assembly => ProtoBufMarshallerFactory.Create(RuntimeTypeModel.Create().RegisterApplicationContracts(assembly)))
+			.ToList();
 }

--- a/Havit.Blazor.Grpc.Server/GrpcServerServiceCollectionExtensions.cs
+++ b/Havit.Blazor.Grpc.Server/GrpcServerServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Grpc.AspNetCore.Server;
 using Havit.Blazor.Grpc.Core;
 using Havit.Blazor.Grpc.Server.GlobalizationLocalization;
 using Havit.Blazor.Grpc.Server.ServerExceptions;
+using Havit.Diagnostics.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf.Grpc.Configuration;
 using ProtoBuf.Grpc.Server;
@@ -13,7 +14,7 @@ namespace Havit.Blazor.Grpc.Server;
 public static class GrpcServerServiceCollectionExtensions
 {
 	/// <summary>
-	/// <see cref="AddGrpcServerInfrastructure(IServiceCollection, Assembly[], Action{GrpcServiceOptions})"/>
+	/// Adds the necessary infrastructure for gRPC servers.
 	/// </summary>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
 	/// <param name="assembliesToScanForDataContracts">Assembly to scan for data contracts</param>
@@ -37,7 +38,7 @@ public static class GrpcServerServiceCollectionExtensions
 		Assembly[] assembliesToScanForDataContracts,
 		Action<GrpcServiceOptions> configureOptions = null)
 	{
-		ArgumentNullException.ThrowIfNull(assembliesToScanForDataContracts, nameof(assembliesToScanForDataContracts));
+		Contract.Requires<ArgumentNullException>(assembliesToScanForDataContracts is not null);
 
 		services.AddSingleton<GlobalizationLocalizationGrpcServerInterceptor>();
 		services.AddSingleton<ServerExceptionsGrpcServerInterceptor>();


### PR DESCRIPTION
Updated
- GrpcClientServiceCollectionExtensions
- EndpointRouteBuilderGrpcExtensions
- GrpcServerServiceCollectionExtensions to support multiple assemblies for scanning data contracts and API contract attributes. Added new overloads for relevant methods with backwards compatibility