### PR TITLE
[HxInputNumber] Toggle value's sign on [MINUS] key

### DIFF
--- a/BlazorAppTest/Pages/HxInputNumberTest.razor
+++ b/BlazorAppTest/Pages/HxInputNumberTest.razor
@@ -4,7 +4,11 @@
 <HxInputNumber Label="sbyte" @bind-Value="_sbyte" Hint="@_sbyte?.ToString()" />
 <HxInputNumber Label="short" @bind-Value="_short" Hint="@_short?.ToString()" />
 <HxInputNumber Label="ushort" @bind-Value="_ushort" Hint="@_ushort?.ToString()" />
-<HxInputNumber Label="int" @bind-Value="_int" Hint="@_int?.ToString()"/>
+<HxInputNumber Label="int" @bind-Value="_int" @bind-Value:after="() => _intUpdateCounter += 1">
+    <HintTemplate>
+        @_int (updated @_intUpdateCounter times)
+    </HintTemplate>
+</HxInputNumber>
 <HxInputNumber Label="uint" @bind-Value="_uint" Hint="@_uint?.ToString()" />
 <HxInputNumber Label="long" @bind-Value="_long" Hint="@_long?.ToString()" />
 <HxInputNumber Label="ulong" @bind-Value="_ulong" Hint="@_ulong?.ToString()" />
@@ -13,7 +17,11 @@
 <HxInputNumber Label="decimal" @bind-Value="_decimal" Hint="@_decimal?.ToString()" />
 
 <h6 class="mt-4">OnInput test</h6>
-<HxInputNumber Label="int" @bind-Value="_int" BindEvent="@BindEvent.OnInput" Hint="@_int?.ToString()"/>
+<HxInputNumber Label="int" @bind-Value="_int" @bind-Value:after="() => _intUpdateCounter += 1" BindEvent="@BindEvent.OnInput">
+    <HintTemplate>
+        @_int (updated @_intUpdateCounter times)
+    </HintTemplate>
+</HxInputNumber>
 <HxInputNumber Label="decimal" @bind-Value="_decimal" BindEvent="@BindEvent.OnInput" Hint="@_decimal?.ToString()" />
 
 @code {
@@ -21,7 +29,8 @@
 	private sbyte? _sbyte;
 	private short? _short;
 	private ushort? _ushort;
-	private int? _int;
+    private int? _int;
+    private int _intUpdateCounter;
 	private uint? _uint;
 	private long? _long;
 	private ulong? _ulong;

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
@@ -211,20 +211,33 @@ public class HxInputNumber<TValue> : HxInputBaseWithInputGroups<TValue>, IInputW
 		builder.AddAttribute(1003, BindEvent.ToEventName(), EventCallback.Factory.CreateBinder<string>(this, value => CurrentValueAsString = value, CurrentValueAsString));
 		builder.SetUpdatesAttributeName("value");
 
+		// When user changes value, we turn of flag "modified by code".
+		// The event handler is also called from the past and keydown event where we turn the flag on.
+		// This is a prevention of two change event calls.
+		builder.AddAttribute(1004, "oninput", "this.modifiedByCode = false;");
+
 		// Normalization of pasted value (applied only if the pasted value differs from the normalized value)
 		// - If we cancel the original paste event, Blazor does not recognize the change, so we fire change event manually.
 		// - This is kind of hack and causes the input to behave slightly differently when normalizing the value (the value is accepted immediately, not after the user leaves the input)
 		// - If this turns out to be a problem, we will have to implement the normalization in the Blazor-handled @onpaste event
-		builder.AddAttribute(1004, "onpaste", @"var clipboardValue = event.clipboardData.getData('text/plain'); var normalizedValue = clipboardValue.replace(/[^\d.,\-eE]/g, ''); if (+clipboardValue != +normalizedValue) { this.value = normalizedValue; this.dispatchEvent(new Event('change')); return false; }");
+		builder.AddAttribute(1005, "onpaste", @"var clipboardValue = event.clipboardData.getData('text/plain'); var normalizedValue = clipboardValue.replace(/[^\d.,\-eE]/g, ''); if (+clipboardValue != +normalizedValue) { this.value = normalizedValue; this.dispatchEvent(new Event('change')); return false; }");
 		builder.SetUpdatesAttributeName("value");
 
-		builder.AddEventStopPropagationAttribute(1004, "onclick", true);
+		// When the user presses '-' key, we toggle the sign of the value.
+		// We also set the modifiedByCode flag to allow fire change event in onblur event later.
+		builder.AddAttribute(1006, "onkeydown", "if (event.key === '-') { let newValue = this.value; if (this.value.startsWith('-')) { newValue = this.value.substring(1); newCursorPosition = Math.max(0, this.selectionStart - 1); } else { newValue = '-' + this.value; newCursorPosition = this.selectionStart + 1; }  if (this.value !== newValue) { let newCursorPositionEnd = newCursorPosition + (this.selectionEnd - this.selectionStart); this.value = newValue; this.setSelectionRange(newCursorPosition, newCursorPositionEnd); this.dispatchEvent(new Event('input')); this.modifiedByCode = true; return false; } }");
+		builder.SetUpdatesAttributeName("value");
+
+		// When the value is modified by code, we fire the change event.
+		builder.AddAttribute(1007, "onblur", "if (this.modifiedByCode) { this.hasBeenModified = false; this.dispatchEvent(new Event('change')); }");
+
+		builder.AddEventStopPropagationAttribute(1008, "onclick", true);
 
 		// The counting of sequence values violates all general recommendations.
 		// We want the value of HxInputNumber to be updated (re-rendered) when the user input changes, even if FormatValueAsString(Value) hasn't changed.
 		// For instance, if a value like "1.00" is displayed and a user modifies it to "1.0", FormatValueAsString(Value) won't change,
 		// and the attribute won't be re-rendered, so the user input stays at "1.0".
-		// To address this issue, we use sequence values starting from 1006. This forces Blazor to update the value anyway (due to the sequence change).
+		// To address this issue, we use sequence values starting from 1100. This forces Blazor to update the value anyway (due to the sequence change).
 		// However, we adjust the sequence only if we want to enforce the re-rendering. Otherwise, the component would update continuously.
 		checked
 		{
@@ -233,7 +246,7 @@ public class HxInputNumber<TValue> : HxInputBaseWithInputGroups<TValue>, IInputW
 				_valueSequenceOffset++;
 				forceRenderValue = false;
 			}
-			builder.AddAttribute(1006 + _valueSequenceOffset, "value", CurrentValueAsString);
+			builder.AddAttribute(1100 + _valueSequenceOffset, "value", CurrentValueAsString);
 		}
 		builder.AddElementReferenceCapture(Int32.MaxValue, elementReference => InputElement = elementReference);
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
@@ -215,7 +215,7 @@ public class HxInputNumber<TValue> : HxInputBaseWithInputGroups<TValue>, IInputW
 		// - If we cancel the original paste event, Blazor does not recognize the change, so we fire change event manually.
 		// - This is kind of hack and causes the input to behave slightly differently when normalizing the value (the value is accepted immediately, not after the user leaves the input)
 		// - If this turns out to be a problem, we will have to implement the normalization in the Blazor-handled @onpaste event
