### PR TITLE
Fixes #1001 + Toasts docs Alert markup fix

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToast.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToast.cs
@@ -96,8 +96,7 @@ public partial class HxToast : ComponentBase, IAsyncDisposable
 		builder.AddAttribute(104, "class", CssClassHelper.Combine(
 			"hx-toast toast",
 			ssrInit ? "hx-toast-init" : null,
-			Color?.ToBackgroundColorCss(),
-			HasContrastColor() ? "text-white" : "text-dark",
+			Color?.ToTextBackgroundColorCss(),
 			CssClass));
 
 		if (AutohideDelay != null)
@@ -113,7 +112,7 @@ public partial class HxToast : ComponentBase, IAsyncDisposable
 		if (renderHeader)
 		{
 			builder.OpenElement(200, "div");
-			builder.AddAttribute(201, "class", CssClassHelper.Combine("toast-header", Color?.ToBackgroundColorCss(), HasContrastColor() ? "text-white" : "text-dark"));
+			builder.AddAttribute(201, "class", CssClassHelper.Combine("toast-header", Color?.ToTextBackgroundColorCss()));
 
 			if (HeaderIcon != null)
 			{

--- a/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Documentation.razor
@@ -16,7 +16,7 @@
 		<Demo Type="typeof(HxToast_Demo)" />
 
 		<DocAlert Type="DocAlertType.Info">
-			<p><code>HxToast</code> supports static server rendering.</p>
+			<code>HxToast</code> supports static server rendering.
 		</DocAlert>
 	</MainContent>
 	<CssVariables>


### PR DESCRIPTION
Removed `HasContrastColor() ? "text-white" : "text-dark"` logic in favor of `ToTextBackgroundColorCss`.
Fixed Toast alert markup.