### PR TITLE
[HxTabPanel] Added Accessibility Features for HxTabPanel

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
@@ -44,7 +44,8 @@
 					           Enabled="CascadeEnabledComponent.EnabledEffective(tab)" aria-describedby="@tab.Id"
 					           aria-controls="@tab.Id"
 					           aria-selected="@CssClassHelper.Combine((IsActive(tab) ? "true" : "false"))"
-					           tabindex="@CssClassHelper.Combine((IsActive(tab) ? "0" : "-1"))">
+					           tabindex="@(IsActive(tab) ? "0" : "-1")" 
+					           id="@(tab.Id + "-header")">
 						@tab.Title
 						@tab.TitleTemplate
 					</HxNavLink>
@@ -63,7 +64,7 @@
 					if ((RenderMode == TabPanelRenderMode.AllTabs)
 					|| ((RenderMode == TabPanelRenderMode.ActiveTabOnly) && IsActive(tab)))
 					{
-                        <div @key="@tab.Id" id="@tab.Id" aria-labelledby="@tab.Id" tabindex="0"  class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
+                        <div @key="@tab.Id" id="@tab.Id" aria-labelledby="@(tab.Id + "-header")" tabindex="0"  class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
                             @tab.Content
 						</div>
 					}

--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
@@ -43,7 +43,7 @@
 					           CssClass="@CssClassHelper.Combine((IsActive(tab) ? "active" : null), tab.TitleCssClass)"
 					           Enabled="CascadeEnabledComponent.EnabledEffective(tab)" aria-describedby="@tab.Id"
 					           aria-controls="@tab.Id"
-					           aria-selected="@CssClassHelper.Combine((IsActive(tab) ? "true" : "false"))"
+					           aria-selected="@(IsActive(tab) ? "true" : "false")"
 					           tabindex="@(IsActive(tab) ? "0" : "-1")" 
 					           id="@(tab.Id + "-header")">
 						@tab.Title

--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
@@ -64,7 +64,7 @@
 					if ((RenderMode == TabPanelRenderMode.AllTabs)
 					|| ((RenderMode == TabPanelRenderMode.ActiveTabOnly) && IsActive(tab)))
 					{
-                        <div @key="@tab.Id" id="@tab.Id" aria-labelledby="@(tab.Id + "-header")" tabindex="0"  class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
+                        <div @key="@tab.Id" id="@tab.Id" role="tabpanel" aria-labelledby="@(tab.Id + "-header")" tabindex="0"  class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
                             @tab.Content
 						</div>
 					}

--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
@@ -39,12 +39,12 @@
 				@if (tab.Visible)
 				{
 					<HxNavLink @key="@tab.Id"
-							   OnClick="async () => await HandleTabClick(tab)"
-							   CssClass="@CssClassHelper.Combine((IsActive(tab) ? "active" : null), tab.TitleCssClass)"
-                               Enabled="CascadeEnabledComponent.EnabledEffective(tab)" aria-describedby="@tab.Id"
-                               aria-control="@tab.Id"
-                               aria-selected="@CssClassHelper.Combine((IsActive(tab) ? "true" : "false"))"
-                               tabindex="-1">
+					           OnClick="async () => await HandleTabClick(tab)"
+					           CssClass="@CssClassHelper.Combine((IsActive(tab) ? "active" : null), tab.TitleCssClass)"
+					           Enabled="CascadeEnabledComponent.EnabledEffective(tab)" aria-describedby="@tab.Id"
+					           aria-controls="@tab.Id"
+					           aria-selected="@CssClassHelper.Combine((IsActive(tab) ? "true" : "false"))"
+					           tabindex="@CssClassHelper.Combine((IsActive(tab) ? "0" : "-1"))">
 						@tab.Title
 						@tab.TitleTemplate
 					</HxNavLink>

--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
@@ -41,7 +41,10 @@
 					<HxNavLink @key="@tab.Id"
 							   OnClick="async () => await HandleTabClick(tab)"
 							   CssClass="@CssClassHelper.Combine((IsActive(tab) ? "active" : null), tab.TitleCssClass)"
-							   Enabled="CascadeEnabledComponent.EnabledEffective(tab)">
+                               Enabled="CascadeEnabledComponent.EnabledEffective(tab)" aria-describedby="@tab.Id"
+                               aria-control="@tab.Id"
+                               aria-selected="@CssClassHelper.Combine((IsActive(tab) ? "true" : "false"))"
+                               tabindex="-1">
 						@tab.Title
 						@tab.TitleTemplate
 					</HxNavLink>
@@ -60,8 +63,8 @@
 					if ((RenderMode == TabPanelRenderMode.AllTabs)
 					|| ((RenderMode == TabPanelRenderMode.ActiveTabOnly) && IsActive(tab)))
 					{
-						<div @key="@tab.Id" class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
-							@tab.Content
+                        <div @key="@tab.Id" id="@tab.Id" aria-labelledby="@tab.Id" tabindex="0"  class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
+                            @tab.Content
 						</div>
 					}
 				}


### PR DESCRIPTION
### Problem description
NVDA Screenreader does not detect tab changes and does not read out the content of the active tab after changing it.
https://github.com/havit/Havit.Blazor/issues/1371

### Solution description
To make HxTabPanel NVDA Screenreader compliant its necessary to add some parameters to the tags:
https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/

With the help of aria-describedby, aria-selected, aria-control and tabindex on the tab and also aria-labeledby and tabindex on the content, screenreader is now able to detect the tabchange and reads out loud the content of the tab content.