### PR TITLE
Dependabot: suppress all npm updates for vendored Bootstrap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,11 @@ updates:
     schedule:
       interval: "daily"
 
-  # We vendor Bootstrap and its npm dependencies manually — disable npm PRs.
+  # Bootstrap is vendored — ignore all npm updates including security PRs.
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/Havit.Bootstrap"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## What

Dependabot was raising PRs for npm packages inside `Havit.Bootstrap/` (our custom Bootstrap build), including security updates — see e.g. #1366.

## Why

Bootstrap is vendored — we follow upstream Bootstrap directly and intentionally don't want Dependabot to manage its npm dependencies.

## Changes

- Fixed the `directory` for the npm ecosystem entry to `/Havit.Bootstrap` (was incorrectly `/`)
- Added `ignore: dependency-name: "*"` which suppresses **all** npm updates, including security PRs (`open-pull-requests-limit: 0` alone does not block security updates)