### PR TITLE
#1080 Fix modal custom icon

### DIFF
--- a/BlazorAppTest/Pages/HxModalTest.razor
+++ b/BlazorAppTest/Pages/HxModalTest.razor
@@ -14,7 +14,7 @@
 	</FooterTemplate>
 </HxModal>
 
-<HxModal @ref="mySecondModal">
+<HxModal @ref="mySecondModal" Title="A very balanced close icon" CloseButtonIcon="BootstrapIcon.YinYang">
 	<BodyTemplate>
 		Second
 	</BodyTemplate>

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
@@ -27,7 +27,7 @@
 							}
 							else
 							{
-								<button type="button" class="btn-close btn-close-custom-icon center d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
+								<button type="button" class="btn-close btn-close-custom-icon d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
 									<HxIcon Icon="@CloseButtonIconEffective" />
 								</button>
 							}

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
@@ -27,7 +27,7 @@
 							}
 							else
 							{
-								<button type="button" class="btn-close btn-close-custom-icon d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
+								<button type="button" class="hx-modal-custom-close-btn btn-close d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
 									<HxIcon Icon="@CloseButtonIconEffective" />
 								</button>
 							}

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
@@ -27,7 +27,7 @@
 							}
 							else
 							{
-								<button type="button" class="btn-close btn-close-custom-icon center	d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
+								<button type="button" class="btn-close btn-close-custom-icon center d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
 									<HxIcon Icon="@CloseButtonIconEffective" />
 								</button>
 							}

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor
@@ -27,7 +27,9 @@
 							}
 							else
 							{
-								<div role="button" data-bs-dismiss="modal" aria-label="Close"><HxIcon Icon="CloseButtonIconEffective"/></div>
+								<button type="button" class="btn-close btn-close-custom-icon center	d-flex align-items-center" data-bs-dismiss="modal" aria-label="Close">
+									<HxIcon Icon="@CloseButtonIconEffective" />
+								</button>
 							}
 						}
 					</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
@@ -1,4 +1,4 @@
-﻿/* Remove custom bootstrap styling to perserve custom icon style */
+﻿/* Remove custom bootstrap styling to preserve custom icon style */
 .btn-close-custom-icon {
 	--bs-btn-close-bg: unset;
 	--bs-btn-close-color: unset;

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
@@ -1,4 +1,4 @@
-﻿/* Remove custom bootstrap styling to preserve custom icon style */
-.btn-close-custom-icon {
+﻿.hx-modal-custom-close-btn {
+	/* Remove custom bootstrap styling to preserve custom icon style */
 	--bs-btn-close-bg: unset;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
@@ -1,10 +1,4 @@
 ﻿/* Remove custom bootstrap styling to preserve custom icon style */
 .btn-close-custom-icon {
 	--bs-btn-close-bg: unset;
-	--bs-btn-close-color: unset;
-	--bs-btn-close-opacity: unset;
-	--bs-btn-close-hover-opacity: unset;
-	--bs-btn-close-focus-shadow: unset;
-	--bs-btn-close-focus-opacity: unset;
-	--bs-btn-close-disabled-opacity: unset;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/HxModal.razor.css
@@ -1,0 +1,10 @@
+﻿/* Remove custom bootstrap styling to perserve custom icon style */
+.btn-close-custom-icon {
+	--bs-btn-close-bg: unset;
+	--bs-btn-close-color: unset;
+	--bs-btn-close-opacity: unset;
+	--bs-btn-close-hover-opacity: unset;
+	--bs-btn-close-focus-shadow: unset;
+	--bs-btn-close-focus-opacity: unset;
+	--bs-btn-close-disabled-opacity: unset;
+}


### PR DESCRIPTION
Solves #1080 

Bootstrap applies a lot of custom styling along with layout, so it is kinda _hacky_ to get rid of it. (Also because the [close button](https://getbootstrap.com/docs/5.0/components/close-button) is a custom concept, different from Bootstrap Icons.)

Perhaps the best solution, due to bootstraps decision on this, is to change the [$btn-close-bg variable](https://getbootstrap.com/docs/5.0/components/close-button/#variables) or to use a custom header and avoid reimplementing the close button (as in the current API & this PR)

