### PR TITLE
HxCalendar, DateHelper - Culture & UICulture consolidation

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor.cs
@@ -119,7 +119,9 @@ public partial class HxCalendar
 
 	protected TimeProvider TimeProviderEffective => TimeProvider ?? GetSettings()?.TimeProvider ?? GetDefaults()?.TimeProvider ?? TimeProviderFromServices;
 
-	private CultureInfo Culture => CultureInfo.CurrentUICulture;
+	private CultureInfo UICulture => CultureInfo.CurrentUICulture;
+	private CultureInfo Culture => CultureInfo.CurrentCulture;
+
 	private DayOfWeek FirstDayOfWeek => Culture.DateTimeFormat.FirstDayOfWeek;
 	protected DateTime DisplayMonthFirstDay => new DateTime(DisplayMonth.Year, DisplayMonth.Month, 1);
 	protected DateTime FirstDayToDisplay
@@ -181,7 +183,7 @@ public partial class HxCalendar
 		_renderData = new RenderData();
 		_renderData.DaysOfWeek = new List<string>(7);
 
-		string[] dayNames = Culture.DateTimeFormat.AbbreviatedDayNames;
+		string[] dayNames = UICulture.DateTimeFormat.AbbreviatedDayNames;
 		DayOfWeek firstDayOfWeek = FirstDayOfWeek;
 
 		DateTime minDateEffective = MinDateEffective;
@@ -199,7 +201,7 @@ public partial class HxCalendar
 			_renderData.DaysOfWeek.Add(dayNames[((int)firstDayOfWeek + i) % 7]);
 		}
 
-		_renderData.Months = Culture.DateTimeFormat.MonthNames.Take(12) // returns 13 items, see https://docs.microsoft.com/en-us/dotnet/api/system.globalization.datetimeformatinfo.monthnames
+		_renderData.Months = UICulture.DateTimeFormat.MonthNames.Take(12) // returns 13 items, see https://docs.microsoft.com/en-us/dotnet/api/system.globalization.datetimeformatinfo.monthnames
 			.Select((name, index) => new MonthData
 			{
 				Index = index,

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/DateHelper.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/DateHelper.cs
@@ -15,9 +15,9 @@ internal static partial class DateHelper
 		}
 
 		// expecting date format with day, month, and year components
-		int dayIndex = CultureInfo.CurrentUICulture.DateTimeFormat.ShortDatePattern.IndexOf("d");
-		int monthIndex = CultureInfo.CurrentUICulture.DateTimeFormat.ShortDatePattern.IndexOf("M");
-		int yearIndex = CultureInfo.CurrentUICulture.DateTimeFormat.ShortDatePattern.IndexOf("y");
+		int dayIndex = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.IndexOf("d");
+		int monthIndex = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.IndexOf("M");
+		int yearIndex = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.IndexOf("y");
 
 		if ((dayIndex < 0) || (monthIndex < 0) || (yearIndex < 0))
 		{


### PR DESCRIPTION
Culture is used instead of UICulture where it should be used.

DateHelper - introduced in #766.
HxCalendar - I think ve should use UICulture for week and month names but Culture for date format and first day of week.

Hopefully, Culture and UICulture (AFAIR) usually share the same value.
