### PR TITLE
Add RenderMode to HxModal to align HxModal with HxOffcanvas

### DIFF
--- a/BlazorAppTest/Pages/HxModalTest.razor
+++ b/BlazorAppTest/Pages/HxModalTest.razor
@@ -7,19 +7,27 @@
 <HxModal @ref="myModal" Title="Modal title">
 	<BodyTemplate>
 		Body
-		<HxButton OnClick="HandleShowNestedClick" Color="ThemeColor.Danger">Show nested (exception expected)</HxButton>
-
-		<HxModal @ref="myNestedModal" />
+		<HxButton OnClick="HandleShowSecondClick" Color="ThemeColor.Danger">Show second</HxButton>
 	</BodyTemplate>
 	<FooterTemplate>
 		<HxButton Text="Close" OnClick="HandleHideClick" Color="ThemeColor.Secondary" />
 	</FooterTemplate>
 </HxModal>
 
+<HxModal @ref="mySecondModal">
+	<BodyTemplate>
+		Second
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton Text="Close" OnClick="HandleHideSecondClick" Color="ThemeColor.Secondary" />
+	</FooterTemplate>
+</HxModal>
+
+
 @code
 {
 	private HxModal myModal;
-	private HxModal myNestedModal;
+	private HxModal mySecondModal;
 
 	private async Task HandleShowClick()
 	{
@@ -31,10 +39,14 @@
 		await myModal.HideAsync();
 	}
 
-	private async Task HandleShowNestedClick()
+	private async Task HandleHideSecondClick()
 	{
-		await myNestedModal.ShowAsync();
+		await mySecondModal.HideAsync();
 	}
 
 
+	private async Task HandleShowSecondClick()
+	{
+		await mySecondModal.ShowAsync();
+	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
@@ -1,47 +1,50 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
 
 <div @ref="_modalElement"
-	 class="@CssClassHelper.Combine("hx-modal modal", AnimatedEffective ? "fade" : null, CssClassEffective)"
-	 tabindex="-1"
-	 data-bs-backdrop="@GetBackdropSetupValue(BackdropEffective)">
+     class="@CssClassHelper.Combine("hx-modal modal", AnimatedEffective ? "fade" : null, CssClassEffective)"
+     tabindex="-1"
+     data-bs-backdrop="@GetBackdropSetupValue(BackdropEffective)">
 	<div class="@CssClassHelper.Combine("modal-dialog", GetDialogSizeCssClass(), GetDialogFullscreenCssClass(), GetDialogScrollableCssClass(), GetDialogCenteredCssClass(), DialogCssClassEffective)">
-		<div class="@CssClassHelper.Combine("modal-content", ContentCssClassEffective)">
-			@if (!String.IsNullOrEmpty(Title) || (HeaderTemplate != null) || ShowCloseButtonEffective)
-			{
-				<div class="@CssClassHelper.Combine("modal-header", HeaderCssClassEffective)">
-					@if (!String.IsNullOrEmpty(Title))
-					{
-						<h5 class="modal-title">@Title</h5>
-					}
-					@if (HeaderTemplate != null)
-					{
-						@HeaderTemplate
-					}
-					@if (ShowCloseButtonEffective)
-					{
-						if (CloseButtonIconEffective is null)
+		@if (_opened || (RenderMode == ModalRenderMode.Always))
+		{
+			<div class="@CssClassHelper.Combine("modal-content", ContentCssClassEffective)">
+				@if (!String.IsNullOrEmpty(Title) || (HeaderTemplate != null) || ShowCloseButtonEffective)
+				{
+					<div class="@CssClassHelper.Combine("modal-header", HeaderCssClassEffective)">
+						@if (!String.IsNullOrEmpty(Title))
 						{
-							<button type="button" class="btn-close text-reset" data-bs-dismiss="modal" aria-label="Close"></button>
+							<h5 class="modal-title">@Title</h5>
 						}
-						else
+						@if (HeaderTemplate != null)
 						{
-							<div role="button" data-bs-dismiss="modal" aria-label="Close"><HxIcon Icon="CloseButtonIconEffective" /></div>
+							@HeaderTemplate
 						}
-					}
-				</div>
-			}
-			@if (BodyTemplate != null)
-			{
-				<div class="@CssClassHelper.Combine("modal-body", BodyCssClassEffective)">
-					@BodyTemplate
-				</div>
-			}
-			@if (FooterTemplate != null)
-			{
-				<div class="@CssClassHelper.Combine("modal-footer", FooterCssClassEffective)">
-					@FooterTemplate
-				</div>
-			}
-		</div>
+						@if (ShowCloseButtonEffective)
+						{
+							if (CloseButtonIconEffective is null)
+							{
+								<button type="button" class="btn-close text-reset" data-bs-dismiss="modal" aria-label="Close"></button>
+							}
+							else
+							{
+								<div role="button" data-bs-dismiss="modal" aria-label="Close"><HxIcon Icon="CloseButtonIconEffective"/></div>
+							}
+						}
+					</div>
+				}
+				@if (BodyTemplate != null)
+				{
+					<div class="@CssClassHelper.Combine("modal-body", BodyCssClassEffective)">
+						@BodyTemplate
+					</div>
+				}
+				@if (FooterTemplate != null)
+				{
+					<div class="@CssClassHelper.Combine("modal-footer", FooterCssClassEffective)">
+						@FooterTemplate
+					</div>
+				}
+			</div>
+		}
 	</div>
 </div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
@@ -1,51 +1,47 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
 
-@if (_opened)
-{
-	<div @ref="_modalElement"
-		 class="@CssClassHelper.Combine("hx-modal modal", AnimatedEffective ? "fade" : null, CssClassEffective)"
-		 tabindex="-1"
-		 data-bs-backdrop="@GetBackdropSetupValue(BackdropEffective)">
-
-		<div class="@CssClassHelper.Combine("modal-dialog", GetDialogSizeCssClass(), GetDialogFullscreenCssClass(), GetDialogScrollableCssClass(), GetDialogCenteredCssClass(), DialogCssClassEffective)">
-			<div class="@CssClassHelper.Combine("modal-content", ContentCssClassEffective)">
-				@if (!String.IsNullOrEmpty(Title) || (HeaderTemplate != null) || ShowCloseButtonEffective)
-				{
-					<div class="@CssClassHelper.Combine("modal-header", HeaderCssClassEffective)">
-						@if (!String.IsNullOrEmpty(Title))
+<div @ref="_modalElement"
+	 class="@CssClassHelper.Combine("hx-modal modal", AnimatedEffective ? "fade" : null, CssClassEffective)"
+	 tabindex="-1"
+	 data-bs-backdrop="@GetBackdropSetupValue(BackdropEffective)">
+	<div class="@CssClassHelper.Combine("modal-dialog", GetDialogSizeCssClass(), GetDialogFullscreenCssClass(), GetDialogScrollableCssClass(), GetDialogCenteredCssClass(), DialogCssClassEffective)">
+		<div class="@CssClassHelper.Combine("modal-content", ContentCssClassEffective)">
+			@if (!String.IsNullOrEmpty(Title) || (HeaderTemplate != null) || ShowCloseButtonEffective)
+			{
+				<div class="@CssClassHelper.Combine("modal-header", HeaderCssClassEffective)">
+					@if (!String.IsNullOrEmpty(Title))
+					{
+						<h5 class="modal-title">@Title</h5>
+					}
+					@if (HeaderTemplate != null)
+					{
+						@HeaderTemplate
+					}
+					@if (ShowCloseButtonEffective)
+					{
+						if (CloseButtonIconEffective is null)
 						{
-							<h5 class="modal-title">@Title</h5>
+							<button type="button" class="btn-close text-reset" data-bs-dismiss="modal" aria-label="Close"></button>
 						}
-						@if (HeaderTemplate != null)
+						else
 						{
-							@HeaderTemplate
+							<div role="button" data-bs-dismiss="modal" aria-label="Close"><HxIcon Icon="CloseButtonIconEffective" /></div>
 						}
-						@if (ShowCloseButtonEffective)
-						{
-							if (CloseButtonIconEffective is null)
-							{
-								<button type="button" class="btn-close text-reset" data-bs-dismiss="modal" aria-label="Close"></button>
-							}
-							else
-							{
-								<div role="button" data-bs-dismiss="modal" aria-label="Close"><HxIcon Icon="CloseButtonIconEffective" /></div>
-							}
-						}
-					</div>
-				}
-				@if (BodyTemplate != null)
-				{
-					<div class="@CssClassHelper.Combine("modal-body", BodyCssClassEffective)">
-						@BodyTemplate
-					</div>
-				}
-				@if (FooterTemplate != null)
-				{
-					<div class="@CssClassHelper.Combine("modal-footer", FooterCssClassEffective)">
-						@FooterTemplate
-					</div>
-				}
-			</div>
+					}
+				</div>
+			}
+			@if (BodyTemplate != null)
+			{
+				<div class="@CssClassHelper.Combine("modal-body", BodyCssClassEffective)">
+					@BodyTemplate
+				</div>
+			}
+			@if (FooterTemplate != null)
+			{
+				<div class="@CssClassHelper.Combine("modal-footer", FooterCssClassEffective)">
+					@FooterTemplate
+				</div>
+			}
 		</div>
 	</div>
-}
+</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.cs
@@ -228,6 +228,8 @@ public partial class HxModal : IAsyncDisposable
 		{
 			_onAfterRenderTasksQueue.Enqueue(async () =>
 			{
+				Console.WriteLine($"{nameof(HxModal)}.{nameof(HxModal.ShowAsync)} elementId: {_modalElement.Id}, opened: {_opened}");
+
 				// Running JS interop is postponed to OnAfterRenderAsync to ensure modalElement is set
 				// and correct order of commands (Show/Hide) is preserved
 				_jsModule ??= await JSRuntime.ImportHavitBlazorBootstrapModuleAsync(nameof(HxModal));
@@ -235,6 +237,7 @@ public partial class HxModal : IAsyncDisposable
 				{
 					return;
 				}
+
 				await _jsModule.InvokeVoidAsync("show", _modalElement, _dotnetObjectReference, CloseOnEscapeEffective, OnHiding.HasDelegate);
 			});
 		}
@@ -258,6 +261,8 @@ public partial class HxModal : IAsyncDisposable
 
 		_onAfterRenderTasksQueue.Enqueue(async () =>
 		{
+			Console.WriteLine($"{nameof(HxModal)}.{nameof(HxModal.HideAsync)} elementId: {_modalElement.Id}, opened: {_opened}");
+
 			// Running JS interop is postponed to OnAfterRenderAsync to ensure modalElement is set
 			// and correct order of commands (Show/Hide) is preserved
 			_jsModule ??= await JSRuntime.ImportHavitBlazorBootstrapModuleAsync(nameof(HxModal));
@@ -265,6 +270,7 @@ public partial class HxModal : IAsyncDisposable
 			{
 				return;
 			}
+
 			await _jsModule.InvokeVoidAsync("hide", _modalElement);
 		});
 		StateHasChanged(); // enforce rendering
@@ -306,6 +312,7 @@ public partial class HxModal : IAsyncDisposable
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
+		Console.WriteLine($"{nameof(HxModal)}.{nameof(HxModal.OnAfterRenderAsync)} - elementId: {_modalElement.Id}, opened: {_opened}");
 		while (_onAfterRenderTasksQueue.TryDequeue(out var task))
 		{
 			await task();

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.cs
@@ -94,6 +94,12 @@ public partial class HxModal : IAsyncDisposable
 	protected ModalFullscreen FullscreenEffective => Fullscreen ?? GetSettings()?.Fullscreen ?? GetDefaults().Fullscreen ?? throw new InvalidOperationException(nameof(Fullscreen) + " default for " + nameof(HxModal) + " has to be set.");
 
 	/// <summary>
+	/// Determines whether the content is always rendered or only if the modal is open.<br />
+	/// The default is <see cref="ModalRenderMode.OpenOnly"/>.<br />
+	/// </summary>
+	[Parameter] public ModalRenderMode RenderMode { get; set; } = ModalRenderMode.OpenOnly;
+
+	/// <summary>
 	/// Indicates whether the modal shows close button in header.
 	/// Default value is <c>true</c>.
 	/// </summary>
@@ -228,8 +234,6 @@ public partial class HxModal : IAsyncDisposable
 		{
 			_onAfterRenderTasksQueue.Enqueue(async () =>
 			{
-				Console.WriteLine($"{nameof(HxModal)}.{nameof(HxModal.ShowAsync)} elementId: {_modalElement.Id}, opened: {_opened}");
-
 				// Running JS interop is postponed to OnAfterRenderAsync to ensure modalElement is set
 				// and correct order of commands (Show/Hide) is preserved
 				_jsModule ??= await JSRuntime.ImportHavitBlazorBootstrapModuleAsync(nameof(HxModal));
@@ -261,8 +265,6 @@ public partial class HxModal : IAsyncDisposable
 
 		_onAfterRenderTasksQueue.Enqueue(async () =>
 		{
-			Console.WriteLine($"{nameof(HxModal)}.{nameof(HxModal.HideAsync)} elementId: {_modalElement.Id}, opened: {_opened}");
-
 			// Running JS interop is postponed to OnAfterRenderAsync to ensure modalElement is set
 			// and correct order of commands (Show/Hide) is preserved
 			_jsModule ??= await JSRuntime.ImportHavitBlazorBootstrapModuleAsync(nameof(HxModal));
@@ -312,7 +314,6 @@ public partial class HxModal : IAsyncDisposable
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
-		Console.WriteLine($"{nameof(HxModal)}.{nameof(HxModal.OnAfterRenderAsync)} - elementId: {_modalElement.Id}, opened: {_opened}");
 		while (_onAfterRenderTasksQueue.TryDequeue(out var task))
 		{
 			await task();

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/ModalRenderMode.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/ModalRenderMode.cs
@@ -1,0 +1,19 @@
+namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Modal render mode.
+/// </summary>
+public enum ModalRenderMode
+{
+	/// <summary>
+	/// Modal content is rendered only when it is open.
+	/// Suitable for item-detail, item-edit, etc.
+	/// </summary>
+	OpenOnly = 0,
+
+	/// <summary>
+	/// Modal content is always rendered (and hidden with CSS if not open).
+	/// Needed for HxFilterForm with HxChipList.
+	/// </summary>
+	Always = 1
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/ModalRenderMode.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/ModalRenderMode.cs
@@ -13,7 +13,7 @@ public enum ModalRenderMode
 
 	/// <summary>
 	/// Modal content is always rendered (and hidden with CSS if not open).
-	/// Needed for HxFilterForm with HxChipList.
+	/// Needed for rendering chips from filter, etc.
 	/// </summary>
 	Always = 1
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxModal.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxModal.js
@@ -1,5 +1,16 @@
 ﻿export function show(element, hxModalDotnetObjectReference, closeOnEscape, subscribeToHideEvent) {
-	if (!element || bootstrap.Modal.getInstance(element)) {
+	if (window.modalElement) {
+		const previousModal = bootstrap.Modal.getInstance(window.modalElement);
+		if (previousModal) {
+			// Although opening a new offcanvas should close the previous one,
+			// we do not set previousOffcanvas.hidePreventionDisabled = true and force the hide() here (when handling the OnHiding event)
+			// We want the developer to handle such specific scenarios on their own.
+			// This might be subject to change in the future.
+			previousModal.hide();
+		}
+	}
+
+	if (!element) {
 		return;
 	}
 
@@ -9,6 +20,7 @@
 	}
 	element.addEventListener('hidden.bs.modal', handleModalHidden);
 	element.addEventListener('shown.bs.modal', handleModalShown);
+	window.modalElement = element;
 
 	const modal = new bootstrap.Modal(element, {
 		keyboard: closeOnEscape

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxModal.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxModal.js
@@ -2,10 +2,6 @@
 	if (window.modalElement) {
 		const previousModal = bootstrap.Modal.getInstance(window.modalElement);
 		if (previousModal) {
-			// Although opening a new offcanvas should close the previous one,
-			// we do not set previousOffcanvas.hidePreventionDisabled = true and force the hide() here (when handling the OnHiding event)
-			// We want the developer to handle such specific scenarios on their own.
-			// This might be subject to change in the future.
 			previousModal.hide();
 		}
 	}
@@ -67,7 +63,7 @@ function handleModalHidden(event) {
 	event.target.hxModalHiding = false;
 
 	if (event.target.hxModalDisposing) {
-		// fix for #110 where the dispose() gets called while the offcanvas is still in hiding-transition
+		// fix for #110 where the dispose() gets called while the modal is still in hiding-transition
 		dispose(event.target, false);
 		return;
 	}
@@ -83,7 +79,7 @@ export function dispose(element, opened) {
 	element.hxModalDisposing = true;
 
 	if (element.hxModalHiding) {
-		// fix for #110 where the dispose() gets called while the offcanvas is still in hiding-transition
+		// fix for #110 where the dispose() gets called while the modal is still in hiding-transition
 		return;
 	}
 

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -8221,7 +8221,7 @@
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ModalRenderMode.Always">
             <summary>
             Modal content is always rendered (and hidden with CSS if not open).
-            Needed for HxFilterForm with HxChipList.
+            Needed for rendering chips from filter, etc.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.ModalSettings">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -7888,6 +7888,12 @@
             Fullscreen behavior of the modal. Default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ModalFullscreen.Disabled"/>.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxModal.RenderMode">
+            <summary>
+            Determines whether the content is always rendered or only if the modal is open.<br />
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ModalRenderMode.OpenOnly"/>.<br />
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxModal.ShowCloseButton">
             <summary>
             Indicates whether the modal shows close button in header.
@@ -8199,6 +8205,23 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.ModalHidingEventArgs.Cancel">
             <summary>
             Set <c>true</c> to prevent modal hiding.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.ModalRenderMode">
+            <summary>
+            Modal render mode.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ModalRenderMode.OpenOnly">
+            <summary>
+            Modal content is rendered only when it is open.
+            Suitable for item-detail, item-edit, etc.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ModalRenderMode.Always">
+            <summary>
+            Modal content is always rendered (and hidden with CSS if not open).
+            Needed for HxFilterForm with HxChipList.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.ModalSettings">

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/BusinessCardValidationModal.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/BusinessCardValidationModal.razor
@@ -1,0 +1,5 @@
+<HxModal @ref="_modalComponent" OnShown="ValidateBusinessCard">
+	<BodyTemplate>
+		<h1>Doing work...</h1>
+	</BodyTemplate>
+</HxModal>

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/BusinessCardValidationModal.razor.cs
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/BusinessCardValidationModal.razor.cs
@@ -1,0 +1,40 @@
+namespace Havit.Blazor.TestApp.Client;
+
+public partial class BusinessCardValidationModal : ComponentBase
+{
+	[Parameter] public bool StartValidation { get; set; }
+	[Parameter] public EventCallback OnValidationFinished { get; set; }
+
+	private HxModal _modalComponent;
+
+	private bool _validationStarted;
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (StartValidation && !_validationStarted)
+		{
+			_validationStarted = true;
+			await _modalComponent.ShowAsync();
+		}
+	}
+
+	private async Task ValidateBusinessCard()
+	{
+		//var workContext = EventCallback.Factory.Create(this, FinishValidation);
+
+		// Do work
+		await Task.Delay(500);
+
+		// Invoke finish handler
+		//await workContext.InvokeAsync();
+		await FinishValidation();
+	}
+
+	private async Task FinishValidation()
+	{
+		await _modalComponent.HideAsync();
+		await OnValidationFinished.InvokeAsync();
+
+		_validationStarted = false;
+	}
+}

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxModal_BusinessCardValidation_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxModal_BusinessCardValidation_Test.razor
@@ -1,0 +1,8 @@
+@page "/HxModal_BusinessCardValidation_Test"
+
+@rendermode InteractiveWebAssembly
+
+<HxButton Color="ThemeColor.Primary" OnClick="TriggerValidation">Start validation</HxButton>
+
+<BusinessCardValidationModal StartValidation="_startValidation"
+                             OnValidationFinished="HandleValidationFinished"/>

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxModal_BusinessCardValidation_Test.razor.cs
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxModal_BusinessCardValidation_Test.razor.cs
@@ -1,0 +1,16 @@
+namespace Havit.Blazor.TestApp.Client;
+
+public partial class HxModal_BusinessCardValidation_Test : ComponentBase
+{
+	private bool _startValidation;
+
+	private void TriggerValidation()
+	{
+		_startValidation = true;
+	}
+
+	private void HandleValidationFinished()
+	{
+		_startValidation = false;
+	}
+}


### PR DESCRIPTION
- Removed wrapping `if (_opened)` so the root modal `div` element is always rendered
- Added `RenderMode` parameter to `HxModal` (defaults to `OpenOnly`)
- Added a repro page for the issue where modal will not properly show up after clicking the **Show** button for a second time

If the modal is not opened and `ModalRenderMode.OpenOnly` is set then the `div.modal` as well as the `div.modal-dialog` inside will render. This is because Bootstrap Modal JS utilizes both of these `divs` when `show` is called.

When I tried to not always render the `div.modal-dialog` element then this line of code would cause a crash with an Illegal invocation exception likely due to an ivalid `this._dialog` value:
https://github.com/twbs/bootstrap/blob/main/js/src/modal.js#L183


