### PR TITLE
[HxInputDate] [HxInputDateRange] Changing value causes two calls of EditContext.OnFieldChanged #787

### DIFF
--- a/BlazorAppTest/Pages/HxInputDate_Issue787_Test.razor
+++ b/BlazorAppTest/Pages/HxInputDate_Issue787_Test.razor
@@ -4,8 +4,8 @@
 <h1>HxInputDate[Range]</h1>
 
 <EditForm EditContext="editContext">
-	<HxInputDate CssClass="col-3" Label="Date" @bind-Value="model.BirthDate" />
-	<HxInputDateRange CssClass="col-3" Label="DateRange" @bind-Value="model.DateRange" />
+    <HxInputDate CssClass="col-3" Label="Date" @bind-Value="model.BirthDate" />
+    <HxInputDateRange CssClass="col-3" Label="DateRange" @bind-Value="model.DateRange" />
 </EditForm>
 
 <p>OnFieldChanged counter: @counter</p>
@@ -27,6 +27,7 @@
     private void HandleFieldChanged(object sender, EventArgs eventArgs)
     {
         counter += 1;
+        StateHasChanged();
     }
 
 	public class Person

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDate.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDate.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Text.RegularExpressions;
+using Havit.Blazor.Components.Web.Bootstrap.Forms.Internal;
 using Havit.Blazor.Components.Web.Bootstrap.Internal;
 using Microsoft.Extensions.Localization;
 
@@ -171,15 +170,15 @@ public class HxInputDate<TValue> : HxInputBase<TValue>, IInputWithPlaceholder, I
 
 		builder.OpenComponent(1, typeof(HxInputDateInternal<TValue>));
 
-		builder.AddAttribute(100, nameof(Value), Value);
-		builder.AddAttribute(101, nameof(ValueChanged), EventCallback.Factory.Create<TValue>(this, value => CurrentValue = value));
-		builder.AddAttribute(102, nameof(ValueExpression), ValueExpression);
+		builder.AddAttribute(100, nameof(HxInputDateInternal<TValue>.CurrentValue), CurrentValue);
+		builder.AddAttribute(100, nameof(HxInputDateInternal<TValue>.CurrentValueAsString), CurrentValueAsString);
+		builder.AddAttribute(101, nameof(HxInputDateInternal<TValue>.CurrentValueAsStringChanged), EventCallback.Factory.Create<string>(this, value => CurrentValueAsString = value));
 
 		builder.AddAttribute(200, nameof(HxInputDateInternal<TValue>.InputId), InputId);
 		builder.AddAttribute(201, nameof(HxInputDateInternal<TValue>.InputCssClass), GetInputCssClassToRender());
 		builder.AddAttribute(202, nameof(HxInputDateInternal<TValue>.EnabledEffective), EnabledEffective);
-		builder.AddAttribute(203, nameof(HxInputDateInternal<TValue>.ParsingErrorMessageEffective), GetParsingErrorMessage());
-		builder.AddAttribute(204, nameof(HxInputDateInternal<TValue>.Placeholder), (labelTypeEffective == Havit.Blazor.Components.Web.Bootstrap.LabelType.Floating) ? "placeholder" : Placeholder);
+		builder.AddAttribute(203, nameof(HxInputDateInternal<TValue>.Placeholder), (labelTypeEffective == Havit.Blazor.Components.Web.Bootstrap.LabelType.Floating) ? "placeholder" : Placeholder);
+		builder.AddAttribute(204, nameof(HxInputDateInternal<TValue>.NameAttributeValue), NameAttributeValue);
 
 		builder.AddAttribute(205, nameof(HxInputDateInternal<TValue>.InputSizeEffective), InputSizeEffective);
 		builder.AddAttribute(206, nameof(HxInputDateInternal<TValue>.CalendarIconEffective), CalendarIconEffective);
