### PR TITLE
HxPager - throw an exception when TotalPages is less than 1

### DIFF
--- a/BlazorAppTest/Pages/HxPager_NoItems_Test.razor
+++ b/BlazorAppTest/Pages/HxPager_NoItems_Test.razor
@@ -1,0 +1,16 @@
+@page "/HxPager_NoItems_Test"
+
+<h1>HxPager NoItems Test</h1>
+
+<HxButton Color="ThemeColor.Primary" Text="Change TotalPages to 0" OnClick="ChangeTotalPagesToZero" CssClass="mb-2" />
+
+<HxPager CurrentPageIndex="0" TotalPages="_totalPages" />
+
+@code {
+	private int _totalPages = 1;
+
+	private void ChangeTotalPagesToZero()
+	{
+		_totalPages = 0;
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor
@@ -11,7 +11,6 @@
 }
 
 <ul class="@CssClassHelper.Combine("hx-pager pagination", CssClassEffective)">
-
 	@if (showFirstLast)
 	{
 		<li class="@previousPageItemDisabledCssClass">

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
@@ -123,10 +123,8 @@ public partial class HxPager : ComponentBase
 	{
 		if (TotalPages < 1)
 		{
-			throw new InvalidOperationException($"{nameof(TotalPages)} has to be greater than or equal to 1.");
+			throw new InvalidOperationException($"{nameof(HxPager)} requires {nameof(TotalPages)} to be greater than or equal to 1.");
 		}
-
-		base.OnParametersSet();
 	}
 
 	/// <summary>

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
@@ -123,7 +123,7 @@ public partial class HxPager : ComponentBase
 	{
 		if (TotalPages < 1)
 		{
-			throw new InvalidOperationException($"{nameof(HxPager)} requires {nameof(TotalPages)} to be greater than or equal to 1.");
+			throw new InvalidOperationException($"[{GetType().Name}] {nameof(TotalPages)} has to be greater than or equal to 1.");
 		}
 	}
 
@@ -132,8 +132,8 @@ public partial class HxPager : ComponentBase
 	/// </summary>
 	protected async Task SetCurrentPageIndexTo(int newPageIndex)
 	{
-		Contract.Requires(newPageIndex >= 0, nameof(newPageIndex));
-		Contract.Requires(newPageIndex < TotalPages, nameof(newPageIndex));
+		Contract.Requires<ArgumentException>(newPageIndex >= 0);
+		Contract.Requires<ArgumentException>(newPageIndex < TotalPages);
 
 		CurrentPageIndex = newPageIndex;
 		await InvokeCurrentPageIndexChangedAsync(CurrentPageIndex);

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
@@ -44,6 +44,7 @@ public partial class HxPager : ComponentBase
 
 	/// <summary>
 	/// Total number of pages of data items.
+	/// Has to be equal to or greater than <c>1</c>.
 	/// </summary>
 	[Parameter, EditorRequired] public int TotalPages { get; set; }
 
@@ -117,6 +118,16 @@ public partial class HxPager : ComponentBase
 	/// </summary>
 	[Parameter] public string CssClass { get; set; }
 	protected string CssClassEffective => CssClass ?? GetSettings()?.CssClass ?? GetDefaults().CssClass;
+
+	protected override void OnParametersSet()
+	{
+		if (TotalPages < 1)
+		{
+			throw new InvalidOperationException($"{nameof(TotalPages)} has to be greater than or equal to 1.");
+		}
+
+		base.OnParametersSet();
+	}
 
 	/// <summary>
 	/// Changes the current page index and fires the event.

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -7011,6 +7011,7 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxPager.TotalPages">
             <summary>
             Total number of pages of data items.
+            Has to be equal to or greater than <c>1</c>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxPager.CurrentPageIndex">

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxPagerTests/HxPager_NoItems_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxPagerTests/HxPager_NoItems_Test.razor
@@ -1,6 +1,5 @@
 @page "/HxPager_NoItems_Test"
-
-<h1>HxPager NoItems Test</h1>
+@rendermode InteractiveServer
 
 <HxButton Color="ThemeColor.Primary" Text="Change TotalPages to 0" OnClick="ChangeTotalPagesToZero" CssClass="mb-2" />
 

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp/appsettings.Development.json
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp/appsettings.Development.json
@@ -1,8 +1,9 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
+	"DetailedErrors": true, // turns on CircuitOptions.DetailedErrors
+	"Logging": {
+		"LogLevel": {
+			"Default": "Information",
+			"Microsoft.AspNetCore": "Warning"
+		}
+	}
 }


### PR DESCRIPTION
Lukáš Michl informed me about a behavior of `HxPager` that doesn't seem optimal. Currently, when `TotalPages` is set to a value lower than 1, the component doesn't look user-friendly and throws an exception when any button is pressed.

![image](https://github.com/user-attachments/assets/a0939fde-0cb6-4973-aad5-a114bbdccaed)

In this PR, a mechanism was added that throws an exception when `TotalPages` is set to a value lower than 1, so developers immediately notice that the value passed to this parameter must be checked and modified.

`HxGrid` solves this problem by not rendering the pager at all when `TotalPages` is lower than 2.