### PR TITLE
Add GrpcWebHandler factory parameter to AddGrpcClientInfrastructure methods

### DIFF
--- a/Havit.Blazor.Grpc.Client.Tests/GrpcClientServiceCollectionExtensionsTests.cs
+++ b/Havit.Blazor.Grpc.Client.Tests/GrpcClientServiceCollectionExtensionsTests.cs
@@ -12,7 +12,6 @@ public class GrpcClientServiceCollectionExtensionsTests
 		// arrange
 		var services = new ServiceCollection();
 
-
 		// act
 		services.AddGrpcClientsByApiContractAttributes(typeof(Dto).Assembly);
 

--- a/Havit.Blazor.Grpc.Client/GrpcClientInfrastructureOptions.cs
+++ b/Havit.Blazor.Grpc.Client/GrpcClientInfrastructureOptions.cs
@@ -1,8 +1,0 @@
-﻿using Grpc.Net.Client.Web;
-
-namespace Havit.Blazor.Grpc.Client;
-
-public class GrpcClientInfrastructureOptions
-{
-	public Func<IServiceProvider, GrpcWebHandler> GrpcWebHandlerFactory { get; set; }
-}

--- a/Havit.Blazor.Grpc.Client/GrpcClientInfrastructureOptions.cs
+++ b/Havit.Blazor.Grpc.Client/GrpcClientInfrastructureOptions.cs
@@ -1,0 +1,8 @@
+﻿using Grpc.Net.Client.Web;
+
+namespace Havit.Blazor.Grpc.Client;
+
+public class GrpcClientInfrastructureOptions
+{
+	public Func<IServiceProvider, GrpcWebHandler> GrpcWebHandlerFactory { get; set; }
+}

--- a/Havit.Blazor.Grpc.Client/GrpcClientServiceCollectionExtensions.cs
+++ b/Havit.Blazor.Grpc.Client/GrpcClientServiceCollectionExtensions.cs
@@ -26,11 +26,13 @@ public static class GrpcClientServiceCollectionExtensions
 	/// </summary>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
 	/// <param name="assemblyToScanForDataContracts">Assembly to scan for data contracts.</param>
+	/// <param name="grpcWebHandlerFactory">An optional factory method for the <see cref="GrpcWebHandler"/>.</param>
 	public static void AddGrpcClientInfrastructure(
 		this IServiceCollection services,
-		Assembly assemblyToScanForDataContracts)
+		Assembly assemblyToScanForDataContracts,
+		Func<IServiceProvider, GrpcWebHandler> grpcWebHandlerFactory = null)
 	{
-		AddGrpcClientInfrastructure(services, [assemblyToScanForDataContracts]);
+		AddGrpcClientInfrastructure(services, [assemblyToScanForDataContracts], grpcWebHandlerFactory);
 	}
 
 	/// <summary>
@@ -38,14 +40,16 @@ public static class GrpcClientServiceCollectionExtensions
 	/// </summary>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
 	/// <param name="assembliesToScanForDataContracts">Assemblies to scan for data contracts.</param>
+	/// <param name="grpcWebHandlerFactory">An optional factory method for the <see cref="GrpcWebHandler"/>.</param>
 	public static void AddGrpcClientInfrastructure(
 		this IServiceCollection services,
-		Assembly[] assembliesToScanForDataContracts)
+		Assembly[] assembliesToScanForDataContracts,
+		Func<IServiceProvider, GrpcWebHandler> grpcWebHandlerFactory = null)
 	{
 		services.AddTransient<ServerExceptionsGrpcClientInterceptor>();
 		services.AddSingleton<GlobalizationLocalizationGrpcClientInterceptor>();
 		services.AddScoped<ClientUriGrpcClientInterceptor>();
-		services.AddTransient<GrpcWebHandler>(provider => new GrpcWebHandler(GrpcWebMode.GrpcWeb, new HttpClientHandler()));
+		services.AddTransient<GrpcWebHandler>(grpcWebHandlerFactory ?? (provider => new GrpcWebHandler(GrpcWebMode.GrpcWeb, new HttpClientHandler())));
 		services.AddSingleton<ClientFactory>(ClientFactory.Create(BinderConfiguration.Create(
 			marshallerFactories: CreateMarshallerFactories(assembliesToScanForDataContracts),
 			binder: new ProtoBufServiceBinder())));


### PR DESCRIPTION
Added an optional parameter to provide custom factory method for the **GrpcWebHandler**.

In my case I needed to provide custom **HttpMessageHandler** to the **GrpcWebHandler**.

https://learn.microsoft.com/en-us/dotnet/maui/data-cloud/local-web-services?view=net-maui-9.0#bypass-the-certificate-security-check
