### PR TITLE
[HxIcon] aria-label not allowed, deprecated

### DIFF
--- a/Havit.Blazor.Components.Web/Icons/HxIcon.cs
+++ b/Havit.Blazor.Components.Web/Icons/HxIcon.cs
@@ -16,6 +16,7 @@ public class HxIcon : ComponentBase
 	/// <summary>
 	/// Accessibility label for screen readers. Hides the icon from screen readers if not set.
 	/// </summary>
+	[Obsolete("AriaLabel on i tag is a violation of HTML semantics and causes problems with accessiblity. This property will be removed in future versions.")]
 	[Parameter] public string AriaLabel { get; set; }
 
 	/// <summary>
@@ -40,7 +41,7 @@ public class HxIcon : ComponentBase
 		}
 		else
 		{
-			builder.AddAttribute(5, "aria-hidden", true);
+			builder.AddAttribute(5, "aria-hidden", "true");
 		}
 		builder.AddMultipleAttributes(3, AdditionalAttributes);
 		builder.CloseComponent();

--- a/Havit.Blazor.Components.Web/Icons/HxIcon.cs
+++ b/Havit.Blazor.Components.Web/Icons/HxIcon.cs
@@ -35,6 +35,7 @@ public class HxIcon : ComponentBase
 		builder.OpenComponent(1, Icon.RendererComponentType);
 		builder.AddAttribute(2, "Icon", Icon);
 		builder.AddAttribute(3, "CssClass", CssClass);
+#pragma warning disable CS0618 // use obsolete parameter for backward compatibility
 		if (!string.IsNullOrEmpty(AriaLabel))
 		{
 			builder.AddAttribute(4, "aria-label", AriaLabel);
@@ -43,6 +44,7 @@ public class HxIcon : ComponentBase
 		{
 			builder.AddAttribute(5, "aria-hidden", "true");
 		}
+#pragma warning restore CS0618// use obsolete parameter for backward compatibility
 		builder.AddMultipleAttributes(3, AdditionalAttributes);
 		builder.CloseComponent();
 	}

--- a/Havit.Blazor.Documentation/Pages/Components/HxIconDoc/HxIcon_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxIconDoc/HxIcon_Documentation.razor
@@ -2,6 +2,12 @@
 
 <ComponentApiDoc Type="typeof(HxIcon)">
 
+    <DocAlert Type="DocAlertType.Warning">
+        If using icons semantically (e.g., for buttons or links), ensure to set appropriate <code>aria-label</code> or <code>title</code> attributes on the parent element for accessibility.
+        <code>HxIcon</code> renders an <code>&lt;i&gt;</code> element. The aria-label is not allowed on <code>&lt;i&gt;</code> elements according to accessibility best practices.
+        Setting these attributes directly on <code>HxIcon</code> is not reccomended, as they may be ignored by assistive technologies.
+    </DocAlert>
+
     <p>(Internally used by <a href="/components/@nameof(HxButton)">@nameof(HxButton)</a> and other components.)</p>
 
     <DocHeading Title="Icon" />

--- a/Havit.Blazor.Documentation/Pages/GettingStarted/GettingStarted.razor
+++ b/Havit.Blazor.Documentation/Pages/GettingStarted/GettingStarted.razor
@@ -24,7 +24,7 @@
 	or create a new project using one of the following GitHub repository templates:
 </p>
 
-<DocHeading Title="Simple Blazor Web App Template" Level="5" />
+<DocHeading Title="Simple Blazor Web App Template" Level="3" />
 <p>
 	For a quick start, you can use the <a href="https://github.com/havit/Havit.Blazor.SimpleBlazorWebAppTemplate">Simple Blazor Web App Template</a>:
 	<ul>
@@ -35,7 +35,7 @@
 	</ul>
 </p>
 
-<DocHeading Title="Enterprise Project Template" Level="5" />
+<DocHeading Title="Enterprise Project Template" Level="3" />
 <p>
 	Try our <a href="https://github.com/havit/NewProjectTemplate-Blazor">Enterprise Project Template</a>, which includes features like EF Core, gRPC code-first, and more:
 	<ul>

--- a/Havit.Blazor.Documentation/Shared/Components/GitHubLink.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/GitHubLink.razor
@@ -1,5 +1,5 @@
-<a href="https://github.com/havit/Havit.Blazor" class="@CssClassHelper.Combine(CssClass, "btn d-flex align-items-center")">
-	<HxIcon Icon="BootstrapIcon.Github" AriaLabel="GitHub repository" CssClass="align-self-end"/>
+<a href="https://github.com/havit/Havit.Blazor" class="@CssClassHelper.Combine(CssClass, "btn d-flex align-items-center")" aria-label="GitHub repository">
+	<HxIcon Icon="BootstrapIcon.Github" CssClass="align-self-end"/>
 </a>
 
 @code

--- a/Havit.Blazor.Documentation/Shared/Navbar.razor
+++ b/Havit.Blazor.Documentation/Shared/Navbar.razor
@@ -26,8 +26,8 @@
             <div class="d-flex gap-3 align-items-center justify-content-center">
                 <Search />
 
-				<a href="https://github.com/havit/Havit.Blazor" class="text-body" target="_blank">
-					<HxIcon Icon="BootstrapIcon.Github" AriaLabel="GitHub repository" />
+				<a href="https://github.com/havit/Havit.Blazor" class="text-body" target="_blank" aria-label="GitHub repository">
+					<HxIcon Icon="BootstrapIcon.Github" />
 				</a>
 				<Havit.Blazor.Documentation.Shared.Components.DocColorMode.DocColorModeSwitcher />
 			</div>


### PR DESCRIPTION
The usage of `aria-label` on `<i>`-element is not allowed. This property needs to be set on the parent element.
To nudge the developers in that direction, the property AriaLabel was deprecated.

Additionally some accessibility problems in the Demo site were fixed.