@@ -227,7 +226,18 @@ public class HxInputDate<TValue> : HxInputBase<TValue>, IInputWithPlaceholder, I
 
 	protected override bool TryParseValueFromString(string value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string validationErrorMessage)
 	{
-		throw new NotSupportedException();
+		if (DateHelper.TryParseDateFromString<TValue>(value, TimeProviderEffective, out var date))
+		{
+			result = date;
+			validationErrorMessage = null;
+			return true;
+		}
+		else
+		{
+			result = default;
+			validationErrorMessage = GetParsingErrorMessage();
+			return false;
+		}
 	}
 
 	/// <summary>

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDate.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDate.cs
@@ -199,7 +199,8 @@ public class HxInputDate<TValue> : HxInputBase<TValue>, IInputWithPlaceholder, I
 		builder.AddAttribute(218, nameof(HxInputDateInternal<TValue>.InputGroupCssClass), InputGroupCssClass);
 		builder.AddAttribute(219, nameof(HxInputDateInternal<TValue>.CalendarDisplayMonth), CalendarDisplayMonth);
 
-		builder.AddMultipleAttributes(300, AdditionalAttributes);
+		builder.AddAttribute(300, nameof(HxInputDateInternal<TValue>.AdditionalAttributes), AdditionalAttributes);
+
 		builder.AddComponentReferenceCapture(301, (__value) => _hxInputDateInternalComponent = (HxInputDateInternal<TValue>)__value);
 
 		builder.CloseComponent();

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDateRange.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputDateRange.cs
@@ -157,9 +157,11 @@ public class HxInputDateRange : HxInputBase<DateTimeRange>, IInputWithSize
 	{
 		builder.OpenComponent(1, typeof(HxInputDateRangeInternal));
 
-		builder.AddAttribute(100, nameof(Value), Value);
-		builder.AddAttribute(101, nameof(ValueChanged), EventCallback.Factory.Create<DateTimeRange>(this, value => CurrentValue = value));
-		builder.AddAttribute(102, nameof(ValueExpression), ValueExpression);
+		builder.AddAttribute(100, nameof(HxInputDateRangeInternal.CurrentValue), Value);
+		builder.AddAttribute(101, nameof(HxInputDateRangeInternal.CurrentValueChanged), EventCallback.Factory.Create<DateTimeRange>(this, value => CurrentValue = value));
+
+		builder.AddAttribute(110, nameof(HxInputDateRangeInternal.EditContext), EditContext);
+		builder.AddAttribute(111, nameof(HxInputDateRangeInternal.FieldIdentifier), FieldIdentifier);
 
 		builder.AddAttribute(200, nameof(HxInputDateRangeInternal.FromInputId), InputId);
 		builder.AddAttribute(201, nameof(HxInputDateRangeInternal.InputCssClass), GetInputCssClassToRender());

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor
@@ -1,84 +1,80 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap.Internal
 @using Havit.Blazor.Components.Web.Bootstrap.Forms.Internal
 @typeparam TValue
-@inherits Microsoft.AspNetCore.Components.Forms.InputBase<TValue>
 
-@if (FieldIdentifier.Model != null)
-{
-	<div class="@CssClassHelper.Combine(
-		            "hx-input-date-wrapper",
-		            ((IInputWithSize)this).GetInputGroupSizeCssClass(),
-		            InputSizeEffective.AsInputGroupCssClass(),
-					InputGroupCssClass,
-					HasInputGroups ? "input-group" : null,
-					HasInputGroupEnd ? "input-group-end" : null,
-					HasInputGroupStart ? "input-group-start" : null,
-		            (CalendarIconEffective is not null) ? "hx-input-date-has-calendar-icon" : null)">
-		@if (InputGroupStartText is not null)
+<div class="@CssClassHelper.Combine(
+		        "hx-input-date-wrapper",
+		        ((IInputWithSize)this).GetInputGroupSizeCssClass(),
+		        InputSizeEffective.AsInputGroupCssClass(),
+				InputGroupCssClass,
+				HasInputGroups ? "input-group" : null,
+				HasInputGroupEnd ? "input-group-end" : null,
+				HasInputGroupStart ? "input-group-start" : null,
+		        (CalendarIconEffective is not null) ? "hx-input-date-has-calendar-icon" : null)">
+	@if (InputGroupStartText is not null)
+	{
+		<span class="input-group-text">@InputGroupStartText</span>
+	}
+
+	@InputGroupStartTemplate
+	<HxDropdown CssClass="@CssClassHelper.Combine(
+					    "hx-input-date",
+					    (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null)"
+				AutoClose="DropdownAutoClose.Outside">
+
+
+		<HxDropdownToggleElement @ref="_hxDropdownToggleElement"
+									ElementName="input"
+									CssClass="@CssClassHelper.Combine(InputCssClass, ((IInputWithSize)this).GetInputSizeCssClass())"
+									type="text"
+									Caret="false"
+									id="@InputId"
+									name="@GetNameAttributeValue()"
+									Value="@CurrentValueAsString"
+									ValueChanged="HandleCurrentValueAsStringChanged"
+									placeholder="@Placeholder"
+									disabled="@(!EnabledEffective)"
+									onfocus="this.select();"
+									inputmode="none"
+									@attributes="AdditionalAttributes" />
+
+		@if (LabelTypeEffective == LabelType.Floating)
 		{
-			<span class="input-group-text">@InputGroupStartText</span>
+			<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
 		}
 
