### PR TITLE
[HxInputDate] - When selected date year is out of the MinDate-MaxDate, year is not displayed

### DIFF
--- a/BlazorAppTest/Pages/HxCalendar_Issue794_Test.razor
+++ b/BlazorAppTest/Pages/HxCalendar_Issue794_Test.razor
@@ -1,0 +1,26 @@
+﻿@page "/HxCalendar_Issue794_Test"
+
+<h1>HxCalendar</h1>
+
+<HxCalendar @bind-Value="@currentDate" MinDate="minDate" MaxDate="maxDate" />
+
+<p>Selected date: @currentDate</p>
+
+<HxButton Text="Set date to 2021" Color="ThemeColor.Secondary" OnClick="HandleSetYear2021Click" />
+<HxButton Text="Set null" Color="ThemeColor.Secondary" OnClick="HandleSetNullClick" />
+
+@code {
+    DateTime minDate = new DateTime(2024, 3, 1);
+    DateTime maxDate = new DateTime(2024, 6, 30);
+    DateTime? currentDate = null;// new DateTime(2021, 10, 6);
+
+    private void HandleSetYear2021Click()
+    {
+        currentDate = new DateTime(2021, 10, 6);
+    }
+
+    private void HandleSetNullClick()
+    {
+        currentDate = null;
+    }
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor.cs
@@ -150,6 +150,7 @@ public partial class HxCalendar
 		bool lastKnownValueChanged = _lastKnownValue != Value;
 		_lastKnownValue = Value;
 
+		// whenever the value is changed from outside, we set the display month to the value month
 		if (DisplayMonth == default || lastKnownValueChanged)
 		{
 			if (Value != null)
@@ -160,10 +161,6 @@ public partial class HxCalendar
 			{
 				await SetDisplayMonthAsync(TimeProviderEffective.GetLocalNow().Date, limitDisplayMonthByMinMaxDateEffective: true);
 			}
-		}
-		else if ((Value != null) && lastKnownValueChanged && ((DisplayMonth.Year != Value.Value.Year) || (DisplayMonth.Month != Value.Value.Month)))
-		{
-			await SetDisplayMonthAsync(Value.Value);
 		}
 
 		UpdateRenderData();
@@ -192,7 +189,10 @@ public partial class HxCalendar
 		int minYear = minDateEffective.Year;
 		int maxYear = maxDateEffective.Year;
 
-		_renderData.Years = Enumerable.Range(minYear, maxYear - minYear + 1).Union([DisplayMonth.Year]).Reverse().ToList();
+		_renderData.Years = Enumerable.Range(minYear, maxYear - minYear + 1)
+			.Union([DisplayMonth.Year])
+			.OrderByDescending(year => year)
+			.ToList();
 
 		for (int i = 0; i < 7; i++)
 		{
@@ -274,8 +274,11 @@ public partial class HxCalendar
 			newDisplayMonth = new[] { newDisplayMonth, new DateTime(MaxDateEffective.Year, MaxDateEffective.Month, 1) }.Min();
 		}
 
-		DisplayMonth = newDisplayMonth;
-		await InvokeDisplayMonthChangedAsync(newDisplayMonth);
+		if (DisplayMonth != newDisplayMonth)
+		{
+			DisplayMonth = newDisplayMonth;
+			await InvokeDisplayMonthChangedAsync(newDisplayMonth);
+		}
 	}
 
 	private async Task HandlePreviousMonthClickAsync()

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxCalendar/HxCalendar_Issue794_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxCalendar/HxCalendar_Issue794_Test.razor
@@ -1,4 +1,5 @@
-﻿@page "/HxCalendar_Issue794_Test"
+﻿@page "/HxCalendar_Issue794"
+@rendermode InteractiveServer
 
 <h1>HxCalendar</h1>
 
@@ -7,6 +8,7 @@
 <p>Selected date: @currentDate</p>
 
 <HxButton Text="Set date to 2021" Color="ThemeColor.Secondary" OnClick="HandleSetYear2021Click" />
+<HxButton Text="Set date to 2026" Color="ThemeColor.Secondary" OnClick="HandleSetYear2026Click" />
 <HxButton Text="Set null" Color="ThemeColor.Secondary" OnClick="HandleSetNullClick" />
 
 @code {
@@ -18,6 +20,12 @@
     {
         currentDate = new DateTime(2021, 10, 6);
     }
+
+    private void HandleSetYear2026Click()
+    {
+        currentDate = new DateTime(2026, 2, 25);
+    }
+
 
     private void HandleSetNullClick()
     {


### PR DESCRIPTION
* DisplayMonth is re-evaluated everytime Value is changed by the parameter ("from outside").
* When Value is set (not null), DisplayMonth is not limited by Min/MaxDateEffective anymore.
* When Value is null, DisplayMonth is set to current month limited by Min/MaxDateEffective (not changed)
* Year selection contains DisplayMonth.Year even it is out of the Min/MaxDateEffective range.
* Move to previous/next also works in the direction to the Min/MaxDateEffective.

https://github.com/user-attachments/assets/a5a70830-67d6-4452-a0fe-ae19ad24f63b

