### PR TITLE
[HxGrid] removal of CTS disposal + tests

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Cancellation_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Cancellation_Tests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Havit.Blazor.Components.Web.Bootstrap.Tests.Grids;
+
+[TestClass]
+public class HxGrid_Cancellation_Tests : BunitTestBase
+{
+	[TestMethod]
+	public async Task HxGrid_Cancellation_ShouldRequestCancellationWhenDisposed()
+	{
+		// Arrange
+		var items = Enumerable.Range(1, 100).Select(i => new { Id = i, Name = $"Item {i}" }).ToList();
+		object selectedItem = items[7];
+
+		var dataProviderTCS = new TaskCompletionSource<bool>();
+		var disposedTCS = new TaskCompletionSource();
+
+		GridDataProviderDelegate<object> dataProvider = async (GridDataProviderRequest<object> request) =>
+		{
+			try
+			{
+				await disposedTCS.Task; // wait for the component to be disposed
+				dataProviderTCS.SetResult(request.CancellationToken.IsCancellationRequested);
+				return request.ApplyTo(items);
+			}
+			catch (Exception ex)
+			{
+				// just to propagate eventual exception to the test
+				dataProviderTCS.SetException(ex);
+				throw;
+			}
+		};
+
+		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+			.Add(p => p.DataProvider, dataProvider));
+
+		// Act
+		DisposeComponents();
+		disposedTCS.SetResult(); // signal that the component is disposed
+		var wasCancellationRequested = await dataProviderTCS.Task;
+
+		// Assert
+		Assert.IsTrue(wasCancellationRequested);
+	}
+
+	// When we dispose CancellationTokenSource in HxGrid, the CancellationToken originated from it throws ObjectDisposedException in some scenarios.
+	// QuickGrid, FluentUI-DataGrid and such reference implementations do not dispose the CancellationTokenSource to avoid this.
+	// We should not dispose the CancellationTokenSource in HxGrid either.
+	// https://stackoverflow.com/questions/6960520/when-to-dispose-cancellationtokensource#:~:text=One%20more%20comment%20by%20Stephen,it%27s%20used%20with%20a%20timeout
+	// http://web.archive.org/web/20160203062224/http://blogs.msdn.com/b/pfxteam/archive/2012/03/25/10287435.aspx (see Steve Toube's comments bellow)
+	[TestMethod]
+	public async Task HxGrid_Cancellation_CancellationTokenUsageInDataProviderShouldNotThrowObjectDisposedExceptionWhenHxGridGetsDisposed()
+	{
+		// Arrange
+		var items = Enumerable.Range(1, 100).Select(i => new { Id = i, Name = $"Item {i}" }).ToList();
+		object selectedItem = items[7];
+
+		var dataProviderTCS = new TaskCompletionSource<bool>();
+		var disposedTCS = new TaskCompletionSource();
+
+		GridDataProviderDelegate<object> dataProvider = async (GridDataProviderRequest<object> request) =>
+		{
+			try
+			{
+				await disposedTCS.Task; // wait for the component to be disposed
+
+				// simulate more sophisticated CancellationToken access (e.g. HttpClient)
+				_ = request.CancellationToken.WaitHandle; // throws ObjectDisposedException if the underlying CancellationTokenSource is disposed
+
+				dataProviderTCS.SetResult(request.CancellationToken.IsCancellationRequested);
+				return request.ApplyTo(items);
+			}
+			catch (Exception ex)
+			{
+				dataProviderTCS.SetException(ex);
+				throw;
+			}
+		};
+
+		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+			.Add(p => p.DataProvider, dataProvider));
+
+		// Act
+		DisposeComponents();
+		disposedTCS.SetResult(); // signal that the component is disposed
+		var wasCancellationRequested = await dataProviderTCS.Task;
+
+		// Assert
+		// the main assertion is that no ObjectDisposedException was thrown
+		Assert.IsTrue(wasCancellationRequested);
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -727,7 +727,7 @@ public partial class HxGrid<TItem> : ComponentBase, IDisposable
 		// TODO Consider CancelAsync method for net8.0+
 		_paginationRefreshDataCancellationTokenSource?.Cancel();
 #pragma warning restore VSTHRD103 // Call async methods when in an async method
-		_paginationRefreshDataCancellationTokenSource?.Dispose();
+		// do not dispose the CTS here, there might be still some tasks running and they might throw ObjectDisposedException when using the CancellationToken
 		_paginationRefreshDataCancellationTokenSource = new CancellationTokenSource();
 		CancellationToken cancellationToken = _paginationRefreshDataCancellationTokenSource.Token;
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -1048,7 +1048,7 @@ public partial class HxGrid<TItem> : ComponentBase, IDisposable
 		if (disposing)
 		{
 			_paginationRefreshDataCancellationTokenSource?.Cancel();
-			_paginationRefreshDataCancellationTokenSource?.Dispose();
+			// do not dispose the CTS here, there might be still some tasks running and they might throw ObjectDisposedException when using the CancellationToken
 			_paginationRefreshDataCancellationTokenSource = null;
 
 			_dataProviderInProgressDelayTimer?.Dispose();


### PR DESCRIPTION
@jirikanda Please review. If you're good with the change, I'll go ahead and update a few other components that currently dispose the CTS (`HxAutosuggest`, `HxSearchBox`, `HxInputTags`, etc.).

Also, we could try setting `_paginationRefreshDataCancellationTokenSource` to `null` once the data load operation finishes (both QuickGrid and FluentUI-DataGrid do this so the GC can collect the CTS ASAP), though it probably won't make much of a difference.

Reference implementations:
* https://github.com/dotnet/aspnetcore/blob/0508333c3452c8064e8d1092de9de29ad3b63bf5/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs#L150
* https://github.com/microsoft/fluentui-blazor/blob/54f2645210d9c6fedf57b3afe6c849be407f24ba/src/Core/Components/DataGrid/FluentDataGrid.razor.cs#L369