### PR TITLE
[HxButton] To add TooltipContainer parameter to HxButton to allow rendering tooltip to a specific place

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor
@@ -3,6 +3,7 @@
 <HxTooltip @ref="_tooltipComponent"
            Text="@Tooltip"
            Placement="@TooltipPlacement"
+           Container="@TooltipContainer"
            CssClass="@TooltipCssClass"
            WrapperCssClass="@GetTooltipWrapperCssClass()">
     <button @ref="buttonElementReference"

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor.cs
@@ -136,6 +136,11 @@ public partial class HxButton : ComponentBase, ICascadeEnabledComponent
 	[Parameter] public string TooltipCssClass { get; set; }
 
 	/// <summary>
+	/// Appends the tooltip to a specific element. Default is <c>body</c>.
+	/// </summary>
+	[Parameter] public string TooltipContainer { get; set; }
+
+	/// <summary>
 	/// Custom CSS class to render with the tooltip <c>span</c> wrapper of the <c>&lt;button /&gt;</c>.<br />
 	/// If set, the <c>span</c> wrapper will be rendered no matter whether the <see cref="Tooltip"/> text is set or not.
 	/// </summary>

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -414,6 +414,11 @@
             Custom CSS class to render with the tooltip.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.TooltipContainer">
+            <summary>
+            Appends the tooltip to a specific element. Default is <c>body</c>.
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.TooltipWrapperCssClass">
             <summary>
             Custom CSS class to render with the tooltip <c>span</c> wrapper of the <c>&lt;button /&gt;</c>.<br />

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxButtonTests/HxButton_TooltipOffcanvasOverlay_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxButtonTests/HxButton_TooltipOffcanvasOverlay_Test.razor
@@ -1,0 +1,25 @@
+@page "/HxButton_TooltipOffcanvasOverlay_Test"
+@rendermode InteractiveAuto
+
+<div id="123" style="isolation: isolate;">
+	<HxButton Text="Show offcanvas" Tooltip="Show offcanvas" TooltipContainer="#123" OnClick="HandleShow" />
+</div>
+<HxOffcanvas @ref="offcanvasComponent" Title="Offcanvas title">
+	<BodyTemplate>
+		<p>Some content for the offcanvas.</p>
+	</BodyTemplate>
+</HxOffcanvas>
+
+@code {
+	private HxOffcanvas offcanvasComponent;
+
+	private async Task HandleShow()
+	{
+		await offcanvasComponent.ShowAsync();
+	}
+
+	private async Task HandleHide()
+	{
+		await offcanvasComponent.HideAsync();
+	}
+}

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxButtonTests/HxButton_TooltipOffcanvasOverlay_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxButtonTests/HxButton_TooltipOffcanvasOverlay_Test.razor
@@ -1,4 +1,4 @@
-@page "/HxButton_TooltipOffcanvasOverlay_Test"
+@page "/HxButton_TooltipOffcanvasOverlay"
 @rendermode InteractiveAuto
 
 <div id="123" style="isolation: isolate;">


### PR DESCRIPTION
This PR tries to solve an issue where if you have a HxButton triggering a HxOffcanvas or HxModal over it, the tooltip gets stuck over all content, specifically on touch devices.
As I did not find any built in mechanism in Bootstrap, I am adding the TooltipContainer parameter to the HxButton that together with isolation isolate helps to manually deal with such a cases.

Before:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/1debea26-3ce5-42af-a5f2-50e064a74d9c" />

After:
<img width="483" alt="image" src="https://github.com/user-attachments/assets/e1101d94-6e4b-4c2d-a77a-26541c5a88c0" />
