### PR TITLE
Fixed LabelTypeEffective instead of the actual LabelType property

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDate.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDate.cs
@@ -104,7 +104,7 @@ public class HxInputDate<TValue> : HxInputBase<TValue>, IInputWithPlaceholder, I
 	protected LabelType LabelTypeEffective => LabelType ?? GetSettings()?.LabelType ?? GetDefaults()?.LabelType ?? HxSetup.Defaults.LabelType;
 	LabelType IInputWithLabelType.LabelTypeEffective => LabelTypeEffective;
 
-	protected override LabelValueRenderOrder RenderOrder => (LabelType == Bootstrap.LabelType.Floating) ? LabelValueRenderOrder.ValueOnly /* label rendered by HxInputDateInternal */ : LabelValueRenderOrder.LabelValue;
+	protected override LabelValueRenderOrder RenderOrder => (LabelTypeEffective == Bootstrap.LabelType.Floating) ? LabelValueRenderOrder.ValueOnly /* label rendered by HxInputDateInternal */ : LabelValueRenderOrder.LabelValue;
 
 	/// <summary>
 	/// Custom CSS class to render with the input-group span.


### PR DESCRIPTION
Fixes #951 

The Render was using LabelType property instead of the LabelTypeEffective.