### PR TITLE
To hide icon while button is spinning instead of removing from DOM

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor
@@ -21,9 +21,9 @@
             {
                 <HxSpinner Size="SpinnerSize.Small" />
             }
-            else if (IconEffective is not null)
+            if (IconEffective is not null)
             {
-                <HxIcon Icon="IconEffective" CssClass="@IconCssClassEffective" />
+                <HxIcon Icon="IconEffective" CssClass="@CssClassHelper.Combine(IconCssClassEffective, SpinnerEffective ? "d-none" : null)" />
             }
         }
 
@@ -37,9 +37,9 @@
             {
                 <HxSpinner Size="SpinnerSize.Small" />
             }
-            else if (IconEffective is not null)
+            if (IconEffective is not null)
             {
-                <HxIcon Icon="IconEffective" CssClass="@IconCssClassEffective" />
+                <HxIcon Icon="IconEffective" CssClass="@CssClassHelper.Combine(IconCssClassEffective, SpinnerEffective ? "d-none" : null)" />
             }
         }
     </button>


### PR DESCRIPTION
To resolve an issue where tooltips hang on displayed when button is clicked while hovering the icon, we hide the icon instead of remove from DOM.