-		@InputGroupStartTemplate
-		<HxDropdown CssClass="@CssClassHelper.Combine(
-					     "hx-input-date",
-					     (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null)"
-					AutoClose="DropdownAutoClose.Outside">
-
-
-			<HxDropdownToggleElement @ref="_hxDropdownToggleElement"
-									 ElementName="input"
-									 CssClass="@CssClassHelper.Combine(InputCssClass, ((IInputWithSize)this).GetInputSizeCssClass())"
-									 type="text"
-									 Caret="false"
-									 id="@InputId"
-									 name="@GetNameAttributeValue()"
-									 Value="@CurrentValueAsString"
-									 ValueChanged="HandleValueChanged"
-									 placeholder="@Placeholder"
-									 disabled="@(!EnabledEffective)"
-									 onfocus="this.select();"
-									 inputmode="none"
-									 @attributes="AdditionalAttributes" />
-
-			@if (LabelTypeEffective == LabelType.Floating)
+		<HxDropdownContent CssClass="hx-input-date-dropdown-menu">
+			@if (EnabledEffective)
 			{
-				<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
-			}
-
-			<HxDropdownContent CssClass="hx-input-date-dropdown-menu">
-				@if (EnabledEffective)
-				{
-					<div class="hx-input-date-calendar">
-						<HxCalendar Value="@DateHelper.GetDateTimeFromValue(Value)" ValueChanged="HandleCalendarValueChangedAsync" MinDate="@MinDateEffective" MaxDate="@MaxDateEffective" DateCustomizationProvider="GetCalendarDateCustomization" KeyboardNavigation="false" DisplayMonth="@GetCalendarDisplayMonthEffective" TimeProvider="TimeProviderEffective" />
-					</div>
-					<div class="hx-input-date-dropdown-buttons">
-						@if (ShowClearButtonEffective)
+				<div class="hx-input-date-calendar">
+					<HxCalendar Value="@DateHelper.GetDateTimeFromValue(CurrentValue)" ValueChanged="HandleCalendarValueChangedAsync" MinDate="@MinDateEffective" MaxDate="@MaxDateEffective" DateCustomizationProvider="GetCalendarDateCustomization" KeyboardNavigation="false" DisplayMonth="@GetCalendarDisplayMonthEffective" TimeProvider="TimeProviderEffective" />
+				</div>
+				<div class="hx-input-date-dropdown-buttons">
+					@if (ShowClearButtonEffective)
+					{
+						<HxButton Text="@StringLocalizerFactory.GetLocalizedValue("Clear", typeof(HxInputDate))" Color="ThemeColor.Link" Size="ButtonSize.Small" OnClick="HandleClearClickAsync" tabindex="-1" Enabled="this.EnabledEffective" />
+					}
+					@if (RenderPredefinedDates)
+					{
+						foreach (var item in PredefinedDatesEffective)
 						{
-							<HxButton Text="@StringLocalizerFactory.GetLocalizedValue("Clear", typeof(HxInputDate))" Color="ThemeColor.Link" Size="ButtonSize.Small" OnClick="HandleClearClickAsync" tabindex="-1" Enabled="this.EnabledEffective" />
+							<HxButton @key="@item" Text="@StringLocalizerFactory.GetLocalizedValue(item.Label, item.ResourceType)" Color="ThemeColor.Link" Size="ButtonSize.Small" OnClick="() => HandleCustomDateClick(item.GetDateEffective(TimeProviderEffective))" tabindex="-1" Enabled="this.EnabledEffective" />
 						}
-						@if (RenderPredefinedDates)
-						{
-							foreach (var item in PredefinedDatesEffective)
-							{
-								<HxButton @key="@item" Text="@StringLocalizerFactory.GetLocalizedValue(item.Label, item.ResourceType)" Color="ThemeColor.Link" Size="ButtonSize.Small" OnClick="() => HandleCustomDateClick(item.GetDateEffective(TimeProviderEffective))" tabindex="-1" Enabled="this.EnabledEffective" />
-							}
-						}
-					</div>
-				}
-			</HxDropdownContent>
-			@if (HasCalendarIcon)
-			{
-				<div @ref="_iconWrapperElement" class="hx-input-date-icon">
-					<HxIcon Icon="CalendarIconEffective" />
+					}
 				</div>
 			}