-		builder.AddAttribute(1005, "onpaste", @"var clipboardValue = event.clipboardData.getData('text/plain'); var normalizedValue = clipboardValue.replace(/[^\d.,\-eE]/g, ''); if (+clipboardValue != +normalizedValue) { this.value = normalizedValue; this.dispatchEvent(new Event('change', { bubbles: true })); return false; }");
+		builder.AddAttribute(1005, "onpaste", @"var clipboardValue = event.clipboardData.getData('text/plain'); var normalizedValue = clipboardValue.replace(/[^\d.,\-eE]/g, ''); if (+clipboardValue != +normalizedValue) { this.value = normalizedValue; this.dispatchEvent(new Event('input', { bubbles: true })); this.modifiedByCode = true; return false; }");
 		builder.SetUpdatesAttributeName("value");
 
 		// When the user presses '-' key, we toggle the sign of the value.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
@@ -225,7 +225,10 @@ public class HxInputNumber<TValue> : HxInputBaseWithInputGroups<TValue>, IInputW
 
 		// When the user presses '-' key, we toggle the sign of the value.
 		// We also set the modifiedByCode flag to allow fire change event in onblur event later.
-		builder.AddAttribute(1006, "onkeydown", "if (event.key === '-') { let newValue = this.value; if (this.value.startsWith('-')) { newValue = this.value.substring(1); newCursorPosition = Math.max(0, this.selectionStart - 1); } else { newValue = '-' + this.value; newCursorPosition = this.selectionStart + 1; }  if (this.value !== newValue) { let newCursorPositionEnd = newCursorPosition + (this.selectionEnd - this.selectionStart); this.value = newValue; this.setSelectionRange(newCursorPosition, newCursorPositionEnd); this.dispatchEvent(new Event('input')); this.modifiedByCode = true; return false; } }");
+		// Selection handling:
+		// - When everything (but non-empty) is selected before adding -, everything is selected after adding -.
+		// - When selected -12 in the value -1234, 12 must remain selected after - removal.
+		builder.AddAttribute(1006, "onkeydown", "if (event.key === '-') { let newValue = this.value; let newSelectionStart = -1; let newSelectionEnd = -1; if (this.value.startsWith('-')) { newValue = this.value.substring(1); newSelectionStart = Math.max(0, this.selectionStart - 1); newSelectionEnd = Math.max(0, this.selectionEnd - 1);  } else { newValue = '-' + this.value; newSelectionStart = (this.selectionStart == 0 && this.selectionEnd > 0 && this.selectionEnd == this.value.length) ? 0 : this.selectionStart + 1; newSelectionEnd = (this.selectionStart == 0 && this.selectionEnd > 0 && this.selectionEnd == this.value.length) ? newValue.length : this.selectionEnd + 1;}  if (this.value !== newValue) { this.value = newValue; this.setSelectionRange(newSelectionStart, newSelectionEnd); this.dispatchEvent(new Event('input')); this.modifiedByCode = true; return false; } }");
 		builder.SetUpdatesAttributeName("value");
 
 		// When the value is modified by code, we fire the change event.


### PR DESCRIPTION
Implements #1005.

The current implementation contains a difference in event behavior between pasting a value and pressing the minus key.
Pressing the minus key behaves "standardly": the key press triggers the `input` event, and the `change` event is only triggered when the input field loses focus.
In contrast, pasting a value from the clipboard triggers the `change` event immediately.