-		</HxDropdown>
-		@InputGroupEndTemplate
-
-		@if (InputGroupEndText is not null)
+		</HxDropdownContent>
+		@if (HasCalendarIcon)
 		{
-			<span class="input-group-text">@InputGroupEndText</span>
+			<div @ref="_iconWrapperElement" class="hx-input-date-icon">
+				<HxIcon Icon="CalendarIconEffective" />
+			</div>
 		}
-	</div>
-}
+	</HxDropdown>
+	@InputGroupEndTemplate
+
+	@if (InputGroupEndText is not null)
+	{
+		<span class="input-group-text">@InputGroupEndText</span>
+	}
+</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
@@ -69,7 +69,7 @@ public partial class HxInputDateInternal<TValue> : ComponentBase, IAsyncDisposab
 
 	[Parameter] public string NameAttributeValue { get; set; }
 
-	[Parameter(CaptureUnmatchedValues = true)] public IReadOnlyDictionary<string, object> AdditionalAttributes { get; set; }
+	[Parameter] public IReadOnlyDictionary<string, object> AdditionalAttributes { get; set; }
 
 	[Inject] protected IStringLocalizerFactory StringLocalizerFactory { get; set; }
 	[Inject] protected IJSRuntime JSRuntime { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
@@ -90,7 +90,6 @@ public partial class HxInputDateInternal<TValue> : ComponentBase, IAsyncDisposab
 
 	private async Task HandleCurrentValueAsStringChanged(string newInputValue)
 	{
-		//CurrentValueAsString = newInputValue;
 		await CurrentValueAsStringChanged.InvokeAsync(newInputValue);
 	}
 
@@ -186,5 +185,7 @@ public partial class HxInputDateInternal<TValue> : ComponentBase, IAsyncDisposab
 		{
 			// NOOP
 		}
+
+		//Dispose(false);
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.cs
@@ -5,19 +5,23 @@ using Microsoft.JSInterop;
 
 namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
 
-public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisposable, IInputWithSize, IInputWithLabelType
+public partial class HxInputDateInternal<TValue> : ComponentBase, IAsyncDisposable, IInputWithSize, IInputWithLabelType
 {
 	[Parameter] public string InputId { get; set; }
 
 	[Parameter] public string InputCssClass { get; set; }
+
+	[Parameter] public TValue CurrentValue { get; set; }
+
+	[Parameter] public string CurrentValueAsString { get; set; }
+
+	[Parameter] public EventCallback<string> CurrentValueAsStringChanged { get; set; }
 
 	[Parameter] public bool EnabledEffective { get; set; } = true;
 
 	[Parameter] public bool ShowPredefinedDatesEffective { get; set; }
 
 	[Parameter] public IEnumerable<InputDatePredefinedDatesItem> PredefinedDatesEffective { get; set; }
-
-	[Parameter] public string ParsingErrorMessageEffective { get; set; }
 
 	[Parameter] public string Placeholder { get; set; }
 
@@ -63,6 +67,10 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 
 	[Parameter] public DateTime CalendarDisplayMonth { get; set; }
 
+	[Parameter] public string NameAttributeValue { get; set; }
+
+	[Parameter(CaptureUnmatchedValues = true)] public IReadOnlyDictionary<string, object> AdditionalAttributes { get; set; }
+
 	[Inject] protected IStringLocalizerFactory StringLocalizerFactory { get; set; }
 	[Inject] protected IJSRuntime JSRuntime { get; set; }
 
@@ -80,27 +88,10 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 	private IJSObjectReference _jsModule;
 	private bool _firstRenderCompleted;
 
-	protected override string FormatValueAsString(TValue value) => HxInputDate<TValue>.FormatValue(value);
-
-	private void HandleValueChanged(string newInputValue)
+	private async Task HandleCurrentValueAsStringChanged(string newInputValue)
 	{
-		CurrentValueAsString = newInputValue;
-	}
-
-	protected override bool TryParseValueFromString(string value, out TValue result, out string validationErrorMessage)
-	{
-		if (DateHelper.TryParseDateFromString<TValue>(value, TimeProviderEffective, out var date))
-		{
-			result = date;
-			validationErrorMessage = null;
-			return true;
-		}
-		else
-		{
-			result = default;
-			validationErrorMessage = ParsingErrorMessageEffective;
-			return false;
-		}
+		//CurrentValueAsString = newInputValue;
+		await CurrentValueAsStringChanged.InvokeAsync(newInputValue);
 	}
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -129,7 +120,7 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 
 	private async Task HandleClearClickAsync()
 	{
-		SetCurrentDate(null);
+		await SetCurrentDateAsync(null);
 		await CloseDropdownAsync();
 	}
 
@@ -141,19 +132,20 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 
 	private async Task HandleCalendarValueChangedAsync(DateTime? date)
 	{
-		SetCurrentDate(date);
+		await SetCurrentDateAsync(date);
 		await CloseDropdownAsync();
 	}
 
 	protected async Task HandleCustomDateClick(DateTime value)
 	{
-		SetCurrentDate(value);
+		await SetCurrentDateAsync(value);
 		await CloseDropdownAsync();
 	}
 
-	protected void SetCurrentDate(DateTime? date)
+	protected async Task SetCurrentDateAsync(DateTime? date)
 	{
-		CurrentValueAsString = date?.ToShortDateString(); // we need to trigger the logic in CurrentValueAsString setter
+		//CurrentValueAsString = date?.ToShortDateString();
+		await HandleCurrentValueAsStringChanged(CurrentValueAsString); // we need to trigger the logic in CurrentValueAsString setter
 	}
 
 	private string GetNameAttributeValue()
@@ -194,7 +186,5 @@ public partial class HxInputDateInternal<TValue> : InputBase<TValue>, IAsyncDisp
 		{
 			// NOOP
 		}
-
-		Dispose(false);
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateRangeInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateRangeInternal.razor
@@ -1,5 +1,4 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap.Internal
-@inherits Microsoft.AspNetCore.Components.Forms.InputBase<DateTimeRange>
 
 @if ((FieldIdentifier.Model != null) && (_fromFieldIdentifier.Model != null) && (_toFieldIdentifier.Model != null))
 {
@@ -18,8 +17,8 @@
                                                                         fromValid ? null : HxInputBase<object>.InvalidCssClass,
                                                                         "rounded-end-0")"
 										 Caret="false"
-										 Value="@(_fromPreviousParsingAttemptFailed ? _incomingFromValueBeforeParsing : FormatDate(Value.StartDate))"
-										 ValueChanged="HandleFromChanged"
+										 Value="@(_fromPreviousParsingAttemptFailed ? _incomingFromValueBeforeParsing : FormatDate(CurrentValue.StartDate))"
+										 ValueChanged="HandleFromChangedAsync"
 										 placeholder="@(FromPlaceholderEffective ?? StringLocalizerFactory.GetLocalizedValue("From", typeof(HxInputDateRange)))"
 										 disabled="@(!EnabledEffective)"
 										 onfocus="this.select();"
@@ -30,7 +29,7 @@
 					@if (EnabledEffective)
 					{
 						<div class="hx-input-date-range-calendar">
-							<HxCalendar Value="@Value.StartDate" ValueChanged="HandleFromCalendarValueChangedAsync" MinDate="@MinDateEffective" MaxDate="@MaxDateEffective" DateCustomizationProvider="GetCalendarDateCustomizationFrom" KeyboardNavigation="false" DisplayMonth="@GetFromCalendarDisplayMonthEffective" TimeProvider="TimeProviderEffective" />
+                                    <HxCalendar Value="@CurrentValue.StartDate" ValueChanged="HandleFromCalendarValueChangedAsync" MinDate="@MinDateEffective" MaxDate="@MaxDateEffective" DateCustomizationProvider="GetCalendarDateCustomizationFrom" KeyboardNavigation="false" DisplayMonth="@GetFromCalendarDisplayMonthEffective" TimeProvider="TimeProviderEffective" />
 						</div>
 						<div class="hx-input-date-range-buttons">
 							@if (ShowClearButtonEffective)
@@ -75,8 +74,8 @@
                                                                         ((IInputWithSize)this).GetInputSizeCssClass(),
                                                                         toValid ? null : HxInputBase<object>.InvalidCssClass,
                                                                         "rounded-start-0")"
-										 Value="@(_toPreviousParsingAttemptFailed ? _incomingToValueBeforeParsing : FormatDate(Value.EndDate))"
-										 ValueChanged="HandleToChanged"
+                                             Value="@(_toPreviousParsingAttemptFailed ? _incomingToValueBeforeParsing : FormatDate(CurrentValue.EndDate))"
+										 ValueChanged="HandleToChangedAsync"
 										 placeholder="@(ToPlaceholderEffective ?? StringLocalizerFactory.GetLocalizedValue("To", typeof(HxInputDateRange)))"
 										 disabled="@(!EnabledEffective)"
 										 onfocus="this.select()"
@@ -87,7 +86,7 @@
 					@if (EnabledEffective)
 					{
 						<div class="hx-input-date-range-calendar">
-							<HxCalendar Value="@Value.EndDate" ValueChanged="HandleToCalendarValueChanged" MinDate="@MinDateEffective" MaxDate="@MaxDateEffective" DateCustomizationProvider="GetCalendarDateCustomizationTo" KeyboardNavigation="false" DisplayMonth="@GetToCalendarDisplayMonthEffective" TimeProvider="TimeProviderEffective" />
+							<HxCalendar Value="@CurrentValue.EndDate" ValueChanged="HandleToCalendarValueChanged" MinDate="@MinDateEffective" MaxDate="@MaxDateEffective" DateCustomizationProvider="GetCalendarDateCustomizationTo" KeyboardNavigation="false" DisplayMonth="@GetToCalendarDisplayMonthEffective" TimeProvider="TimeProviderEffective" />
 						</div>
 						<div class="hx-input-date-range-buttons">
 							@if (ShowClearButtonEffective)


### PR DESCRIPTION
HxInputDate
- HxInputDateInternal now forwards value handling to HxInputDateInternal via CurrentValueAsStringChanged.
- an enclosing `if (FieldIdentifier.Model != null)` in the HxInputDateInternal.razor.cs was removed

HxInputDateRange
- handling from/to date parts stays in HxInputDateRangeInternal
- only (the whole range) value changes are propagated from HxInputDateRangeInternal to HxInputDateRange
- HxInputDateRangeInternal still calls `EditContext.NotifyFieldChanged(_fromFieldIdentifier/_toFieldIdentifier)` (functionality not changed), this means any valid change fires NotifyFieldChanged twice (_fromFieldIdentifier/_toFieldIdentifier and the "whole" value)
- order of actions in methods calling CurrentValueChanges is perserved but can be subject of futher discussion (ie. should `HandleToClearClickAsync` method call first `CurrentValueChanged` or `CloseDropdownAsync`?)

HxInputDateInternal and HxInputDateRangeInternal does not implement IDisposable anymore (but still implements IAsyncDisposable).
