### PR TITLE
HxMarkdown: New standalone Markdown-to-HTML component

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMarkdownTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMarkdownTests.cs
@@ -67,7 +67,7 @@ public class HxMarkdownTests : BunitTestBase
 		);
 
 		// Assert – no wrapper div, content rendered directly
-		Assert.AreEqual(0, cut.FindAll("div").Count);
+		Assert.IsEmpty(cut.FindAll("div"));
 	}
 
 	[TestMethod]
@@ -112,7 +112,7 @@ public class HxMarkdownTests : BunitTestBase
 		);
 
 		// Assert – HTML should be escaped (< encoded to &lt;, > remains)
-		Assert.AreEqual(0, cut.FindAll("b").Count);
+		Assert.IsEmpty(cut.FindAll("b"));
 		Assert.IsTrue(cut.Markup.Contains("&lt;b&gt;") || cut.Markup.Contains("&lt;b>"));
 	}
 
@@ -149,7 +149,7 @@ public class HxMarkdownTests : BunitTestBase
 
 		// Assert
 		var table = cut.Find("table");
-		Assert.IsTrue(table.GetAttribute("class").Contains("table-bordered"));
+		Assert.Contains("table-bordered", table.GetAttribute("class"));
 	}
 
 	[TestMethod]
@@ -236,7 +236,7 @@ public class HxMarkdownTests : BunitTestBase
 		);
 
 		// Assert
-		Assert.AreEqual(2, cut.FindAll("ul li").Count);
+		Assert.HasCount(2, cut.FindAll("ul li"));
 	}
 
 	[TestMethod]
@@ -248,7 +248,7 @@ public class HxMarkdownTests : BunitTestBase
 		);
 
 		// Assert
-		Assert.AreEqual(2, cut.FindAll("ol li").Count);
+		Assert.HasCount(2, cut.FindAll("ol li"));
 	}
 
 	[TestMethod]
@@ -308,7 +308,7 @@ public class HxMarkdownTests : BunitTestBase
 		);
 
 		// Assert
-		Assert.AreEqual(0, cut.FindAll("h1").Count);
+		Assert.IsEmpty(cut.FindAll("h1"));
 		Assert.AreEqual("Second", cut.Find("h2").TextContent);
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMarkdownTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMarkdownTests.cs
@@ -1,0 +1,316 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
+
+[TestClass]
+public class HxMarkdownTests : BunitTestBase
+{
+	#region Basic Rendering
+
+	[TestMethod]
+	public void HxMarkdown_NullContent_RendersNothing()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, null)
+		);
+
+		// Assert
+		Assert.AreEqual(string.Empty, cut.Markup.Trim());
+	}
+
+	[TestMethod]
+	public void HxMarkdown_EmptyContent_RendersNothing()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "")
+		);
+
+		// Assert
+		Assert.AreEqual(string.Empty, cut.Markup.Trim());
+	}
+
+	[TestMethod]
+	public void HxMarkdown_SimpleText_RendersParagraph()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "Hello world")
+		);
+
+		// Assert
+		cut.Find("p"); // throws if not found
+		Assert.AreEqual("Hello world", cut.Find("p").TextContent);
+	}
+
+	[TestMethod]
+	public void HxMarkdown_Heading_RendersH1()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "# My Heading")
+		);
+
+		// Assert
+		Assert.AreEqual("My Heading", cut.Find("h1").TextContent);
+	}
+
+	#endregion
+
+	#region Wrapper div Behavior
+
+	[TestMethod]
+	public void HxMarkdown_NoWrapperByDefault()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "Text")
+		);
+
+		// Assert – no wrapper div, content rendered directly
+		Assert.AreEqual(0, cut.FindAll("div").Count);
+	}
+
+	[TestMethod]
+	public void HxMarkdown_CssClass_RendersWrapperDiv()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "Text")
+			.Add(p => p.CssClass, "my-class")
+		);
+
+		// Assert
+		var div = cut.Find("div.my-class");
+		Assert.IsNotNull(div);
+		Assert.AreEqual("Text", div.QuerySelector("p").TextContent);
+	}
+
+	[TestMethod]
+	public void HxMarkdown_AdditionalAttributes_RendersWrapperDiv()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "Text")
+			.AddUnmatched("id", "my-md")
+		);
+
+		// Assert
+		var div = cut.Find("div#my-md");
+		Assert.IsNotNull(div);
+	}
+
+	#endregion
+
+	#region SanitizeHtml Parameter
+
+	[TestMethod]
+	public void HxMarkdown_SanitizeHtml_DefaultTrue_EscapesHtml()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "<b>bold</b>")
+		);
+
+		// Assert – HTML should be escaped (< encoded to &lt;, > remains)
+		Assert.AreEqual(0, cut.FindAll("b").Count);
+		Assert.IsTrue(cut.Markup.Contains("&lt;b&gt;") || cut.Markup.Contains("&lt;b>"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_SanitizeHtml_False_PreservesHtml()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "<b>bold</b>")
+			.Add(p => p.SanitizeHtml, false)
+		);
+
+		// Assert – HTML should pass through
+		Assert.AreEqual("bold", cut.Find("b").TextContent);
+	}
+
+	#endregion
+
+	#region Settings / Defaults
+
+	[TestMethod]
+	public void HxMarkdown_Settings_OverridesDefaults()
+	{
+		var settings = new MarkdownSettings
+		{
+			TableCssClass = "table table-bordered"
+		};
+
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "| A |\n|---|\n| 1 |")
+			.Add(p => p.Settings, settings)
+		);
+
+		// Assert
+		var table = cut.Find("table");
+		Assert.IsTrue(table.GetAttribute("class").Contains("table-bordered"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_ParameterOverridesSettings()
+	{
+		var settings = new MarkdownSettings
+		{
+			TableCssClass = "table table-bordered"
+		};
+
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "| A |\n|---|\n| 1 |")
+			.Add(p => p.Settings, settings)
+			.Add(p => p.TableCssClass, "custom-table")
+		);
+
+		// Assert
+		var table = cut.Find("table");
+		Assert.AreEqual("custom-table", table.GetAttribute("class"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_Defaults_ApplyTableClass()
+	{
+		// Act – use default settings (table class = "table")
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "| A |\n|---|\n| 1 |")
+		);
+
+		// Assert
+		var table = cut.Find("table");
+		Assert.AreEqual("table", table.GetAttribute("class"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_Defaults_ApplyBlockquoteClass()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "> Quote")
+		);
+
+		// Assert
+		var bq = cut.Find("blockquote");
+		Assert.AreEqual("blockquote", bq.GetAttribute("class"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_Defaults_ApplyImageClass()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "![Alt](https://example.com/img.png)")
+		);
+
+		// Assert
+		var img = cut.Find("img");
+		Assert.AreEqual("img-fluid", img.GetAttribute("class"));
+	}
+
+	#endregion
+
+	#region Complex Rendering
+
+	[TestMethod]
+	public void HxMarkdown_CodeBlock_RendersPreCode()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "```\nvar x = 1;\n```")
+		);
+
+		// Assert
+		Assert.IsNotNull(cut.Find("pre code"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_UnorderedList_RendersUl()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "- Item 1\n- Item 2")
+		);
+
+		// Assert
+		Assert.AreEqual(2, cut.FindAll("ul li").Count);
+	}
+
+	[TestMethod]
+	public void HxMarkdown_OrderedList_RendersOl()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "1. First\n2. Second")
+		);
+
+		// Assert
+		Assert.AreEqual(2, cut.FindAll("ol li").Count);
+	}
+
+	[TestMethod]
+	public void HxMarkdown_HorizontalRule_RendersHr()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "---")
+		);
+
+		// Assert
+		Assert.IsNotNull(cut.Find("hr"));
+	}
+
+	[TestMethod]
+	public void HxMarkdown_InlineBold_RendersStrong()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "This is **bold**")
+		);
+
+		// Assert
+		Assert.AreEqual("bold", cut.Find("strong").TextContent);
+	}
+
+	[TestMethod]
+	public void HxMarkdown_InlineLink_RendersAnchor()
+	{
+		// Act
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "[Click](https://example.com)")
+		);
+
+		// Assert
+		var link = cut.Find("a");
+		Assert.AreEqual("https://example.com", link.GetAttribute("href"));
+		Assert.AreEqual("Click", link.TextContent);
+	}
+
+	#endregion
+
+	#region Re-render on Content Change
+
+	[TestMethod]
+	public void HxMarkdown_ContentChange_UpdatesRenderedOutput()
+	{
+		// Arrange
+		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+			.Add(p => p.Content, "# First")
+		);
+		Assert.AreEqual("First", cut.Find("h1").TextContent);
+
+		// Act
+		cut.SetParametersAndRender(parameters => parameters
+			.Add(p => p.Content, "## Second")
+		);
+
+		// Assert
+		Assert.AreEqual(0, cut.FindAll("h1").Count);
+		Assert.AreEqual("Second", cut.Find("h2").TextContent);
+	}
+
+	#endregion
+}

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -715,5 +715,17 @@ public class MarkdownParserTests
 		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_TableHeaderWithoutTrailingPipe_AfterParagraph_NotSplitIncorrectly()
+	{
+		// Header line without trailing pipe (| A | B) must NOT break the paragraph,
+		// because TryParseTable requires both leading and trailing pipes.
+		var markdown = "Some text\n| A | B\n|---|---|\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("Some text", result);
+		Assert.Contains("| A | B", result);
+		Assert.DoesNotContain("<table", result);
+	}
+
 	#endregion
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -390,4 +390,106 @@ public class MarkdownParserTests
 	}
 
 	#endregion
+
+	#region Security - XSS and Attribute Injection
+
+	[TestMethod]
+	public void MarkdownParser_Image_AltWithQuote_AttributeInjectionPrevented()
+	{
+		// A " in the alt text must be encoded to prevent breaking out of the attribute and injecting new attributes.
+		var result = MarkdownParser.ToHtml("![alt\" onerror=\"alert(1)](image.png)", DefaultOptions);
+		// The output should have " encoded as &quot; so the attribute cannot be broken
+		Assert.DoesNotContain("\" onerror=\"", result);
+		Assert.Contains("alt=\"alt&quot; onerror=&quot;", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_AltWithQuote_EncodedAsHtmlEntity()
+	{
+		var result = MarkdownParser.ToHtml("![say \"hello\"](image.png)", DefaultOptions);
+		Assert.Contains("alt=\"say &quot;hello&quot;\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_JavascriptUrlInSrc_IsBlocked()
+	{
+		var result = MarkdownParser.ToHtml("![alt](javascript:alert(1))", DefaultOptions);
+		Assert.DoesNotContain("javascript:", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_DataUrlInSrc_IsBlocked()
+	{
+		var result = MarkdownParser.ToHtml("![alt](data:text/html,payload)", DefaultOptions);
+		Assert.DoesNotContain("data:", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_SafeHttpsUrl_IsPreserved()
+	{
+		var result = MarkdownParser.ToHtml("![alt](https://example.com/img.png)", DefaultOptions);
+		Assert.Contains("src=\"https://example.com/img.png\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_SafeRelativeUrl_IsPreserved()
+	{
+		var result = MarkdownParser.ToHtml("![alt](/images/photo.png)", DefaultOptions);
+		Assert.Contains("src=\"/images/photo.png\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_JavascriptUrl_SanitizeHtmlFalse_IsPreserved()
+	{
+		// SanitizeHtml=false opts out of all sanitization; URL scheme is kept as-is.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("![alt](javascript:alert(1))", options);
+		Assert.Contains("javascript:", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_JavascriptUrlInHref_IsBlocked()
+	{
+		var result = MarkdownParser.ToHtml("[Click here](javascript:alert(1))", DefaultOptions);
+		Assert.DoesNotContain("javascript:", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_DataUrlInHref_IsBlocked()
+	{
+		var result = MarkdownParser.ToHtml("[Click here](data:text/html,payload)", DefaultOptions);
+		Assert.DoesNotContain("data:", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_SafeHttpsUrl_IsPreserved()
+	{
+		var result = MarkdownParser.ToHtml("[Link](https://example.com)", DefaultOptions);
+		Assert.Contains("href=\"https://example.com\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_JavascriptUrl_SanitizeHtmlFalse_IsPreserved()
+	{
+		// SanitizeHtml=false opts out of all sanitization; URL scheme is kept as-is.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("[Click here](javascript:alert(1))", options);
+		Assert.Contains("javascript:", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_ProtocolRelativeUrl_IsBlocked()
+	{
+		var result = MarkdownParser.ToHtml("![alt](//evil.com/image.png)", DefaultOptions);
+		Assert.DoesNotContain("//evil.com", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_ProtocolRelativeUrl_IsBlocked()
+	{
+		var result = MarkdownParser.ToHtml("[Link](//evil.com)", DefaultOptions);
+		Assert.DoesNotContain("//evil.com", result);
+	}
+
+	#endregion
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -649,5 +649,27 @@ public class MarkdownParserTests
 		Assert.DoesNotContain("//evil.com", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_Image_UrlWithQuote_AttributeInjectionPrevented()
+	{
+		// A " in the URL must be encoded to prevent breaking out of src="..." and injecting attributes.
+		var result = MarkdownParser.ToHtml("![alt](url\"onclick=\"alert(1))", DefaultOptions);
+		Assert.DoesNotContain("\" onclick=\"", result);
+		Assert.DoesNotContain("\"onclick=\"", result);
+		// The " chars in the URL are encoded as &quot; so the attribute cannot be broken.
+		Assert.Contains("src=\"url&quot;onclick=&quot;alert(1\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_UrlWithQuote_AttributeInjectionPrevented()
+	{
+		// A " in the href URL must be encoded to prevent breaking out of href="..." and injecting attributes.
+		var result = MarkdownParser.ToHtml("[text](url\"onclick=\"alert(1))", DefaultOptions);
+		Assert.DoesNotContain("\" onclick=\"", result);
+		Assert.DoesNotContain("\"onclick=\"", result);
+		// The " chars in the URL are encoded as &quot; so the attribute cannot be broken.
+		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
+	}
+
 	#endregion
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -128,6 +128,34 @@ public class MarkdownParserTests
 		Assert.AreEqual("<pre><code>code here</code></pre>", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_FencedCodeBlock_LongerOpeningFence_NotClosedByShorterFence()
+	{
+		// Opening fence of 4 backticks requires closing fence of >= 4 backticks (CommonMark).
+		// A 3-backtick closing line should appear literally in the code content, not close the block.
+		var markdown = "````\nvar x = 1;\n```\nvar y = 2;\n````";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<pre><code>var x = 1;\n```\nvar y = 2;</code></pre>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_FencedCodeBlock_LongerClosingFence_ClosesBlock()
+	{
+		// A closing fence longer than the opening fence must also close the block (CommonMark).
+		var markdown = "```\nvar x = 1;\n`````";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<pre><code>var x = 1;</code></pre>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_FencedCodeBlock_FourBackticksWithLanguage()
+	{
+		// 4-backtick opening with language hint should be supported
+		var markdown = "````csharp\nvar x = 1;\n````";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<pre><code class=\"language-csharp\">var x = 1;</code></pre>", result);
+	}
+
 	#endregion
 
 	#region Blockquotes

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -661,6 +661,27 @@ public class MarkdownParserTests
 	}
 
 	[TestMethod]
+	public void MarkdownParser_Image_UrlWithQuote_SanitizeHtmlFalse_AttributeInjectionPrevented()
+	{
+		// Even with SanitizeHtml=false, " in URL must be encoded to produce valid HTML attributes.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("![alt](url\"onclick=\"alert(1))", options);
+		Assert.DoesNotContain("\" onclick=\"", result);
+		Assert.DoesNotContain("\"onclick=\"", result);
+		Assert.Contains("src=\"url&quot;onclick=&quot;alert(1\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_AltWithQuote_SanitizeHtmlFalse_AttributeInjectionPrevented()
+	{
+		// Even with SanitizeHtml=false, " in alt must be encoded to produce valid HTML attributes.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("![alt\" onerror=\"alert(1)](image.png)", options);
+		Assert.DoesNotContain("\" onerror=\"", result);
+		Assert.Contains("alt=\"alt&quot; onerror=&quot;alert(1)\"", result);
+	}
+
+	[TestMethod]
 	public void MarkdownParser_Link_UrlWithQuote_AttributeInjectionPrevented()
 	{
 		// A " in the href URL must be encoded to prevent breaking out of href="..." and injecting attributes.
@@ -668,6 +689,28 @@ public class MarkdownParserTests
 		Assert.DoesNotContain("\" onclick=\"", result);
 		Assert.DoesNotContain("\"onclick=\"", result);
 		// The " chars in the URL are encoded as &quot; so the attribute cannot be broken.
+		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_UrlWithQuote_SanitizeHtmlFalse_AttributeInjectionPrevented()
+	{
+		// Even with SanitizeHtml=false, " in URL must be encoded to produce valid HTML attributes.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("[text](url\"onclick=\"alert(1))", options);
+		Assert.DoesNotContain("\" onclick=\"", result);
+		Assert.DoesNotContain("\"onclick=\"", result);
+		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_TitleWithQuote_SanitizeHtmlFalse_AttributeInjectionPrevented()
+	{
+		// Even with SanitizeHtml=false, " in URL must be encoded to produce valid HTML attributes.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("[text](url\"onclick=\"alert(1))", options);
+		Assert.DoesNotContain("\" onclick=\"", result);
+		Assert.DoesNotContain("\"onclick=\"", result);
 		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -703,16 +703,5 @@ public class MarkdownParserTests
 		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
 	}
 
-	[TestMethod]
-	public void MarkdownParser_Link_TitleWithQuote_SanitizeHtmlFalse_AttributeInjectionPrevented()
-	{
-		// Even with SanitizeHtml=false, " in URL must be encoded to produce valid HTML attributes.
-		var options = new MarkdownRenderOptions { SanitizeHtml = false };
-		var result = MarkdownParser.ToHtml("[text](url\"onclick=\"alert(1))", options);
-		Assert.DoesNotContain("\" onclick=\"", result);
-		Assert.DoesNotContain("\"onclick=\"", result);
-		Assert.Contains("href=\"url&quot;onclick=&quot;alert(1\"", result);
-	}
-
 	#endregion
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -484,6 +484,18 @@ public class MarkdownParserTests
 		Assert.Contains("<em>", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_TableImmediatelyAfterParagraph_WithoutBlankLine_ParsedSeparately()
+	{
+		// Table immediately after paragraph text (no blank line separator) must be parsed as a separate table block
+		var markdown = "Some text\n| A | B |\n|---|---|\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("<p>Some text</p>", result);
+		Assert.Contains("<table", result);
+		Assert.Contains("<th>A</th>", result);
+		Assert.Contains("<td>1</td>", result);
+	}
+
 	#endregion
 
 	#region Line Endings

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -184,6 +184,30 @@ public class MarkdownParserTests
 		Assert.Contains("Line two", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_NestedBlockquote_TwoLevels()
+	{
+		// >> nested should produce a blockquote inside a blockquote
+		var result = MarkdownParser.ToHtml(">> nested", DefaultOptions);
+		Assert.AreEqual("<blockquote class=\"blockquote\"><blockquote class=\"blockquote\"><p>nested</p></blockquote></blockquote>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_NestedBlockquote_ThreeLevels()
+	{
+		// >>> triple-nested
+		var result = MarkdownParser.ToHtml(">>> triple", DefaultOptions);
+		Assert.AreEqual("<blockquote class=\"blockquote\"><blockquote class=\"blockquote\"><blockquote class=\"blockquote\"><p>triple</p></blockquote></blockquote></blockquote>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_NestedBlockquote_WithSpaceSyntax()
+	{
+		// CommonMark: "> > nested" (space between markers) also produces nested blockquote
+		var result = MarkdownParser.ToHtml("> > nested", DefaultOptions);
+		Assert.AreEqual("<blockquote class=\"blockquote\"><blockquote class=\"blockquote\"><p>nested</p></blockquote></blockquote>", result);
+	}
+
 	#endregion
 
 	#region Horizontal Rules

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -391,6 +391,57 @@ public class MarkdownParserTests
 
 	#endregion
 
+	#region Inline Code - Protection and Encoding
+
+	[TestMethod]
+	public void MarkdownParser_InlineCode_MarkdownInsideCode_NotProcessed()
+	{
+		// Bold markers inside a code span must not be processed — content is literal
+		var result = MarkdownParser.ToHtml("`**bold**`", DefaultOptions);
+		Assert.AreEqual("<p><code>**bold**</code></p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_InlineCode_LinkInsideCode_NotProcessed()
+	{
+		// Link syntax inside a code span must not be rendered as a hyperlink
+		var result = MarkdownParser.ToHtml("`[link](https://example.com)`", DefaultOptions);
+		Assert.DoesNotContain("<a ", result);
+		Assert.Contains("<code>[link](https://example.com)</code>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_InlineCode_HtmlTagInCode_AlwaysEncoded()
+	{
+		// Code content must always be HTML-encoded, regardless of SanitizeHtml
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("`<script>alert(1)</script>`", options);
+		Assert.DoesNotContain("<script>", result);
+		Assert.Contains("<code>&lt;script>", result);
+	}
+
+	#endregion
+
+	#region Links - Relative URL Handling
+
+	[TestMethod]
+	public void MarkdownParser_Link_BareRelativeUrl_IsPreserved()
+	{
+		// A bare relative URL (no leading /) must not be replaced with #
+		var result = MarkdownParser.ToHtml("[Link](page.html)", DefaultOptions);
+		Assert.Contains("href=\"page.html\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_BareRelativeUrl_IsPreserved()
+	{
+		// A bare relative image path (no leading /) must not be replaced with #
+		var result = MarkdownParser.ToHtml("![alt](photo.jpg)", DefaultOptions);
+		Assert.Contains("src=\"photo.jpg\"", result);
+	}
+
+	#endregion
+
 	#region Security - XSS and Attribute Injection
 
 	[TestMethod]

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -117,7 +117,7 @@ public class MarkdownParserTests
 	{
 		var markdown = "```\n<div>test</div>\n```";
 		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
-		Assert.IsTrue(result.Contains("&lt;div&gt;test&lt;/div&gt;"));
+		Assert.Contains("&lt;div&gt;test&lt;/div&gt;", result);
 	}
 
 	[TestMethod]
@@ -144,7 +144,7 @@ public class MarkdownParserTests
 	{
 		var options = new MarkdownRenderOptions { SanitizeHtml = true, BlockquoteCssClass = "custom-quote" };
 		var result = MarkdownParser.ToHtml("> Quote text", options);
-		Assert.IsTrue(result.Contains("class=\"custom-quote\""));
+		Assert.Contains("class=\"custom-quote\"", result);
 	}
 
 	[TestMethod]
@@ -152,8 +152,8 @@ public class MarkdownParserTests
 	{
 		var markdown = "> Line one\n> Line two";
 		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
-		Assert.IsTrue(result.Contains("Line one"));
-		Assert.IsTrue(result.Contains("Line two"));
+		Assert.Contains("Line one", result);
+		Assert.Contains("Line two", result);
 	}
 
 	#endregion
@@ -221,11 +221,11 @@ public class MarkdownParserTests
 		var markdown = "| Header 1 | Header 2 |\n|---|---|\n| Cell 1 | Cell 2 |";
 		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
 
-		Assert.IsTrue(result.Contains("<table class=\"table\">"));
-		Assert.IsTrue(result.Contains("<th>Header 1</th>"));
-		Assert.IsTrue(result.Contains("<th>Header 2</th>"));
-		Assert.IsTrue(result.Contains("<td>Cell 1</td>"));
-		Assert.IsTrue(result.Contains("<td>Cell 2</td>"));
+		Assert.Contains("<table class=\"table\">", result);
+		Assert.Contains("<th>Header 1</th>", result);
+		Assert.Contains("<th>Header 2</th>", result);
+		Assert.Contains("<td>Cell 1</td>", result);
+		Assert.Contains("<td>Cell 2</td>", result);
 	}
 
 	[TestMethod]
@@ -234,7 +234,7 @@ public class MarkdownParserTests
 		var options = new MarkdownRenderOptions { SanitizeHtml = true, TableCssClass = "table table-striped" };
 		var markdown = "| A | B |\n|---|---|\n| 1 | 2 |";
 		var result = MarkdownParser.ToHtml(markdown, options);
-		Assert.IsTrue(result.Contains("class=\"table table-striped\""));
+		Assert.Contains("class=\"table table-striped\"", result);
 	}
 
 	[TestMethod]
@@ -243,10 +243,10 @@ public class MarkdownParserTests
 		var markdown = "| Name | Value |\n|---|---|\n| A | 1 |\n| B | 2 |\n| C | 3 |";
 		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
 
-		Assert.IsTrue(result.Contains("<thead>"));
-		Assert.IsTrue(result.Contains("<tbody>"));
-		Assert.IsTrue(result.Contains("<td>A</td>"));
-		Assert.IsTrue(result.Contains("<td>3</td>"));
+		Assert.Contains("<thead>", result);
+		Assert.Contains("<tbody>", result);
+		Assert.Contains("<td>A</td>", result);
+		Assert.Contains("<td>3</td>", result);
 	}
 
 	#endregion
@@ -306,15 +306,15 @@ public class MarkdownParserTests
 	public void MarkdownParser_LinkWithTitle_RendersTitleAttribute()
 	{
 		var result = MarkdownParser.ToHtml("[Link](https://example.com \"My Title\")", DefaultOptions);
-		Assert.IsTrue(result.Contains("title=\"My Title\""));
+		Assert.Contains("title=\"My Title\"", result);
 	}
 
 	[TestMethod]
 	public void MarkdownParser_Image_RendersImgTag()
 	{
 		var result = MarkdownParser.ToHtml("![Alt text](https://example.com/img.png)", DefaultOptions);
-		Assert.IsTrue(result.Contains("<img src=\"https://example.com/img.png\" alt=\"Alt text\""));
-		Assert.IsTrue(result.Contains("class=\"img-fluid\""));
+		Assert.Contains("<img src=\"https://example.com/img.png\" alt=\"Alt text\"", result);
+		Assert.Contains("class=\"img-fluid\"", result);
 	}
 
 	[TestMethod]
@@ -322,7 +322,7 @@ public class MarkdownParserTests
 	{
 		var options = new MarkdownRenderOptions { SanitizeHtml = true, ImageCssClass = "custom-img" };
 		var result = MarkdownParser.ToHtml("![Alt](url.png)", options);
-		Assert.IsTrue(result.Contains("class=\"custom-img\""));
+		Assert.Contains("class=\"custom-img\"", result);
 	}
 
 	#endregion
@@ -334,8 +334,8 @@ public class MarkdownParserTests
 	{
 		var options = new MarkdownRenderOptions { SanitizeHtml = true };
 		var result = MarkdownParser.ToHtml("<script>alert('xss')</script>", options);
-		Assert.IsTrue(result.Contains("&lt;script>"));
-		Assert.IsFalse(result.Contains("<script>"));
+		Assert.Contains("&lt;script>", result);
+		Assert.DoesNotContain("<script>", result);
 	}
 
 	[TestMethod]
@@ -343,7 +343,7 @@ public class MarkdownParserTests
 	{
 		var options = new MarkdownRenderOptions { SanitizeHtml = false };
 		var result = MarkdownParser.ToHtml("<em>italic</em>", options);
-		Assert.IsTrue(result.Contains("<em>italic</em>"));
+		Assert.Contains("<em>italic</em>", result);
 	}
 
 	#endregion
@@ -355,8 +355,8 @@ public class MarkdownParserTests
 	{
 		var markdown = "# Title\n\nSome text here.";
 		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
-		Assert.IsTrue(result.StartsWith("<h1>Title</h1>"));
-		Assert.IsTrue(result.Contains("<p>Some text here.</p>"));
+		Assert.StartsWith("<h1>Title</h1>", result);
+		Assert.Contains("<p>Some text here.</p>", result);
 	}
 
 	[TestMethod]
@@ -364,8 +364,8 @@ public class MarkdownParserTests
 	{
 		var markdown = "- Item 1\n- Item 2\n\nParagraph text.";
 		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
-		Assert.IsTrue(result.Contains("<ul>"));
-		Assert.IsTrue(result.Contains("<p>Paragraph text.</p>"));
+		Assert.Contains("<ul>", result);
+		Assert.Contains("<p>Paragraph text.</p>", result);
 	}
 
 	[TestMethod]
@@ -373,7 +373,8 @@ public class MarkdownParserTests
 	{
 		var result = MarkdownParser.ToHtml("***bold and italic***", DefaultOptions);
 		// ** wraps *, so we get <strong><em>bold and italic</em></strong>
-		Assert.IsTrue(result.Contains("<strong>") && result.Contains("<em>"));
+		Assert.Contains("<strong>", result);
+		Assert.Contains("<em>", result);
 	}
 
 	#endregion

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -727,5 +727,54 @@ public class MarkdownParserTests
 		Assert.DoesNotContain("<table", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_TableHeaderWithTrailingWhitespace_AfterParagraph_ParsedSeparately()
+	{
+		// Trailing whitespace after the last | must not prevent table detection.
+		// ParseParagraph must Trim() consistently with TryParseTable.
+		var markdown = "Some text\n| A | B |   \n|---|---|\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("<p>Some text</p>", result);
+		Assert.Contains("<table", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_LinkUrlWithMarkdownMarkers_NotMangledByEmphasis()
+	{
+		// Bold markers ** inside a URL must not be converted to <strong>.
+		var markdown = "[click](https://x.com/**path**/y)";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("href=\"https://x.com/**path**/y\"", result);
+		Assert.DoesNotContain("<strong>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_ImageAltWithUnderscores_NotMangledByEmphasis()
+	{
+		// Underscores in image alt text must not be converted to <em>.
+		var markdown = "![my_image_alt](https://example.com/img.png)";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("alt=\"my_image_alt\"", result);
+		Assert.DoesNotContain("<em>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_LinkUrlWithAmpersand_SanitizeHtmlFalse_AmpEncoded()
+	{
+		// & in URLs must be encoded as &amp; in attribute values even when SanitizeHtml=false.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("[link](https://x.com?a=1&b=2)", options);
+		Assert.Contains("href=\"https://x.com?a=1&amp;b=2\"", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_ImageUrlWithAmpersand_SanitizeHtmlFalse_AmpEncoded()
+	{
+		// & in image URLs must be encoded as &amp; in attribute values even when SanitizeHtml=false.
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("![alt](https://x.com/img?a=1&b=2)", options);
+		Assert.Contains("src=\"https://x.com/img?a=1&amp;b=2\"", result);
+	}
+
 	#endregion
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -301,6 +301,61 @@ public class MarkdownParserTests
 		Assert.Contains("<td>3</td>", result);
 	}
 
+	[TestMethod]
+	public void MarkdownParser_Table_AlignmentLeft_EmitsStyleAttribute()
+	{
+		// :--- means left alignment
+		var markdown = "| A | B |\n| :--- | :--- |\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("<th style=\"text-align:left\">", result);
+		Assert.Contains("<td style=\"text-align:left\">", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Table_AlignmentRight_EmitsStyleAttribute()
+	{
+		// ---: means right alignment
+		var markdown = "| A | B |\n| ---: | ---: |\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("<th style=\"text-align:right\">", result);
+		Assert.Contains("<td style=\"text-align:right\">", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Table_AlignmentCenter_EmitsStyleAttribute()
+	{
+		// :---: means center alignment
+		var markdown = "| A | B |\n| :---: | :---: |\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("<th style=\"text-align:center\">", result);
+		Assert.Contains("<td style=\"text-align:center\">", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Table_AlignmentNone_NoStyleAttribute()
+	{
+		// --- with no colons means no alignment (default)
+		var markdown = "| A |\n| --- |\n| 1 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.DoesNotContain("style=", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Table_MixedAlignments_PerColumn()
+	{
+		// Each column may have a different alignment
+		var markdown = "| Left | Center | Right | None |\n| :--- | :---: | ---: | --- |\n| a | b | c | d |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Contains("<th style=\"text-align:left\">Left</th>", result);
+		Assert.Contains("<th style=\"text-align:center\">Center</th>", result);
+		Assert.Contains("<th style=\"text-align:right\">Right</th>", result);
+		Assert.Contains("<th>None</th>", result);
+		Assert.Contains("<td style=\"text-align:left\">a</td>", result);
+		Assert.Contains("<td style=\"text-align:center\">b</td>", result);
+		Assert.Contains("<td style=\"text-align:right\">c</td>", result);
+		Assert.Contains("<td>d</td>", result);
+	}
+
 	#endregion
 
 	#region Inline Elements

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -1,0 +1,392 @@
+﻿using Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
+
+[TestClass]
+public class MarkdownParserTests
+{
+	private static MarkdownRenderOptions DefaultOptions => new MarkdownRenderOptions
+	{
+		SanitizeHtml = true,
+		TableCssClass = "table",
+		BlockquoteCssClass = "blockquote",
+		ImageCssClass = "img-fluid"
+	};
+
+	#region Null / Empty / Whitespace
+
+	[TestMethod]
+	public void MarkdownParser_NullInput_ReturnsEmpty()
+	{
+		var result = MarkdownParser.ToHtml(null, DefaultOptions);
+		Assert.AreEqual(string.Empty, result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_EmptyInput_ReturnsEmpty()
+	{
+		var result = MarkdownParser.ToHtml("", DefaultOptions);
+		Assert.AreEqual(string.Empty, result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_WhitespaceOnlyInput_ReturnsEmpty()
+	{
+		var result = MarkdownParser.ToHtml("   \n  \n  ", DefaultOptions);
+		Assert.AreEqual(string.Empty, result);
+	}
+
+	#endregion
+
+	#region Paragraphs
+
+	[TestMethod]
+	public void MarkdownParser_SimpleText_RendersAsParagraph()
+	{
+		var result = MarkdownParser.ToHtml("Hello world", DefaultOptions);
+		Assert.AreEqual("<p>Hello world</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_TwoParagraphs_SeparatedByBlankLine()
+	{
+		var result = MarkdownParser.ToHtml("First paragraph\n\nSecond paragraph", DefaultOptions);
+		Assert.AreEqual("<p>First paragraph</p><p>Second paragraph</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_MultipleLinesWithinParagraph_JoinedWithSpace()
+	{
+		var result = MarkdownParser.ToHtml("Line one\nLine two", DefaultOptions);
+		Assert.AreEqual("<p>Line one Line two</p>", result);
+	}
+
+	#endregion
+
+	#region Headings
+
+	[TestMethod]
+	[DataRow("# Heading 1", "<h1>Heading 1</h1>", DisplayName = "H1")]
+	[DataRow("## Heading 2", "<h2>Heading 2</h2>", DisplayName = "H2")]
+	[DataRow("### Heading 3", "<h3>Heading 3</h3>", DisplayName = "H3")]
+	[DataRow("#### Heading 4", "<h4>Heading 4</h4>", DisplayName = "H4")]
+	[DataRow("##### Heading 5", "<h5>Heading 5</h5>", DisplayName = "H5")]
+	[DataRow("###### Heading 6", "<h6>Heading 6</h6>", DisplayName = "H6")]
+	public void MarkdownParser_Headings_RenderedCorrectly(string markdown, string expected)
+	{
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_HeadingWithTrailingHashes_Stripped()
+	{
+		var result = MarkdownParser.ToHtml("## Heading ##", DefaultOptions);
+		Assert.AreEqual("<h2>Heading</h2>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_HashWithoutSpace_NotAHeading()
+	{
+		var result = MarkdownParser.ToHtml("#NotAHeading", DefaultOptions);
+		Assert.AreEqual("<p>#NotAHeading</p>", result);
+	}
+
+	#endregion
+
+	#region Code Blocks
+
+	[TestMethod]
+	public void MarkdownParser_FencedCodeBlock_RendersPreCode()
+	{
+		var markdown = "```\nvar x = 1;\n```";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<pre><code>var x = 1;</code></pre>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_FencedCodeBlock_WithLanguage()
+	{
+		var markdown = "```csharp\nvar x = 1;\n```";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<pre><code class=\"language-csharp\">var x = 1;</code></pre>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_FencedCodeBlock_HtmlEncoded()
+	{
+		var markdown = "```\n<div>test</div>\n```";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.IsTrue(result.Contains("&lt;div&gt;test&lt;/div&gt;"));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_TildeFencedCodeBlock_RendersPreCode()
+	{
+		var markdown = "~~~\ncode here\n~~~";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<pre><code>code here</code></pre>", result);
+	}
+
+	#endregion
+
+	#region Blockquotes
+
+	[TestMethod]
+	public void MarkdownParser_Blockquote_RenderedWithClass()
+	{
+		var result = MarkdownParser.ToHtml("> This is a quote", DefaultOptions);
+		Assert.AreEqual("<blockquote class=\"blockquote\"><p>This is a quote</p></blockquote>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Blockquote_CustomCssClass()
+	{
+		var options = new MarkdownRenderOptions { SanitizeHtml = true, BlockquoteCssClass = "custom-quote" };
+		var result = MarkdownParser.ToHtml("> Quote text", options);
+		Assert.IsTrue(result.Contains("class=\"custom-quote\""));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_MultilineBlockquote_JoinedCorrectly()
+	{
+		var markdown = "> Line one\n> Line two";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.IsTrue(result.Contains("Line one"));
+		Assert.IsTrue(result.Contains("Line two"));
+	}
+
+	#endregion
+
+	#region Horizontal Rules
+
+	[TestMethod]
+	[DataRow("---", DisplayName = "Dashes")]
+	[DataRow("***", DisplayName = "Asterisks")]
+	[DataRow("___", DisplayName = "Underscores")]
+	[DataRow("- - -", DisplayName = "Spaced dashes")]
+	public void MarkdownParser_HorizontalRule_RendersHr(string markdown)
+	{
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<hr />", result);
+	}
+
+	#endregion
+
+	#region Unordered Lists
+
+	[TestMethod]
+	public void MarkdownParser_UnorderedList_WithDash()
+	{
+		var markdown = "- Item 1\n- Item 2\n- Item 3";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_UnorderedList_WithAsterisk()
+	{
+		var markdown = "* Item A\n* Item B";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<ul><li>Item A</li><li>Item B</li></ul>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_UnorderedList_WithPlus()
+	{
+		var markdown = "+ First\n+ Second";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<ul><li>First</li><li>Second</li></ul>", result);
+	}
+
+	#endregion
+
+	#region Ordered Lists
+
+	[TestMethod]
+	public void MarkdownParser_OrderedList_RenderedCorrectly()
+	{
+		var markdown = "1. First\n2. Second\n3. Third";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<ol><li>First</li><li>Second</li><li>Third</li></ol>", result);
+	}
+
+	#endregion
+
+	#region Tables
+
+	[TestMethod]
+	public void MarkdownParser_Table_RenderedWithBootstrapClass()
+	{
+		var markdown = "| Header 1 | Header 2 |\n|---|---|\n| Cell 1 | Cell 2 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+
+		Assert.IsTrue(result.Contains("<table class=\"table\">"));
+		Assert.IsTrue(result.Contains("<th>Header 1</th>"));
+		Assert.IsTrue(result.Contains("<th>Header 2</th>"));
+		Assert.IsTrue(result.Contains("<td>Cell 1</td>"));
+		Assert.IsTrue(result.Contains("<td>Cell 2</td>"));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Table_CustomCssClass()
+	{
+		var options = new MarkdownRenderOptions { SanitizeHtml = true, TableCssClass = "table table-striped" };
+		var markdown = "| A | B |\n|---|---|\n| 1 | 2 |";
+		var result = MarkdownParser.ToHtml(markdown, options);
+		Assert.IsTrue(result.Contains("class=\"table table-striped\""));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Table_MultipleDataRows()
+	{
+		var markdown = "| Name | Value |\n|---|---|\n| A | 1 |\n| B | 2 |\n| C | 3 |";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+
+		Assert.IsTrue(result.Contains("<thead>"));
+		Assert.IsTrue(result.Contains("<tbody>"));
+		Assert.IsTrue(result.Contains("<td>A</td>"));
+		Assert.IsTrue(result.Contains("<td>3</td>"));
+	}
+
+	#endregion
+
+	#region Inline Elements
+
+	[TestMethod]
+	public void MarkdownParser_BoldWithDoubleAsterisks_RendersStrong()
+	{
+		var result = MarkdownParser.ToHtml("This is **bold** text", DefaultOptions);
+		Assert.AreEqual("<p>This is <strong>bold</strong> text</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_BoldWithDoubleUnderscores_RendersStrong()
+	{
+		var result = MarkdownParser.ToHtml("This is __bold__ text", DefaultOptions);
+		Assert.AreEqual("<p>This is <strong>bold</strong> text</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_ItalicWithSingleAsterisk_RendersEm()
+	{
+		var result = MarkdownParser.ToHtml("This is *italic* text", DefaultOptions);
+		Assert.AreEqual("<p>This is <em>italic</em> text</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_ItalicWithSingleUnderscore_RendersEm()
+	{
+		var result = MarkdownParser.ToHtml("This is _italic_ text", DefaultOptions);
+		Assert.AreEqual("<p>This is <em>italic</em> text</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_InlineCode_RendersCodeTag()
+	{
+		var result = MarkdownParser.ToHtml("Use `var x = 1;` here", DefaultOptions);
+		Assert.AreEqual("<p>Use <code>var x = 1;</code> here</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Strikethrough_RendersSTag()
+	{
+		var result = MarkdownParser.ToHtml("This is ~~deleted~~ text", DefaultOptions);
+		Assert.AreEqual("<p>This is <s>deleted</s> text</p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Link_RendersAnchor()
+	{
+		var result = MarkdownParser.ToHtml("[Click here](https://example.com)", DefaultOptions);
+		Assert.AreEqual("<p><a href=\"https://example.com\">Click here</a></p>", result);
+	}
+
+	[TestMethod]
+	public void MarkdownParser_LinkWithTitle_RendersTitleAttribute()
+	{
+		var result = MarkdownParser.ToHtml("[Link](https://example.com \"My Title\")", DefaultOptions);
+		Assert.IsTrue(result.Contains("title=\"My Title\""));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_RendersImgTag()
+	{
+		var result = MarkdownParser.ToHtml("![Alt text](https://example.com/img.png)", DefaultOptions);
+		Assert.IsTrue(result.Contains("<img src=\"https://example.com/img.png\" alt=\"Alt text\""));
+		Assert.IsTrue(result.Contains("class=\"img-fluid\""));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_Image_CustomCssClass()
+	{
+		var options = new MarkdownRenderOptions { SanitizeHtml = true, ImageCssClass = "custom-img" };
+		var result = MarkdownParser.ToHtml("![Alt](url.png)", options);
+		Assert.IsTrue(result.Contains("class=\"custom-img\""));
+	}
+
+	#endregion
+
+	#region HTML Sanitization
+
+	[TestMethod]
+	public void MarkdownParser_SanitizeHtml_True_EscapesHtmlTags()
+	{
+		var options = new MarkdownRenderOptions { SanitizeHtml = true };
+		var result = MarkdownParser.ToHtml("<script>alert('xss')</script>", options);
+		Assert.IsTrue(result.Contains("&lt;script>"));
+		Assert.IsFalse(result.Contains("<script>"));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_SanitizeHtml_False_PreservesHtmlTags()
+	{
+		var options = new MarkdownRenderOptions { SanitizeHtml = false };
+		var result = MarkdownParser.ToHtml("<em>italic</em>", options);
+		Assert.IsTrue(result.Contains("<em>italic</em>"));
+	}
+
+	#endregion
+
+	#region Mixed Content
+
+	[TestMethod]
+	public void MarkdownParser_MixedContent_HeadingAndParagraph()
+	{
+		var markdown = "# Title\n\nSome text here.";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.IsTrue(result.StartsWith("<h1>Title</h1>"));
+		Assert.IsTrue(result.Contains("<p>Some text here.</p>"));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_MixedContent_ListFollowedByParagraph()
+	{
+		var markdown = "- Item 1\n- Item 2\n\nParagraph text.";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.IsTrue(result.Contains("<ul>"));
+		Assert.IsTrue(result.Contains("<p>Paragraph text.</p>"));
+	}
+
+	[TestMethod]
+	public void MarkdownParser_BoldAndItalicCombined()
+	{
+		var result = MarkdownParser.ToHtml("***bold and italic***", DefaultOptions);
+		// ** wraps *, so we get <strong><em>bold and italic</em></strong>
+		Assert.IsTrue(result.Contains("<strong>") && result.Contains("<em>"));
+	}
+
+	#endregion
+
+	#region Line Endings
+
+	[TestMethod]
+	public void MarkdownParser_CrLfLineEndings_ParsedCorrectly()
+	{
+		var markdown = "# Title\r\n\r\nParagraph text";
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.AreEqual("<h1>Title</h1><p>Paragraph text</p>", result);
+	}
+
+	#endregion
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/HxMarkdown.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/HxMarkdown.cs
@@ -93,17 +93,42 @@ public partial class HxMarkdown : ComponentBase
 	private bool HasWrapper => !string.IsNullOrEmpty(CssClassEffective) || (AdditionalAttributes is not null && AdditionalAttributes.Count > 0);
 
 	private string _renderedHtml;
+	private string _previousContent;
+	private bool _previousSanitizeHtml;
+	private string _previousTableCssClass;
+	private string _previousBlockquoteCssClass;
+	private string _previousImageCssClass;
 
 	protected override void OnParametersSet()
 	{
 		base.OnParametersSet();
 
+		var sanitize = SanitizeHtmlEffective;
+		var tableCss = TableCssClassEffective;
+		var blockquoteCss = BlockquoteCssClassEffective;
+		var imageCss = ImageCssClassEffective;
+
+		if (Content == _previousContent
+			&& sanitize == _previousSanitizeHtml
+			&& tableCss == _previousTableCssClass
+			&& blockquoteCss == _previousBlockquoteCssClass
+			&& imageCss == _previousImageCssClass)
+		{
+			return;
+		}
+
+		_previousContent = Content;
+		_previousSanitizeHtml = sanitize;
+		_previousTableCssClass = tableCss;
+		_previousBlockquoteCssClass = blockquoteCss;
+		_previousImageCssClass = imageCss;
+
 		var options = new MarkdownRenderOptions
 		{
-			SanitizeHtml = SanitizeHtmlEffective,
-			TableCssClass = TableCssClassEffective,
-			BlockquoteCssClass = BlockquoteCssClassEffective,
-			ImageCssClass = ImageCssClassEffective
+			SanitizeHtml = sanitize,
+			TableCssClass = tableCss,
+			BlockquoteCssClass = blockquoteCss,
+			ImageCssClass = imageCss
 		};
 
 		_renderedHtml = MarkdownParser.ToHtml(Content, options);

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/HxMarkdown.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/HxMarkdown.cs
@@ -47,7 +47,7 @@ public partial class HxMarkdown : ComponentBase
 	/// <summary>
 	/// Markdown text to render as HTML.
 	/// </summary>
-	[Parameter] public string Content { get; set; }
+	[Parameter, EditorRequired] public string Content { get; set; }
 
 	/// <summary>
 	/// When <c>true</c> (default), HTML tags in the input are escaped.

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/HxMarkdown.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/HxMarkdown.cs
@@ -1,0 +1,132 @@
+﻿using Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Renders Markdown content as HTML using Bootstrap typography.<br />
+/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxMarkdown">https://havit.blazor.eu/components/HxMarkdown</see>
+/// </summary>
+public partial class HxMarkdown : ComponentBase
+{
+	/// <summary>
+	/// Application-wide defaults for <see cref="HxMarkdown"/> and derived components.
+	/// </summary>
+	public static MarkdownSettings Defaults { get; set; }
+
+	static HxMarkdown()
+	{
+		Defaults = new MarkdownSettings()
+		{
+			SanitizeHtml = true,
+			CssClass = null,
+			TableCssClass = "table",
+			BlockquoteCssClass = "blockquote",
+			ImageCssClass = "img-fluid"
+		};
+	}
+
+	/// <summary>
+	/// Returns application-wide defaults for the component.
+	/// Enables overriding defaults in descendants (use a separate set of defaults).
+	/// </summary>
+	protected virtual MarkdownSettings GetDefaults() => Defaults;
+
+	/// <summary>
+	/// Set of settings to be applied to the component instance (overrides <see cref="Defaults"/>, overridden by individual parameters).
+	/// </summary>
+	[Parameter] public MarkdownSettings Settings { get; set; }
+
+	/// <summary>
+	/// Returns an optional set of component settings.
+	/// </summary>
+	/// <remarks>
+	/// Similar to <see cref="GetDefaults"/>, enables defining wider <see cref="Settings"/> in component descendants (by returning a derived settings class).
+	/// </remarks>
+	protected virtual MarkdownSettings GetSettings() => Settings;
+
+	/// <summary>
+	/// Markdown text to render as HTML.
+	/// </summary>
+	[Parameter] public string Content { get; set; }
+
+	/// <summary>
+	/// When <c>true</c> (default), HTML tags in the input are escaped.
+	/// When <c>false</c>, raw HTML in the input passes through to the output (use only with trusted content).
+	/// </summary>
+	[Parameter] public bool? SanitizeHtml { get; set; }
+	protected bool SanitizeHtmlEffective => SanitizeHtml ?? GetSettings()?.SanitizeHtml ?? GetDefaults().SanitizeHtml ?? true;
+
+	/// <summary>
+	/// CSS class for <c>&lt;table&gt;</c> elements rendered from markdown tables.
+	/// Default is <c>"table"</c> (Bootstrap table).
+	/// </summary>
+	[Parameter] public string TableCssClass { get; set; }
+	protected string TableCssClassEffective => TableCssClass ?? GetSettings()?.TableCssClass ?? GetDefaults().TableCssClass;
+
+	/// <summary>
+	/// CSS class for <c>&lt;blockquote&gt;</c> elements rendered from markdown blockquotes.
+	/// Default is <c>"blockquote"</c> (Bootstrap blockquote).
+	/// </summary>
+	[Parameter] public string BlockquoteCssClass { get; set; }
+	protected string BlockquoteCssClassEffective => BlockquoteCssClass ?? GetSettings()?.BlockquoteCssClass ?? GetDefaults().BlockquoteCssClass;
+
+	/// <summary>
+	/// CSS class for <c>&lt;img&gt;</c> elements rendered from markdown images.
+	/// Default is <c>"img-fluid"</c> (Bootstrap responsive image).
+	/// </summary>
+	[Parameter] public string ImageCssClass { get; set; }
+	protected string ImageCssClassEffective => ImageCssClass ?? GetSettings()?.ImageCssClass ?? GetDefaults().ImageCssClass;
+
+	/// <summary>
+	/// Any additional CSS class to apply to the wrapper element.
+	/// When set (or when <see cref="AdditionalAttributes"/> is used), the output is wrapped in a <c>&lt;div&gt;</c>.
+	/// </summary>
+	[Parameter] public string CssClass { get; set; }
+	protected string CssClassEffective => CssClass ?? GetSettings()?.CssClass ?? GetDefaults().CssClass;
+
+	/// <summary>
+	/// Additional attributes to be splatted onto the wrapper <c>&lt;div&gt;</c> element.
+	/// When set, the output is wrapped in a <c>&lt;div&gt;</c>.
+	/// </summary>
+	[Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+	private bool HasWrapper => !string.IsNullOrEmpty(CssClassEffective) || (AdditionalAttributes is not null && AdditionalAttributes.Count > 0);
+
+	private string _renderedHtml;
+
+	protected override void OnParametersSet()
+	{
+		base.OnParametersSet();
+
+		var options = new MarkdownRenderOptions
+		{
+			SanitizeHtml = SanitizeHtmlEffective,
+			TableCssClass = TableCssClassEffective,
+			BlockquoteCssClass = BlockquoteCssClassEffective,
+			ImageCssClass = ImageCssClassEffective
+		};
+
+		_renderedHtml = MarkdownParser.ToHtml(Content, options);
+	}
+
+	protected override void BuildRenderTree(RenderTreeBuilder builder)
+	{
+		if (string.IsNullOrEmpty(_renderedHtml))
+		{
+			return;
+		}
+
+		if (HasWrapper)
+		{
+			builder.OpenElement(0, "div");
+			builder.AddAttribute(1, "class", CssClassEffective);
+			builder.AddMultipleAttributes(2, AdditionalAttributes);
+			builder.AddMarkupContent(3, _renderedHtml);
+			builder.CloseElement();
+		}
+		else
+		{
+			builder.AddMarkupContent(0, _renderedHtml);
+		}
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownBlock.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownBlock.cs
@@ -1,0 +1,44 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+/// <summary>
+/// Represents a parsed block-level markdown element.
+/// </summary>
+internal enum MarkdownBlockType
+{
+	Paragraph,
+	Heading,
+	CodeBlock,
+	Blockquote,
+	UnorderedList,
+	OrderedList,
+	HorizontalRule,
+	Table
+}
+
+/// <summary>
+/// A single block-level element parsed from markdown.
+/// </summary>
+internal class MarkdownBlock
+{
+	public MarkdownBlockType Type { get; set; }
+
+	/// <summary>
+	/// Raw text lines of the block (before inline parsing).
+	/// </summary>
+	public List<string> Lines { get; set; } = new();
+
+	/// <summary>
+	/// Heading level (1-6). Only relevant for <see cref="MarkdownBlockType.Heading"/>.
+	/// </summary>
+	public int HeadingLevel { get; set; }
+
+	/// <summary>
+	/// Language hint for code blocks (e.g. "csharp"). Only relevant for <see cref="MarkdownBlockType.CodeBlock"/>.
+	/// </summary>
+	public string CodeLanguage { get; set; }
+
+	/// <summary>
+	/// Child blocks (e.g. list items contain paragraph blocks).
+	/// </summary>
+	public List<MarkdownBlock> Children { get; set; }
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownBlock.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownBlock.cs
@@ -1,21 +1,6 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
 
 /// <summary>
-/// Represents a parsed block-level markdown element.
-/// </summary>
-internal enum MarkdownBlockType
-{
-	Paragraph,
-	Heading,
-	CodeBlock,
-	Blockquote,
-	UnorderedList,
-	OrderedList,
-	HorizontalRule,
-	Table
-}
-
-/// <summary>
 /// A single block-level element parsed from markdown.
 /// </summary>
 internal class MarkdownBlock

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownBlockType.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownBlockType.cs
@@ -1,0 +1,16 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+/// <summary>
+/// Represents a parsed block-level markdown element.
+/// </summary>
+internal enum MarkdownBlockType
+{
+	Paragraph,
+	Heading,
+	CodeBlock,
+	Blockquote,
+	UnorderedList,
+	OrderedList,
+	HorizontalRule,
+	Table
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -44,17 +44,20 @@ internal static partial class MarkdownInlineParser
 			return string.Empty;
 		}
 
+		// Shared placeholder list — code spans, images and links are all replaced with
+		// placeholders so that subsequent emphasis/strikethrough passes cannot mangle them.
+		var placeholders = new List<string>();
+
 		// Step 1: Extract inline code spans and replace with placeholders.
 		// Code content is HTML-encoded (always, regardless of SanitizeHtml) and protected
 		// from all subsequent inline-element passes (bold, italic, links, etc.).
-		var codePlaceholders = new List<string>();
 		text = InlineCodeRegex().Replace(text, match =>
 		{
 			var code = match.Groups[1].Value;
 			// Always HTML-encode code content — code spans are always literal text.
 			var encoded = code.Replace("&", "&amp;").Replace("<", "&lt;");
-			var placeholder = $"\x00CODE{codePlaceholders.Count}\x00";
-			codePlaceholders.Add($"<code>{encoded}</code>");
+			var placeholder = $"\x00PH{placeholders.Count}\x00";
+			placeholders.Add($"<code>{encoded}</code>");
 			return placeholder;
 		});
 
@@ -74,29 +77,42 @@ internal static partial class MarkdownInlineParser
 			text = sanitized.ToString();
 		}
 
-		// Step 3: Process other inline elements in correct order:
-		// Images before links (image syntax contains link syntax)
-		// Bold before italic (** before *)
-		text = ProcessImages(text, options);
-		text = ProcessLinks(text, options);
+		// Step 3: Process images and links first. Generated HTML tags are replaced with
+		// placeholders so bold/italic/strikethrough cannot corrupt URLs or attributes.
+		text = ProcessImages(text, options, placeholders);
+		text = ProcessLinks(text, options, placeholders);
+
+		// Step 4: Emphasis and other inline elements (safe — HTML tags are placeholdered).
 		text = ProcessBold(text);
 		text = ProcessItalic(text);
 		text = ProcessStrikethrough(text);
 		text = ProcessLineBreaks(text);
 
-		// Step 4: Restore code span placeholders.
-		if (codePlaceholders.Count > 0)
+		// Step 5: Restore all placeholders.
+		for (int i = 0; i < placeholders.Count; i++)
 		{
-			for (int i = 0; i < codePlaceholders.Count; i++)
-			{
-				text = text.Replace($"\x00CODE{i}\x00", codePlaceholders[i]);
-			}
+			text = text.Replace($"\x00PH{i}\x00", placeholders[i]);
 		}
 
 		return text;
 	}
 
-	private static string ProcessImages(string text, MarkdownRenderOptions options)
+	/// <summary>
+	/// Encodes a value for safe use inside an HTML attribute (double-quoted).
+	/// When <paramref name="ampAlreadyEncoded"/> is true, <c>&amp;</c> is assumed to already
+	/// be encoded by an earlier sanitization pass (SanitizeHtml=true).
+	/// </summary>
+	private static string EncodeAttributeValue(string value, bool ampAlreadyEncoded)
+	{
+		if (!ampAlreadyEncoded)
+		{
+			value = value.Replace("&", "&amp;");
+		}
+		value = value.Replace("\"", "&quot;");
+		return value;
+	}
+
+	private static string ProcessImages(string text, MarkdownRenderOptions options, List<string> placeholders)
 	{
 		return ImageRegex().Replace(text, match =>
 		{
@@ -108,20 +124,24 @@ internal static partial class MarkdownInlineParser
 			{
 				url = "#";
 			}
-			// Always encode quotes in attribute values to produce valid HTML regardless of SanitizeHtml.
-			alt = alt.Replace("\"", "&quot;");
-			url = url.Replace("\"", "&quot;");
-			title = title.Replace("\"", "&quot;");
+			// Encode attribute values for valid HTML. When SanitizeHtml=true, & is already
+			// encoded in Step 2 so we skip it to avoid double-encoding.
+			alt = EncodeAttributeValue(alt, options.SanitizeHtml);
+			url = EncodeAttributeValue(url, options.SanitizeHtml);
+			title = EncodeAttributeValue(title, options.SanitizeHtml);
 
 			var cssClass = options.ImageCssClass;
 			var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
 			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
 
-			return $"<img src=\"{url}\" alt=\"{alt}\"{titleAttr}{classAttr} />";
+			var imgTag = $"<img src=\"{url}\" alt=\"{alt}\"{titleAttr}{classAttr} />";
+			var placeholder = $"\x00PH{placeholders.Count}\x00";
+			placeholders.Add(imgTag);
+			return placeholder;
 		});
 	}
 
-	private static string ProcessLinks(string text, MarkdownRenderOptions options)
+	private static string ProcessLinks(string text, MarkdownRenderOptions options, List<string> placeholders)
 	{
 		return LinkRegex().Replace(text, match =>
 		{
@@ -133,13 +153,17 @@ internal static partial class MarkdownInlineParser
 			{
 				url = "#";
 			}
-			// Always encode quotes in attribute values to produce valid HTML regardless of SanitizeHtml.
-			url = url.Replace("\"", "&quot;");
-			title = title.Replace("\"", "&quot;");
+			// Encode attribute values for valid HTML. When SanitizeHtml=true, & is already
+			// encoded in Step 2 so we skip it to avoid double-encoding.
+			url = EncodeAttributeValue(url, options.SanitizeHtml);
+			title = EncodeAttributeValue(title, options.SanitizeHtml);
 
 			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
 
-			return $"<a href=\"{url}\"{titleAttr}>{linkText}</a>";
+			var linkTag = $"<a href=\"{url}\"{titleAttr}>{linkText}</a>";
+			var placeholder = $"\x00PH{placeholders.Count}\x00";
+			placeholders.Add(linkTag);
+			return placeholder;
 		});
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -8,31 +8,31 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
 internal static partial class MarkdownInlineParser
 {
 	[GeneratedRegex(@"`([^`]+)`")]
-	private static partial Regex InlineCodeRegex { get; }
+	private static partial Regex InlineCodeRegex();
 
 	[GeneratedRegex(@"!\[([^\]]*)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)")]
-	private static partial Regex ImageRegex { get; }
+	private static partial Regex ImageRegex();
 
 	[GeneratedRegex(@"\[([^\]]+)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)")]
-	private static partial Regex LinkRegex { get; }
+	private static partial Regex LinkRegex();
 
 	[GeneratedRegex(@"\*\*(.+?)\*\*")]
-	private static partial Regex BoldAsteriskRegex { get; }
+	private static partial Regex BoldAsteriskRegex();
 
 	[GeneratedRegex(@"__(.+?)__")]
-	private static partial Regex BoldUnderscoreRegex { get; }
+	private static partial Regex BoldUnderscoreRegex();
 
 	[GeneratedRegex(@"\*(.+?)\*")]
-	private static partial Regex ItalicAsteriskRegex { get; }
+	private static partial Regex ItalicAsteriskRegex();
 
 	[GeneratedRegex(@"(?<!\w)_(.+?)_(?!\w)")]
-	private static partial Regex ItalicUnderscoreRegex { get; }
+	private static partial Regex ItalicUnderscoreRegex();
 
 	[GeneratedRegex(@"~~(.+?)~~")]
-	private static partial Regex StrikethroughRegex { get; }
+	private static partial Regex StrikethroughRegex();
 
 	[GeneratedRegex(@"  \n")]
-	private static partial Regex LineBreakRegex { get; }
+	private static partial Regex LineBreakRegex();
 
 	/// <summary>
 	/// Converts inline markdown syntax to HTML within a text block.
@@ -47,9 +47,19 @@ internal static partial class MarkdownInlineParser
 		// When sanitizing, encode only the HTML-dangerous characters (&lt; and &amp;)
 		// that don't conflict with markdown syntax. The " and > characters are safe
 		// in HTML text context and are needed for markdown link titles / blockquote syntax.
-		if (options.SanitizeHtml)
+		if (options.SanitizeHtml && text.AsSpan().IndexOfAny('&', '<') >= 0)
 		{
-			text = text.Replace("&", "&amp;").Replace("<", "&lt;");
+			var sanitized = new StringBuilder(text.Length);
+			foreach (var c in text)
+			{
+				switch (c)
+				{
+					case '&': sanitized.Append("&amp;"); break;
+					case '<': sanitized.Append("&lt;"); break;
+					default: sanitized.Append(c); break;
+				}
+			}
+			text = sanitized.ToString();
 		}
 
 		// Process inline elements in correct order:
@@ -72,7 +82,7 @@ internal static partial class MarkdownInlineParser
 
 	private static string ProcessInlineCode(string text)
 	{
-		return InlineCodeRegex.Replace(text, match =>
+		return InlineCodeRegex().Replace(text, match =>
 		{
 			var code = match.Groups[1].Value;
 			return $"<code>{code}</code>";
@@ -81,7 +91,7 @@ internal static partial class MarkdownInlineParser
 
 	private static string ProcessImages(string text, MarkdownRenderOptions options)
 	{
-		return ImageRegex.Replace(text, match =>
+		return ImageRegex().Replace(text, match =>
 		{
 			var alt = match.Groups[1].Value;
 			var url = match.Groups[2].Value;
@@ -97,7 +107,7 @@ internal static partial class MarkdownInlineParser
 
 	private static string ProcessLinks(string text)
 	{
-		return LinkRegex.Replace(text, match =>
+		return LinkRegex().Replace(text, match =>
 		{
 			var linkText = match.Groups[1].Value;
 			var url = match.Groups[2].Value;
@@ -111,26 +121,26 @@ internal static partial class MarkdownInlineParser
 
 	private static string ProcessBold(string text)
 	{
-		text = BoldAsteriskRegex.Replace(text, "<strong>$1</strong>");
-		text = BoldUnderscoreRegex.Replace(text, "<strong>$1</strong>");
+		text = BoldAsteriskRegex().Replace(text, "<strong>$1</strong>");
+		text = BoldUnderscoreRegex().Replace(text, "<strong>$1</strong>");
 		return text;
 	}
 
 	private static string ProcessItalic(string text)
 	{
-		text = ItalicAsteriskRegex.Replace(text, "<em>$1</em>");
-		text = ItalicUnderscoreRegex.Replace(text, "<em>$1</em>");
+		text = ItalicAsteriskRegex().Replace(text, "<em>$1</em>");
+		text = ItalicUnderscoreRegex().Replace(text, "<em>$1</em>");
 		return text;
 	}
 
 	private static string ProcessStrikethrough(string text)
 	{
-		return StrikethroughRegex.Replace(text, "<s>$1</s>");
+		return StrikethroughRegex().Replace(text, "<s>$1</s>");
 	}
 
 	private static string ProcessLineBreaks(string text)
 	{
-		text = LineBreakRegex.Replace(text, "<br />");
+		text = LineBreakRegex().Replace(text, "<br />");
 		text = text.Replace("\n", " ");
 		return text;
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -44,9 +44,21 @@ internal static partial class MarkdownInlineParser
 			return string.Empty;
 		}
 
-		// When sanitizing, encode only the HTML-dangerous characters (&lt; and &amp;)
-		// that don't conflict with markdown syntax. The " and > characters are safe
-		// in HTML text context and are needed for markdown link titles / blockquote syntax.
+		// Step 1: Extract inline code spans and replace with placeholders.
+		// Code content is HTML-encoded (always, regardless of SanitizeHtml) and protected
+		// from all subsequent inline-element passes (bold, italic, links, etc.).
+		var codePlaceholders = new List<string>();
+		text = InlineCodeRegex().Replace(text, match =>
+		{
+			var code = match.Groups[1].Value;
+			// Always HTML-encode code content — code spans are always literal text.
+			var encoded = code.Replace("&", "&amp;").Replace("<", "&lt;");
+			var placeholder = $"\x00CODE{codePlaceholders.Count}\x00";
+			codePlaceholders.Add($"<code>{encoded}</code>");
+			return placeholder;
+		});
+
+		// Step 2: Sanitize remaining text (& and < outside of code spans).
 		if (options.SanitizeHtml && text.AsSpan().IndexOfAny('&', '<') >= 0)
 		{
 			var sanitized = new StringBuilder(text.Length);
@@ -62,14 +74,9 @@ internal static partial class MarkdownInlineParser
 			text = sanitized.ToString();
 		}
 
-		// Process inline elements in correct order:
-		// 1. Inline code first (to protect content inside backticks from further processing)
-		// 2. Images before links (image syntax contains link syntax)
-		// 3. Bold before italic (** before *)
-		// 4. Strikethrough
-		// 5. Line breaks
-
-		text = ProcessInlineCode(text);
+		// Step 3: Process other inline elements in correct order:
+		// Images before links (image syntax contains link syntax)
+		// Bold before italic (** before *)
 		text = ProcessImages(text, options);
 		text = ProcessLinks(text, options);
 		text = ProcessBold(text);
@@ -77,16 +84,16 @@ internal static partial class MarkdownInlineParser
 		text = ProcessStrikethrough(text);
 		text = ProcessLineBreaks(text);
 
-		return text;
-	}
-
-	private static string ProcessInlineCode(string text)
-	{
-		return InlineCodeRegex().Replace(text, match =>
+		// Step 4: Restore code span placeholders.
+		if (codePlaceholders.Count > 0)
 		{
-			var code = match.Groups[1].Value;
-			return $"<code>{code}</code>";
-		});
+			for (int i = 0; i < codePlaceholders.Count; i++)
+			{
+				text = text.Replace($"\x00CODE{i}\x00", codePlaceholders[i]);
+			}
+		}
+
+		return text;
 	}
 
 	private static string ProcessImages(string text, MarkdownRenderOptions options)
@@ -145,24 +152,37 @@ internal static partial class MarkdownInlineParser
 			return true;
 		}
 
-		// Relative URLs are always safe (but not protocol-relative //host/path)
-		if (url[0] == '#' || (url[0] == '/' && (url.Length < 2 || url[1] != '/')))
+		// Protocol-relative URLs (//host/path) can be used for scheme-hijacking
+		if (url.StartsWith("//", StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		// Find first colon and first slash to distinguish scheme from path
+		var colonIndex = url.IndexOf(':');
+
+		// No colon → no scheme → safe relative URL (e.g., "page.html", "images/photo.png")
+		if (colonIndex < 0)
 		{
 			return true;
 		}
 
-		if (url.StartsWith("./", StringComparison.Ordinal) || url.StartsWith("../", StringComparison.Ordinal))
+		// A slash before the colon means the colon is inside a path segment, not a scheme
+		// (e.g., "/path/to/page:anchor" or "./dir/file:name")
+		var slashIndex = url.IndexOf('/');
+		if (slashIndex >= 0 && slashIndex < colonIndex)
 		{
 			return true;
 		}
 
-		// Only allow known-safe absolute URL schemes
-		return url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-			|| url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-			|| url.StartsWith("ftp://", StringComparison.OrdinalIgnoreCase)
-			|| url.StartsWith("ftps://", StringComparison.OrdinalIgnoreCase)
-			|| url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
-			|| url.StartsWith("tel:", StringComparison.OrdinalIgnoreCase);
+		// URL has a scheme — allow only the known-safe ones
+		var scheme = url.Substring(0, colonIndex);
+		return scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
+			|| scheme.Equals("https", StringComparison.OrdinalIgnoreCase)
+			|| scheme.Equals("ftp", StringComparison.OrdinalIgnoreCase)
+			|| scheme.Equals("ftps", StringComparison.OrdinalIgnoreCase)
+			|| scheme.Equals("mailto", StringComparison.OrdinalIgnoreCase)
+			|| scheme.Equals("tel", StringComparison.OrdinalIgnoreCase);
 	}
 
 	private static string ProcessBold(string text)

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -1,13 +1,39 @@
-﻿using System.Net;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
 
 /// <summary>
 /// Processes inline markdown elements (bold, italic, code, links, images, strikethrough, line breaks).
 /// </summary>
-internal static class MarkdownInlineParser
+internal static partial class MarkdownInlineParser
 {
+	[GeneratedRegex(@"`([^`]+)`")]
+	private static partial Regex InlineCodeRegex { get; }
+
+	[GeneratedRegex(@"!\[([^\]]*)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)")]
+	private static partial Regex ImageRegex { get; }
+
+	[GeneratedRegex(@"\[([^\]]+)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)")]
+	private static partial Regex LinkRegex { get; }
+
+	[GeneratedRegex(@"\*\*(.+?)\*\*")]
+	private static partial Regex BoldAsteriskRegex { get; }
+
+	[GeneratedRegex(@"__(.+?)__")]
+	private static partial Regex BoldUnderscoreRegex { get; }
+
+	[GeneratedRegex(@"\*(.+?)\*")]
+	private static partial Regex ItalicAsteriskRegex { get; }
+
+	[GeneratedRegex(@"(?<!\w)_(.+?)_(?!\w)")]
+	private static partial Regex ItalicUnderscoreRegex { get; }
+
+	[GeneratedRegex(@"~~(.+?)~~")]
+	private static partial Regex StrikethroughRegex { get; }
+
+	[GeneratedRegex(@"  \n")]
+	private static partial Regex LineBreakRegex { get; }
+
 	/// <summary>
 	/// Converts inline markdown syntax to HTML within a text block.
 	/// </summary>
@@ -46,8 +72,7 @@ internal static class MarkdownInlineParser
 
 	private static string ProcessInlineCode(string text)
 	{
-		// Match `code` - backtick-delimited inline code
-		return Regex.Replace(text, @"`([^`]+)`", match =>
+		return InlineCodeRegex.Replace(text, match =>
 		{
 			var code = match.Groups[1].Value;
 			return $"<code>{code}</code>";
@@ -56,8 +81,7 @@ internal static class MarkdownInlineParser
 
 	private static string ProcessImages(string text, MarkdownRenderOptions options)
 	{
-		// Match ![alt](url) or ![alt](url "title")
-		return Regex.Replace(text, @"!\[([^\]]*)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)", match =>
+		return ImageRegex.Replace(text, match =>
 		{
 			var alt = match.Groups[1].Value;
 			var url = match.Groups[2].Value;
@@ -73,8 +97,7 @@ internal static class MarkdownInlineParser
 
 	private static string ProcessLinks(string text)
 	{
-		// Match [text](url) or [text](url "title")
-		return Regex.Replace(text, @"\[([^\]]+)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)", match =>
+		return LinkRegex.Replace(text, match =>
 		{
 			var linkText = match.Groups[1].Value;
 			var url = match.Groups[2].Value;
@@ -88,31 +111,26 @@ internal static class MarkdownInlineParser
 
 	private static string ProcessBold(string text)
 	{
-		// **bold** and __bold__
-		text = Regex.Replace(text, @"\*\*(.+?)\*\*", "<strong>$1</strong>");
-		text = Regex.Replace(text, @"__(.+?)__", "<strong>$1</strong>");
+		text = BoldAsteriskRegex.Replace(text, "<strong>$1</strong>");
+		text = BoldUnderscoreRegex.Replace(text, "<strong>$1</strong>");
 		return text;
 	}
 
 	private static string ProcessItalic(string text)
 	{
-		// *italic* and _italic_ (but not inside words for _)
-		text = Regex.Replace(text, @"\*(.+?)\*", "<em>$1</em>");
-		text = Regex.Replace(text, @"(?<!\w)_(.+?)_(?!\w)", "<em>$1</em>");
+		text = ItalicAsteriskRegex.Replace(text, "<em>$1</em>");
+		text = ItalicUnderscoreRegex.Replace(text, "<em>$1</em>");
 		return text;
 	}
 
 	private static string ProcessStrikethrough(string text)
 	{
-		// ~~strikethrough~~
-		return Regex.Replace(text, @"~~(.+?)~~", "<s>$1</s>");
+		return StrikethroughRegex.Replace(text, "<s>$1</s>");
 	}
 
 	private static string ProcessLineBreaks(string text)
 	{
-		// Two spaces at end of line followed by newline = <br />
-		text = Regex.Replace(text, @"  \n", "<br />");
-		// Single newline within a paragraph = space (soft break)
+		text = LineBreakRegex.Replace(text, "<br />");
 		text = text.Replace("\n", " ");
 		return text;
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -71,7 +71,7 @@ internal static partial class MarkdownInlineParser
 
 		text = ProcessInlineCode(text);
 		text = ProcessImages(text, options);
-		text = ProcessLinks(text);
+		text = ProcessLinks(text, options);
 		text = ProcessBold(text);
 		text = ProcessItalic(text);
 		text = ProcessStrikethrough(text);
@@ -97,6 +97,16 @@ internal static partial class MarkdownInlineParser
 			var url = match.Groups[2].Value;
 			var title = match.Groups[3].Value;
 
+			if (options.SanitizeHtml)
+			{
+				alt = alt.Replace("\"", "&quot;");
+				title = title.Replace("\"", "&quot;");
+				if (!IsSafeUrl(url))
+				{
+					url = "#";
+				}
+			}
+
 			var cssClass = options.ImageCssClass;
 			var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
 			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
@@ -105,7 +115,7 @@ internal static partial class MarkdownInlineParser
 		});
 	}
 
-	private static string ProcessLinks(string text)
+	private static string ProcessLinks(string text, MarkdownRenderOptions options)
 	{
 		return LinkRegex().Replace(text, match =>
 		{
@@ -113,10 +123,46 @@ internal static partial class MarkdownInlineParser
 			var url = match.Groups[2].Value;
 			var title = match.Groups[3].Value;
 
+			if (options.SanitizeHtml)
+			{
+				title = title.Replace("\"", "&quot;");
+				if (!IsSafeUrl(url))
+				{
+					url = "#";
+				}
+			}
+
 			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
 
 			return $"<a href=\"{url}\"{titleAttr}>{linkText}</a>";
 		});
+	}
+
+	private static bool IsSafeUrl(string url)
+	{
+		if (string.IsNullOrEmpty(url))
+		{
+			return true;
+		}
+
+		// Relative URLs are always safe (but not protocol-relative //host/path)
+		if (url[0] == '#' || (url[0] == '/' && (url.Length < 2 || url[1] != '/')))
+		{
+			return true;
+		}
+
+		if (url.StartsWith("./", StringComparison.Ordinal) || url.StartsWith("../", StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		// Only allow known-safe absolute URL schemes
+		return url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+			|| url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+			|| url.StartsWith("ftp://", StringComparison.OrdinalIgnoreCase)
+			|| url.StartsWith("ftps://", StringComparison.OrdinalIgnoreCase)
+			|| url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+			|| url.StartsWith("tel:", StringComparison.OrdinalIgnoreCase);
 	}
 
 	private static string ProcessBold(string text)

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -106,13 +106,13 @@ internal static partial class MarkdownInlineParser
 
 			if (options.SanitizeHtml)
 			{
-				alt = alt.Replace("\"", "&quot;");
-				url = url.Replace("\"", "&quot;");
-				title = title.Replace("\"", "&quot;");
 				if (!IsSafeUrl(url))
 				{
 					url = "#";
 				}
+				alt = alt.Replace("\"", "&quot;");
+				url = url.Replace("\"", "&quot;");
+				title = title.Replace("\"", "&quot;");
 			}
 
 			var cssClass = options.ImageCssClass;
@@ -133,12 +133,12 @@ internal static partial class MarkdownInlineParser
 
 			if (options.SanitizeHtml)
 			{
-				url = url.Replace("\"", "&quot;");
-				title = title.Replace("\"", "&quot;");
 				if (!IsSafeUrl(url))
 				{
 					url = "#";
 				}
+				url = url.Replace("\"", "&quot;");
+				title = title.Replace("\"", "&quot;");
 			}
 
 			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -1,0 +1,119 @@
+﻿using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+/// <summary>
+/// Processes inline markdown elements (bold, italic, code, links, images, strikethrough, line breaks).
+/// </summary>
+internal static class MarkdownInlineParser
+{
+	/// <summary>
+	/// Converts inline markdown syntax to HTML within a text block.
+	/// </summary>
+	internal static string ProcessInlineElements(string text, MarkdownRenderOptions options)
+	{
+		if (string.IsNullOrEmpty(text))
+		{
+			return string.Empty;
+		}
+
+		// When sanitizing, encode only the HTML-dangerous characters (&lt; and &amp;)
+		// that don't conflict with markdown syntax. The " and > characters are safe
+		// in HTML text context and are needed for markdown link titles / blockquote syntax.
+		if (options.SanitizeHtml)
+		{
+			text = text.Replace("&", "&amp;").Replace("<", "&lt;");
+		}
+
+		// Process inline elements in correct order:
+		// 1. Inline code first (to protect content inside backticks from further processing)
+		// 2. Images before links (image syntax contains link syntax)
+		// 3. Bold before italic (** before *)
+		// 4. Strikethrough
+		// 5. Line breaks
+
+		text = ProcessInlineCode(text);
+		text = ProcessImages(text, options);
+		text = ProcessLinks(text);
+		text = ProcessBold(text);
+		text = ProcessItalic(text);
+		text = ProcessStrikethrough(text);
+		text = ProcessLineBreaks(text);
+
+		return text;
+	}
+
+	private static string ProcessInlineCode(string text)
+	{
+		// Match `code` - backtick-delimited inline code
+		return Regex.Replace(text, @"`([^`]+)`", match =>
+		{
+			var code = match.Groups[1].Value;
+			return $"<code>{code}</code>";
+		});
+	}
+
+	private static string ProcessImages(string text, MarkdownRenderOptions options)
+	{
+		// Match ![alt](url) or ![alt](url "title")
+		return Regex.Replace(text, @"!\[([^\]]*)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)", match =>
+		{
+			var alt = match.Groups[1].Value;
+			var url = match.Groups[2].Value;
+			var title = match.Groups[3].Value;
+
+			var cssClass = options.ImageCssClass;
+			var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
+			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
+
+			return $"<img src=\"{url}\" alt=\"{alt}\"{titleAttr}{classAttr} />";
+		});
+	}
+
+	private static string ProcessLinks(string text)
+	{
+		// Match [text](url) or [text](url "title")
+		return Regex.Replace(text, @"\[([^\]]+)\]\(([^\s\)]+)(?:\s+""([^""]*)"")?\)", match =>
+		{
+			var linkText = match.Groups[1].Value;
+			var url = match.Groups[2].Value;
+			var title = match.Groups[3].Value;
+
+			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
+
+			return $"<a href=\"{url}\"{titleAttr}>{linkText}</a>";
+		});
+	}
+
+	private static string ProcessBold(string text)
+	{
+		// **bold** and __bold__
+		text = Regex.Replace(text, @"\*\*(.+?)\*\*", "<strong>$1</strong>");
+		text = Regex.Replace(text, @"__(.+?)__", "<strong>$1</strong>");
+		return text;
+	}
+
+	private static string ProcessItalic(string text)
+	{
+		// *italic* and _italic_ (but not inside words for _)
+		text = Regex.Replace(text, @"\*(.+?)\*", "<em>$1</em>");
+		text = Regex.Replace(text, @"(?<!\w)_(.+?)_(?!\w)", "<em>$1</em>");
+		return text;
+	}
+
+	private static string ProcessStrikethrough(string text)
+	{
+		// ~~strikethrough~~
+		return Regex.Replace(text, @"~~(.+?)~~", "<s>$1</s>");
+	}
+
+	private static string ProcessLineBreaks(string text)
+	{
+		// Two spaces at end of line followed by newline = <br />
+		text = Regex.Replace(text, @"  \n", "<br />");
+		// Single newline within a paragraph = space (soft break)
+		text = text.Replace("\n", " ");
+		return text;
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -104,16 +104,14 @@ internal static partial class MarkdownInlineParser
 			var url = match.Groups[2].Value;
 			var title = match.Groups[3].Value;
 
-			if (options.SanitizeHtml)
+			if (options.SanitizeHtml && !IsSafeUrl(url))
 			{
-				if (!IsSafeUrl(url))
-				{
-					url = "#";
-				}
-				alt = alt.Replace("\"", "&quot;");
-				url = url.Replace("\"", "&quot;");
-				title = title.Replace("\"", "&quot;");
+				url = "#";
 			}
+			// Always encode quotes in attribute values to produce valid HTML regardless of SanitizeHtml.
+			alt = alt.Replace("\"", "&quot;");
+			url = url.Replace("\"", "&quot;");
+			title = title.Replace("\"", "&quot;");
 
 			var cssClass = options.ImageCssClass;
 			var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
@@ -131,15 +129,13 @@ internal static partial class MarkdownInlineParser
 			var url = match.Groups[2].Value;
 			var title = match.Groups[3].Value;
 
-			if (options.SanitizeHtml)
+			if (options.SanitizeHtml && !IsSafeUrl(url))
 			{
-				if (!IsSafeUrl(url))
-				{
-					url = "#";
-				}
-				url = url.Replace("\"", "&quot;");
-				title = title.Replace("\"", "&quot;");
+				url = "#";
 			}
+			// Always encode quotes in attribute values to produce valid HTML regardless of SanitizeHtml.
+			url = url.Replace("\"", "&quot;");
+			title = title.Replace("\"", "&quot;");
 
 			var titleAttr = !string.IsNullOrEmpty(title) ? $" title=\"{title}\"" : "";
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownInlineParser.cs
@@ -107,6 +107,7 @@ internal static partial class MarkdownInlineParser
 			if (options.SanitizeHtml)
 			{
 				alt = alt.Replace("\"", "&quot;");
+				url = url.Replace("\"", "&quot;");
 				title = title.Replace("\"", "&quot;");
 				if (!IsSafeUrl(url))
 				{
@@ -132,6 +133,7 @@ internal static partial class MarkdownInlineParser
 
 			if (options.SanitizeHtml)
 			{
+				url = url.Replace("\"", "&quot;");
 				title = title.Replace("\"", "&quot;");
 				if (!IsSafeUrl(url))
 				{

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -441,7 +441,8 @@ internal static partial class MarkdownParser
 
 				// Check for table start (| ... | followed by separator line).
 				// Must require trailing | to match TryParseTable's header-line check.
-				if (trimmedSpan.StartsWith("|") && trimmedSpan.EndsWith("|") && (i + 1 < lines.Length) && IsTableSeparator(lines[i + 1].Trim()))
+				// Use TrimEnd() so trailing whitespace doesn't prevent the match (TryParseTable uses Trim()).
+				if (trimmedSpan.StartsWith("|") && trimmedSpan.TrimEnd().EndsWith("|") && (i + 1 < lines.Length) && IsTableSeparator(lines[i + 1].Trim()))
 				{
 					break;
 				}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -6,8 +6,16 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
 /// <summary>
 /// Standalone markdown-to-HTML parser. Converts markdown text to HTML using Bootstrap typography classes.
 /// </summary>
-internal static class MarkdownParser
+internal static partial class MarkdownParser
 {
+	[GeneratedRegex(@"^:?-{1,}:?$")]
+	private static partial Regex TableSeparatorCellRegex { get; }
+
+	[GeneratedRegex(@"^\d+\.\s")]
+	private static partial Regex OrderedListItemRegex { get; }
+
+	[GeneratedRegex(@"^\d+\.\s(.*)$")]
+	private static partial Regex OrderedListItemContentRegex { get; }
 	/// <summary>
 	/// Converts markdown text to HTML.
 	/// </summary>
@@ -304,7 +312,7 @@ internal static class MarkdownParser
 		}
 		// Each cell should be like ---  or :--- or ---: or :---:
 		var cells = SplitTableRow(line);
-		return cells.All(c => Regex.IsMatch(c.Trim(), @"^:?-{1,}:?$"));
+		return cells.All(c => TableSeparatorCellRegex.IsMatch(c.Trim()));
 	}
 
 	private static bool IsUnorderedListItem(string line)
@@ -316,7 +324,7 @@ internal static class MarkdownParser
 	private static bool IsOrderedListItem(string line)
 	{
 		var trimmed = line.TrimStart();
-		return Regex.IsMatch(trimmed, @"^\d+\.\s");
+		return OrderedListItemRegex.IsMatch(trimmed);
 	}
 
 	private static MarkdownBlock ParseUnorderedList(List<string> lines, ref int i)
@@ -353,7 +361,7 @@ internal static class MarkdownParser
 		while (i < lines.Count && IsOrderedListItem(lines[i]))
 		{
 			var trimmed = lines[i].TrimStart();
-			var match = Regex.Match(trimmed, @"^\d+\.\s(.*)$");
+			var match = OrderedListItemContentRegex.Match(trimmed);
 			var content = match.Success ? match.Groups[1].Value : trimmed;
 			block.Children.Add(new MarkdownBlock
 			{

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -1,0 +1,571 @@
+﻿using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+/// <summary>
+/// Standalone markdown-to-HTML parser. Converts markdown text to HTML using Bootstrap typography classes.
+/// </summary>
+internal static class MarkdownParser
+{
+	/// <summary>
+	/// Converts markdown text to HTML.
+	/// </summary>
+	/// <param name="markdown">The markdown text to convert.</param>
+	/// <param name="options">Rendering options.</param>
+	/// <returns>HTML string.</returns>
+	internal static string ToHtml(string markdown, MarkdownRenderOptions options)
+	{
+		if (string.IsNullOrEmpty(markdown))
+		{
+			return string.Empty;
+		}
+
+		var lines = NormalizeLineEndings(markdown);
+		var blocks = ParseBlocks(lines, options.SanitizeHtml);
+		return RenderBlocks(blocks, options);
+	}
+
+	private static List<string> NormalizeLineEndings(string text)
+	{
+		return text.ReplaceLineEndings("\n").Split('\n').ToList();
+	}
+
+	#region Block-level parsing
+
+	private static List<MarkdownBlock> ParseBlocks(List<string> lines, bool sanitizeHtml)
+	{
+		var blocks = new List<MarkdownBlock>();
+		int i = 0;
+
+		while (i < lines.Count)
+		{
+			// Blank line – skip
+			if (string.IsNullOrWhiteSpace(lines[i]))
+			{
+				i++;
+				continue;
+			}
+
+			// Fenced code block (``` or ~~~)
+			if (TryParseCodeBlock(lines, ref i, out var codeBlock))
+			{
+				blocks.Add(codeBlock);
+				continue;
+			}
+
+			// Horizontal rule (---, ***, ___)
+			if (TryParseHorizontalRule(lines[i], out var hrBlock))
+			{
+				blocks.Add(hrBlock);
+				i++;
+				continue;
+			}
+
+			// Heading (# ... ######)
+			if (TryParseHeading(lines[i], out var headingBlock))
+			{
+				blocks.Add(headingBlock);
+				i++;
+				continue;
+			}
+
+			// Blockquote (> ...)
+			if (lines[i].TrimStart().StartsWith(">"))
+			{
+				var bqBlock = ParseBlockquote(lines, ref i);
+				blocks.Add(bqBlock);
+				continue;
+			}
+
+			// Table (| ... |)
+			if (TryParseTable(lines, ref i, out var tableBlock))
+			{
+				blocks.Add(tableBlock);
+				continue;
+			}
+
+			// Unordered list (- , * , + )
+			if (IsUnorderedListItem(lines[i]))
+			{
+				var listBlock = ParseUnorderedList(lines, ref i);
+				blocks.Add(listBlock);
+				continue;
+			}
+
+			// Ordered list (1. , 2. , etc.)
+			if (IsOrderedListItem(lines[i]))
+			{
+				var listBlock = ParseOrderedList(lines, ref i);
+				blocks.Add(listBlock);
+				continue;
+			}
+
+			// Paragraph (default)
+			var paraBlock = ParseParagraph(lines, ref i, sanitizeHtml);
+			blocks.Add(paraBlock);
+		}
+
+		return blocks;
+	}
+
+	private static bool TryParseCodeBlock(List<string> lines, ref int i, out MarkdownBlock block)
+	{
+		block = null;
+		var trimmed = lines[i].TrimStart();
+		string fence = null;
+
+		if (trimmed.StartsWith("```"))
+		{
+			fence = "```";
+		}
+		else if (trimmed.StartsWith("~~~"))
+		{
+			fence = "~~~";
+		}
+
+		if (fence == null)
+		{
+			return false;
+		}
+
+		var language = trimmed.Substring(fence.Length).Trim();
+		block = new MarkdownBlock
+		{
+			Type = MarkdownBlockType.CodeBlock,
+			CodeLanguage = string.IsNullOrEmpty(language) ? null : language
+		};
+
+		i++; // skip opening fence
+		while (i < lines.Count)
+		{
+			var currentTrimmed = lines[i].TrimStart();
+			if (currentTrimmed.StartsWith(fence.Substring(0, 3)) && currentTrimmed.Trim().Length <= fence.Length + 3 && currentTrimmed.Trim().All(c => c == fence[0]))
+			{
+				i++; // skip closing fence
+				break;
+			}
+			block.Lines.Add(lines[i]);
+			i++;
+		}
+
+		return true;
+	}
+
+	private static bool TryParseHorizontalRule(string line, out MarkdownBlock block)
+	{
+		block = null;
+		var trimmed = line.Trim();
+
+		if (trimmed.Length < 3)
+		{
+			return false;
+		}
+
+		// Must be 3+ of the same char (-, *, _) with optional spaces
+		var withoutSpaces = trimmed.Replace(" ", "");
+		if (withoutSpaces.Length >= 3 && withoutSpaces.All(c => c == '-'))
+		{
+			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
+			return true;
+		}
+		if (withoutSpaces.Length >= 3 && withoutSpaces.All(c => c == '*'))
+		{
+			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
+			return true;
+		}
+		if (withoutSpaces.Length >= 3 && withoutSpaces.All(c => c == '_'))
+		{
+			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
+			return true;
+		}
+
+		return false;
+	}
+
+	private static bool TryParseHeading(string line, out MarkdownBlock block)
+	{
+		block = null;
+		var trimmed = line.TrimStart();
+
+		if (!trimmed.StartsWith("#"))
+		{
+			return false;
+		}
+
+		int level = 0;
+		while (level < trimmed.Length && level < 6 && trimmed[level] == '#')
+		{
+			level++;
+		}
+
+		// Must have a space after # (or be just #'s followed by nothing)
+		if (level < trimmed.Length && trimmed[level] != ' ')
+		{
+			return false;
+		}
+
+		var content = trimmed.Substring(level).Trim();
+		// Remove trailing #'s (optional closing)
+		content = content.TrimEnd('#').TrimEnd();
+
+		block = new MarkdownBlock
+		{
+			Type = MarkdownBlockType.Heading,
+			HeadingLevel = level,
+			Lines = { content }
+		};
+		return true;
+	}
+
+	private static MarkdownBlock ParseBlockquote(List<string> lines, ref int i)
+	{
+		var block = new MarkdownBlock { Type = MarkdownBlockType.Blockquote };
+
+		while (i < lines.Count)
+		{
+			var trimmed = lines[i].TrimStart();
+			if (trimmed.StartsWith(">"))
+			{
+				// Remove leading > and optional space
+				var content = trimmed.Substring(1);
+				if (content.StartsWith(" "))
+				{
+					content = content.Substring(1);
+				}
+				block.Lines.Add(content);
+				i++;
+			}
+			else if (string.IsNullOrWhiteSpace(lines[i]))
+			{
+				break;
+			}
+			else
+			{
+				// continuation line in same blockquote
+				block.Lines.Add(lines[i]);
+				i++;
+			}
+		}
+
+		return block;
+	}
+
+	private static bool TryParseTable(List<string> lines, ref int i, out MarkdownBlock block)
+	{
+		block = null;
+
+		// Need at least header + separator + one data row
+		if (i + 1 >= lines.Count)
+		{
+			return false;
+		}
+
+		var headerLine = lines[i].Trim();
+		if (!headerLine.StartsWith("|") || !headerLine.EndsWith("|"))
+		{
+			return false;
+		}
+
+		// Check second line is separator (|---|---|)
+		var separatorLine = lines[i + 1].Trim();
+		if (!IsTableSeparator(separatorLine))
+		{
+			return false;
+		}
+
+		block = new MarkdownBlock { Type = MarkdownBlockType.Table };
+		block.Lines.Add(headerLine);
+		block.Lines.Add(separatorLine);
+		i += 2;
+
+		while (i < lines.Count)
+		{
+			var trimmed = lines[i].Trim();
+			if (trimmed.StartsWith("|"))
+			{
+				block.Lines.Add(trimmed);
+				i++;
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		return true;
+	}
+
+	private static bool IsTableSeparator(string line)
+	{
+		if (!line.StartsWith("|"))
+		{
+			return false;
+		}
+		// Each cell should be like ---  or :--- or ---: or :---:
+		var cells = SplitTableRow(line);
+		return cells.All(c => Regex.IsMatch(c.Trim(), @"^:?-{1,}:?$"));
+	}
+
+	private static bool IsUnorderedListItem(string line)
+	{
+		var trimmed = line.TrimStart();
+		return (trimmed.StartsWith("- ") || trimmed.StartsWith("* ") || trimmed.StartsWith("+ "));
+	}
+
+	private static bool IsOrderedListItem(string line)
+	{
+		var trimmed = line.TrimStart();
+		return Regex.IsMatch(trimmed, @"^\d+\.\s");
+	}
+
+	private static MarkdownBlock ParseUnorderedList(List<string> lines, ref int i)
+	{
+		var block = new MarkdownBlock
+		{
+			Type = MarkdownBlockType.UnorderedList,
+			Children = new List<MarkdownBlock>()
+		};
+
+		while (i < lines.Count && IsUnorderedListItem(lines[i]))
+		{
+			var trimmed = lines[i].TrimStart();
+			var content = trimmed.Substring(2); // skip "- ", "* ", "+ "
+			block.Children.Add(new MarkdownBlock
+			{
+				Type = MarkdownBlockType.Paragraph,
+				Lines = { content }
+			});
+			i++;
+		}
+
+		return block;
+	}
+
+	private static MarkdownBlock ParseOrderedList(List<string> lines, ref int i)
+	{
+		var block = new MarkdownBlock
+		{
+			Type = MarkdownBlockType.OrderedList,
+			Children = new List<MarkdownBlock>()
+		};
+
+		while (i < lines.Count && IsOrderedListItem(lines[i]))
+		{
+			var trimmed = lines[i].TrimStart();
+			var match = Regex.Match(trimmed, @"^\d+\.\s(.*)$");
+			var content = match.Success ? match.Groups[1].Value : trimmed;
+			block.Children.Add(new MarkdownBlock
+			{
+				Type = MarkdownBlockType.Paragraph,
+				Lines = { content }
+			});
+			i++;
+		}
+
+		return block;
+	}
+
+	private static MarkdownBlock ParseParagraph(List<string> lines, ref int i, bool sanitizeHtml)
+	{
+		var block = new MarkdownBlock { Type = MarkdownBlockType.Paragraph };
+
+		while (i < lines.Count && !string.IsNullOrWhiteSpace(lines[i]))
+		{
+			// Stop if next line looks like a different block type
+			if (lines[i].TrimStart().StartsWith("#")
+				|| lines[i].TrimStart().StartsWith(">")
+				|| lines[i].TrimStart().StartsWith("```")
+				|| lines[i].TrimStart().StartsWith("~~~")
+				|| IsUnorderedListItem(lines[i])
+				|| IsOrderedListItem(lines[i]))
+			{
+				// Check for HR
+				if (TryParseHorizontalRule(lines[i], out _))
+				{
+					break;
+				}
+				break;
+			}
+
+			// Check for HR within paragraph
+			if (TryParseHorizontalRule(lines[i], out _))
+			{
+				break;
+			}
+
+			block.Lines.Add(lines[i]);
+			i++;
+		}
+
+		return block;
+	}
+
+	#endregion
+
+	#region Rendering
+
+	private static string RenderBlocks(List<MarkdownBlock> blocks, MarkdownRenderOptions options)
+	{
+		var sb = new StringBuilder();
+
+		for (int i = 0; i < blocks.Count; i++)
+		{
+			RenderBlock(sb, blocks[i], options);
+		}
+
+		return sb.ToString().TrimEnd('\n');
+	}
+
+	private static void RenderBlock(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		switch (block.Type)
+		{
+			case MarkdownBlockType.Heading:
+				RenderHeading(sb, block, options);
+				break;
+			case MarkdownBlockType.CodeBlock:
+				RenderCodeBlock(sb, block, options);
+				break;
+			case MarkdownBlockType.Blockquote:
+				RenderBlockquote(sb, block, options);
+				break;
+			case MarkdownBlockType.UnorderedList:
+				RenderUnorderedList(sb, block, options);
+				break;
+			case MarkdownBlockType.OrderedList:
+				RenderOrderedList(sb, block, options);
+				break;
+			case MarkdownBlockType.HorizontalRule:
+				sb.Append("<hr />");
+				break;
+			case MarkdownBlockType.Table:
+				RenderTable(sb, block, options);
+				break;
+			case MarkdownBlockType.Paragraph:
+				RenderParagraph(sb, block, options);
+				break;
+		}
+	}
+
+	private static void RenderHeading(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		var tag = $"h{block.HeadingLevel}";
+		var content = MarkdownInlineParser.ProcessInlineElements(JoinLines(block.Lines), options);
+		sb.Append($"<{tag}>{content}</{tag}>");
+	}
+
+	private static void RenderCodeBlock(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		var code = WebUtility.HtmlEncode(string.Join("\n", block.Lines));
+		if (!string.IsNullOrEmpty(block.CodeLanguage))
+		{
+			sb.Append($"<pre><code class=\"language-{WebUtility.HtmlEncode(block.CodeLanguage)}\">{code}</code></pre>");
+		}
+		else
+		{
+			sb.Append($"<pre><code>{code}</code></pre>");
+		}
+	}
+
+	private static void RenderBlockquote(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		var cssClass = options.BlockquoteCssClass;
+		var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
+		var innerContent = MarkdownInlineParser.ProcessInlineElements(JoinLines(block.Lines), options);
+		sb.Append($"<blockquote{classAttr}><p>{innerContent}</p></blockquote>");
+	}
+
+	private static void RenderUnorderedList(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		sb.Append("<ul>");
+		foreach (var child in block.Children)
+		{
+			var content = MarkdownInlineParser.ProcessInlineElements(JoinLines(child.Lines), options);
+			sb.Append($"<li>{content}</li>");
+		}
+		sb.Append("</ul>");
+	}
+
+	private static void RenderOrderedList(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		sb.Append("<ol>");
+		foreach (var child in block.Children)
+		{
+			var content = MarkdownInlineParser.ProcessInlineElements(JoinLines(child.Lines), options);
+			sb.Append($"<li>{content}</li>");
+		}
+		sb.Append("</ol>");
+	}
+
+	private static void RenderTable(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		if (block.Lines.Count < 2)
+		{
+			return;
+		}
+
+		var cssClass = options.TableCssClass;
+		var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
+
+		sb.Append($"<table{classAttr}>");
+
+		// Header row
+		var headerCells = SplitTableRow(block.Lines[0]);
+		sb.Append("<thead><tr>");
+		foreach (var cell in headerCells)
+		{
+			var content = MarkdownInlineParser.ProcessInlineElements(cell.Trim(), options);
+			sb.Append($"<th>{content}</th>");
+		}
+		sb.Append("</tr></thead>");
+
+		// Data rows (skip line 0 = header, line 1 = separator)
+		if (block.Lines.Count > 2)
+		{
+			sb.Append("<tbody>");
+			for (int r = 2; r < block.Lines.Count; r++)
+			{
+				var cells = SplitTableRow(block.Lines[r]);
+				sb.Append("<tr>");
+				foreach (var cell in cells)
+				{
+					var content = MarkdownInlineParser.ProcessInlineElements(cell.Trim(), options);
+					sb.Append($"<td>{content}</td>");
+				}
+				sb.Append("</tr>");
+			}
+			sb.Append("</tbody>");
+		}
+
+		sb.Append("</table>");
+	}
+
+	private static void RenderParagraph(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
+	{
+		var content = MarkdownInlineParser.ProcessInlineElements(JoinLines(block.Lines), options);
+		sb.Append($"<p>{content}</p>");
+	}
+
+	private static string JoinLines(List<string> lines)
+	{
+		return string.Join("\n", lines);
+	}
+
+	private static List<string> SplitTableRow(string row)
+	{
+		// Remove leading/trailing |
+		var trimmed = row.Trim();
+		if (trimmed.StartsWith("|"))
+		{
+			trimmed = trimmed.Substring(1);
+		}
+		if (trimmed.EndsWith("|"))
+		{
+			trimmed = trimmed.Substring(0, trimmed.Length - 1);
+		}
+		return trimmed.Split('|').ToList();
+	}
+
+	#endregion
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -339,6 +339,22 @@ internal static partial class MarkdownParser
 		return trimmed.StartsWith("- ") || trimmed.StartsWith("* ") || trimmed.StartsWith("+ ");
 	}
 
+	private static bool IsHeadingStart(ReadOnlySpan<char> line)
+	{
+		var trimmed = line.TrimStart();
+		if (!trimmed.StartsWith("#"))
+		{
+			return false;
+		}
+		int level = 0;
+		while (level < trimmed.Length && level < 6 && trimmed[level] == '#')
+		{
+			level++;
+		}
+		// Valid heading: # followed by space or end of line
+		return level >= trimmed.Length || trimmed[level] == ' ';
+	}
+
 	private static bool IsOrderedListItem(ReadOnlySpan<char> line)
 	{
 		var trimmed = line.TrimStart();
@@ -396,29 +412,43 @@ internal static partial class MarkdownParser
 	{
 		var block = new MarkdownBlock { Type = MarkdownBlockType.Paragraph };
 
+		// The first line is guaranteed by ParseBlocks to not match any other block parser,
+		// so we always consume it. Break checks only apply to continuation lines (2nd+).
+		bool isFirstLine = true;
+
 		while (i < lines.Length && !string.IsNullOrWhiteSpace(lines[i]))
 		{
-			var trimmedSpan = lines[i].AsSpan().TrimStart();
-
-			// Stop if next line looks like a different block type
-			if (trimmedSpan.StartsWith("#")
-				|| trimmedSpan.StartsWith(">")
-				|| trimmedSpan.StartsWith("```")
-				|| trimmedSpan.StartsWith("~~~")
-				|| IsUnorderedListItem(trimmedSpan)
-				|| IsOrderedListItem(trimmedSpan))
+			if (!isFirstLine)
 			{
-				break;
-			}
+				var trimmedSpan = lines[i].AsSpan().TrimStart();
 
-			// Check for HR within paragraph (--- doesn't match any prefix above)
-			if (TryParseHorizontalRule(lines[i], out _))
-			{
-				break;
+				// Stop if continuation line looks like a different block type
+				if (trimmedSpan.StartsWith(">")
+					|| trimmedSpan.StartsWith("```")
+					|| trimmedSpan.StartsWith("~~~")
+					|| IsUnorderedListItem(trimmedSpan)
+					|| IsOrderedListItem(trimmedSpan)
+					|| IsHeadingStart(trimmedSpan))
+				{
+					break;
+				}
+
+				// Check for HR within paragraph
+				if (TryParseHorizontalRule(lines[i], out _))
+				{
+					break;
+				}
+
+				// Check for table start (| ... | followed by separator line)
+				if (trimmedSpan.StartsWith("|") && (i + 1 < lines.Length) && IsTableSeparator(lines[i + 1].Trim()))
+				{
+					break;
+				}
 			}
 
 			block.Lines.Add(lines[i]);
 			i++;
+			isFirstLine = false;
 		}
 
 		return block;

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -121,23 +121,29 @@ internal static partial class MarkdownParser
 	{
 		block = null;
 		var trimmed = lines[i].TrimStart();
-		string fence = null;
+		char fenceChar;
 
 		if (trimmed.StartsWith("```"))
 		{
-			fence = "```";
+			fenceChar = '`';
 		}
 		else if (trimmed.StartsWith("~~~"))
 		{
-			fence = "~~~";
+			fenceChar = '~';
 		}
-
-		if (fence == null)
+		else
 		{
 			return false;
 		}
 
-		var language = trimmed.Substring(fence.Length).Trim();
+		// Count the actual opening fence length (CommonMark: >= 3 of the same char)
+		int fenceLength = 0;
+		while (fenceLength < trimmed.Length && trimmed[fenceLength] == fenceChar)
+		{
+			fenceLength++;
+		}
+
+		var language = trimmed.Substring(fenceLength).Trim();
 		block = new MarkdownBlock
 		{
 			Type = MarkdownBlockType.CodeBlock,
@@ -147,8 +153,9 @@ internal static partial class MarkdownParser
 		i++; // skip opening fence
 		while (i < lines.Length)
 		{
-			var currentTrimmed = lines[i].TrimStart();
-			if (currentTrimmed.StartsWith(fence.Substring(0, 3)) && currentTrimmed.Trim().Length <= fence.Length + 3 && currentTrimmed.Trim().All(c => c == fence[0]))
+			var currentTrimmed = lines[i].Trim();
+			// Closing fence: same char only, length >= opening fence length (CommonMark)
+			if (currentTrimmed.Length >= fenceLength && currentTrimmed.All(c => c == fenceChar))
 			{
 				i++; // skip closing fence
 				break;

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -439,8 +439,9 @@ internal static partial class MarkdownParser
 					break;
 				}
 
-				// Check for table start (| ... | followed by separator line)
-				if (trimmedSpan.StartsWith("|") && (i + 1 < lines.Length) && IsTableSeparator(lines[i + 1].Trim()))
+				// Check for table start (| ... | followed by separator line).
+				// Must require trailing | to match TryParseTable's header-line check.
+				if (trimmedSpan.StartsWith("|") && trimmedSpan.EndsWith("|") && (i + 1 < lines.Length) && IsTableSeparator(lines[i + 1].Trim()))
 				{
 					break;
 				}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -30,7 +30,7 @@ internal static partial class MarkdownParser
 		}
 
 		var lines = NormalizeLineEndings(markdown);
-		var blocks = ParseBlocks(lines, options.SanitizeHtml);
+		var blocks = ParseBlocks(lines);
 		return RenderBlocks(blocks, options);
 	}
 
@@ -41,7 +41,7 @@ internal static partial class MarkdownParser
 
 	#region Block-level parsing
 
-	private static List<MarkdownBlock> ParseBlocks(string[] lines, bool sanitizeHtml)
+	private static List<MarkdownBlock> ParseBlocks(string[] lines)
 	{
 		var blocks = new List<MarkdownBlock>();
 		int i = 0;
@@ -110,7 +110,7 @@ internal static partial class MarkdownParser
 			}
 
 			// Paragraph (default)
-			var paraBlock = ParseParagraph(lines, ref i, sanitizeHtml);
+			var paraBlock = ParseParagraph(lines, ref i);
 			blocks.Add(paraBlock);
 		}
 
@@ -504,7 +504,7 @@ internal static partial class MarkdownParser
 		var cssClass = options.BlockquoteCssClass;
 		var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
 		// Recursively parse the blockquote's inner lines so nested blockquotes (>> ...) are rendered correctly.
-		var innerBlocks = ParseBlocks(block.Lines.ToArray(), options.SanitizeHtml);
+		var innerBlocks = ParseBlocks(block.Lines.ToArray());
 		var innerHtml = RenderBlocks(innerBlocks, options);
 		sb.Append($"<blockquote{classAttr}>{innerHtml}</blockquote>");
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -394,6 +394,11 @@ internal static partial class MarkdownParser
 
 	private static MarkdownBlock ParseParagraph(string[] lines, ref int i, bool sanitizeHtml)
 	{
+		return ParseParagraph(lines, ref i);
+	}
+
+	private static MarkdownBlock ParseParagraph(string[] lines, ref int i)
+	{
 		var block = new MarkdownBlock { Type = MarkdownBlockType.Paragraph };
 
 		while (i < lines.Length && !string.IsNullOrWhiteSpace(lines[i]))

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -548,13 +548,18 @@ internal static partial class MarkdownParser
 
 		sb.Append($"<table{classAttr}>");
 
+		// Parse column alignments from separator row (line 1)
+		var alignments = GetColumnAlignments(block.Lines[1]);
+
 		// Header row
 		var headerCells = SplitTableRow(block.Lines[0]);
 		sb.Append("<thead><tr>");
-		foreach (var cell in headerCells)
+		for (int c = 0; c < headerCells.Length; c++)
 		{
-			var content = MarkdownInlineParser.ProcessInlineElements(cell.Trim(), options);
-			sb.Append($"<th>{content}</th>");
+			var content = MarkdownInlineParser.ProcessInlineElements(headerCells[c].Trim(), options);
+			var align = c < alignments.Length ? alignments[c] : null;
+			var styleAttr = align != null ? $" style=\"text-align:{align}\"" : "";
+			sb.Append($"<th{styleAttr}>{content}</th>");
 		}
 		sb.Append("</tr></thead>");
 
@@ -566,10 +571,12 @@ internal static partial class MarkdownParser
 			{
 				var cells = SplitTableRow(block.Lines[r]);
 				sb.Append("<tr>");
-				foreach (var cell in cells)
+				for (int c = 0; c < cells.Length; c++)
 				{
-					var content = MarkdownInlineParser.ProcessInlineElements(cell.Trim(), options);
-					sb.Append($"<td>{content}</td>");
+					var content = MarkdownInlineParser.ProcessInlineElements(cells[c].Trim(), options);
+					var align = c < alignments.Length ? alignments[c] : null;
+					var styleAttr = align != null ? $" style=\"text-align:{align}\"" : "";
+					sb.Append($"<td{styleAttr}>{content}</td>");
 				}
 				sb.Append("</tr>");
 			}
@@ -577,6 +584,38 @@ internal static partial class MarkdownParser
 		}
 
 		sb.Append("</table>");
+	}
+
+	/// <summary>
+	/// Parses the separator row and returns the text-align value for each column, or null when no alignment is specified.
+	/// </summary>
+	private static string[] GetColumnAlignments(string separatorLine)
+	{
+		var cells = SplitTableRow(separatorLine);
+		var alignments = new string[cells.Length];
+		for (int i = 0; i < cells.Length; i++)
+		{
+			var cell = cells[i].Trim();
+			var left = cell.StartsWith(':');
+			var right = cell.EndsWith(':');
+			if (left && right)
+			{
+				alignments[i] = "center";
+			}
+			else if (right)
+			{
+				alignments[i] = "right";
+			}
+			else if (left)
+			{
+				alignments[i] = "left";
+			}
+			else
+			{
+				alignments[i] = null;
+			}
+		}
+		return alignments;
 	}
 
 	private static void RenderParagraph(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -508,8 +508,10 @@ internal static partial class MarkdownParser
 	{
 		var cssClass = options.BlockquoteCssClass;
 		var classAttr = !string.IsNullOrEmpty(cssClass) ? $" class=\"{cssClass}\"" : "";
-		var innerContent = MarkdownInlineParser.ProcessInlineElements(JoinLines(block.Lines), options);
-		sb.Append($"<blockquote{classAttr}><p>{innerContent}</p></blockquote>");
+		// Recursively parse the blockquote's inner lines so nested blockquotes (>> ...) are rendered correctly.
+		var innerBlocks = ParseBlocks(block.Lines.ToArray(), options.SanitizeHtml);
+		var innerHtml = RenderBlocks(innerBlocks, options);
+		sb.Append($"<blockquote{classAttr}>{innerHtml}</blockquote>");
 	}
 
 	private static void RenderUnorderedList(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -392,11 +392,6 @@ internal static partial class MarkdownParser
 		return block;
 	}
 
-	private static MarkdownBlock ParseParagraph(string[] lines, ref int i, bool sanitizeHtml)
-	{
-		return ParseParagraph(lines, ref i);
-	}
-
 	private static MarkdownBlock ParseParagraph(string[] lines, ref int i)
 	{
 		var block = new MarkdownBlock { Type = MarkdownBlockType.Paragraph };

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -281,7 +281,7 @@ internal static partial class MarkdownParser
 	{
 		block = null;
 
-		// Need at least header + separator + one data row
+		// Need at least header + separator; data rows are optional
 		if (i + 1 >= lines.Length)
 		{
 			return false;

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -9,13 +9,13 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
 internal static partial class MarkdownParser
 {
 	[GeneratedRegex(@"^:?-{1,}:?$")]
-	private static partial Regex TableSeparatorCellRegex { get; }
+	private static partial Regex TableSeparatorCellRegex();
 
 	[GeneratedRegex(@"^\d+\.\s")]
-	private static partial Regex OrderedListItemRegex { get; }
+	private static partial Regex OrderedListItemRegex();
 
 	[GeneratedRegex(@"^\d+\.\s(.*)$")]
-	private static partial Regex OrderedListItemContentRegex { get; }
+	private static partial Regex OrderedListItemContentRegex();
 	/// <summary>
 	/// Converts markdown text to HTML.
 	/// </summary>
@@ -34,19 +34,19 @@ internal static partial class MarkdownParser
 		return RenderBlocks(blocks, options);
 	}
 
-	private static List<string> NormalizeLineEndings(string text)
+	private static string[] NormalizeLineEndings(string text)
 	{
-		return text.ReplaceLineEndings("\n").Split('\n').ToList();
+		return text.ReplaceLineEndings("\n").Split('\n');
 	}
 
 	#region Block-level parsing
 
-	private static List<MarkdownBlock> ParseBlocks(List<string> lines, bool sanitizeHtml)
+	private static List<MarkdownBlock> ParseBlocks(string[] lines, bool sanitizeHtml)
 	{
 		var blocks = new List<MarkdownBlock>();
 		int i = 0;
 
-		while (i < lines.Count)
+		while (i < lines.Length)
 		{
 			// Blank line – skip
 			if (string.IsNullOrWhiteSpace(lines[i]))
@@ -79,7 +79,7 @@ internal static partial class MarkdownParser
 			}
 
 			// Blockquote (> ...)
-			if (lines[i].TrimStart().StartsWith(">"))
+			if (lines[i].AsSpan().TrimStart().StartsWith(">"))
 			{
 				var bqBlock = ParseBlockquote(lines, ref i);
 				blocks.Add(bqBlock);
@@ -117,7 +117,7 @@ internal static partial class MarkdownParser
 		return blocks;
 	}
 
-	private static bool TryParseCodeBlock(List<string> lines, ref int i, out MarkdownBlock block)
+	private static bool TryParseCodeBlock(string[] lines, ref int i, out MarkdownBlock block)
 	{
 		block = null;
 		var trimmed = lines[i].TrimStart();
@@ -145,7 +145,7 @@ internal static partial class MarkdownParser
 		};
 
 		i++; // skip opening fence
-		while (i < lines.Count)
+		while (i < lines.Length)
 		{
 			var currentTrimmed = lines[i].TrimStart();
 			if (currentTrimmed.StartsWith(fence.Substring(0, 3)) && currentTrimmed.Trim().Length <= fence.Length + 3 && currentTrimmed.Trim().All(c => c == fence[0]))
@@ -160,7 +160,7 @@ internal static partial class MarkdownParser
 		return true;
 	}
 
-	private static bool TryParseHorizontalRule(string line, out MarkdownBlock block)
+	private static bool TryParseHorizontalRule(ReadOnlySpan<char> line, out MarkdownBlock block)
 	{
 		block = null;
 		var trimmed = line.Trim();
@@ -170,24 +170,35 @@ internal static partial class MarkdownParser
 			return false;
 		}
 
-		// Must be 3+ of the same char (-, *, _) with optional spaces
-		var withoutSpaces = trimmed.Replace(" ", "");
-		if (withoutSpaces.Length >= 3 && withoutSpaces.All(c => c == '-'))
+		// Must be 3+ of the same char (-, *, _) with optional spaces between them
+		char ruleChar = '\0';
+		int charCount = 0;
+		foreach (var c in trimmed)
 		{
-			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
-			return true;
-		}
-		if (withoutSpaces.Length >= 3 && withoutSpaces.All(c => c == '*'))
-		{
-			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
-			return true;
-		}
-		if (withoutSpaces.Length >= 3 && withoutSpaces.All(c => c == '_'))
-		{
-			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
-			return true;
+			if (c == ' ')
+			{
+				continue;
+			}
+			if (ruleChar == '\0')
+			{
+				if (c is not ('-' or '*' or '_'))
+				{
+					return false;
+				}
+				ruleChar = c;
+			}
+			if (c != ruleChar)
+			{
+				return false;
+			}
+			charCount++;
 		}
 
+		if (charCount >= 3)
+		{
+			block = new MarkdownBlock { Type = MarkdownBlockType.HorizontalRule };
+			return true;
+		}
 		return false;
 	}
 
@@ -226,11 +237,11 @@ internal static partial class MarkdownParser
 		return true;
 	}
 
-	private static MarkdownBlock ParseBlockquote(List<string> lines, ref int i)
+	private static MarkdownBlock ParseBlockquote(string[] lines, ref int i)
 	{
 		var block = new MarkdownBlock { Type = MarkdownBlockType.Blockquote };
 
-		while (i < lines.Count)
+		while (i < lines.Length)
 		{
 			var trimmed = lines[i].TrimStart();
 			if (trimmed.StartsWith(">"))
@@ -259,12 +270,12 @@ internal static partial class MarkdownParser
 		return block;
 	}
 
-	private static bool TryParseTable(List<string> lines, ref int i, out MarkdownBlock block)
+	private static bool TryParseTable(string[] lines, ref int i, out MarkdownBlock block)
 	{
 		block = null;
 
 		// Need at least header + separator + one data row
-		if (i + 1 >= lines.Count)
+		if (i + 1 >= lines.Length)
 		{
 			return false;
 		}
@@ -287,7 +298,7 @@ internal static partial class MarkdownParser
 		block.Lines.Add(separatorLine);
 		i += 2;
 
-		while (i < lines.Count)
+		while (i < lines.Length)
 		{
 			var trimmed = lines[i].Trim();
 			if (trimmed.StartsWith("|"))
@@ -312,22 +323,22 @@ internal static partial class MarkdownParser
 		}
 		// Each cell should be like ---  or :--- or ---: or :---:
 		var cells = SplitTableRow(line);
-		return cells.All(c => TableSeparatorCellRegex.IsMatch(c.Trim()));
+		return cells.All(c => TableSeparatorCellRegex().IsMatch(c.Trim()));
 	}
 
-	private static bool IsUnorderedListItem(string line)
+	private static bool IsUnorderedListItem(ReadOnlySpan<char> line)
 	{
 		var trimmed = line.TrimStart();
-		return (trimmed.StartsWith("- ") || trimmed.StartsWith("* ") || trimmed.StartsWith("+ "));
+		return trimmed.StartsWith("- ") || trimmed.StartsWith("* ") || trimmed.StartsWith("+ ");
 	}
 
-	private static bool IsOrderedListItem(string line)
+	private static bool IsOrderedListItem(ReadOnlySpan<char> line)
 	{
 		var trimmed = line.TrimStart();
-		return OrderedListItemRegex.IsMatch(trimmed);
+		return OrderedListItemRegex().IsMatch(trimmed);
 	}
 
-	private static MarkdownBlock ParseUnorderedList(List<string> lines, ref int i)
+	private static MarkdownBlock ParseUnorderedList(string[] lines, ref int i)
 	{
 		var block = new MarkdownBlock
 		{
@@ -335,7 +346,7 @@ internal static partial class MarkdownParser
 			Children = new List<MarkdownBlock>()
 		};
 
-		while (i < lines.Count && IsUnorderedListItem(lines[i]))
+		while (i < lines.Length && IsUnorderedListItem(lines[i]))
 		{
 			var trimmed = lines[i].TrimStart();
 			var content = trimmed.Substring(2); // skip "- ", "* ", "+ "
@@ -350,7 +361,7 @@ internal static partial class MarkdownParser
 		return block;
 	}
 
-	private static MarkdownBlock ParseOrderedList(List<string> lines, ref int i)
+	private static MarkdownBlock ParseOrderedList(string[] lines, ref int i)
 	{
 		var block = new MarkdownBlock
 		{
@@ -358,10 +369,10 @@ internal static partial class MarkdownParser
 			Children = new List<MarkdownBlock>()
 		};
 
-		while (i < lines.Count && IsOrderedListItem(lines[i]))
+		while (i < lines.Length && IsOrderedListItem(lines[i]))
 		{
 			var trimmed = lines[i].TrimStart();
-			var match = OrderedListItemContentRegex.Match(trimmed);
+			var match = OrderedListItemContentRegex().Match(trimmed);
 			var content = match.Success ? match.Groups[1].Value : trimmed;
 			block.Children.Add(new MarkdownBlock
 			{
@@ -374,29 +385,26 @@ internal static partial class MarkdownParser
 		return block;
 	}
 
-	private static MarkdownBlock ParseParagraph(List<string> lines, ref int i, bool sanitizeHtml)
+	private static MarkdownBlock ParseParagraph(string[] lines, ref int i, bool sanitizeHtml)
 	{
 		var block = new MarkdownBlock { Type = MarkdownBlockType.Paragraph };
 
-		while (i < lines.Count && !string.IsNullOrWhiteSpace(lines[i]))
+		while (i < lines.Length && !string.IsNullOrWhiteSpace(lines[i]))
 		{
+			var trimmedSpan = lines[i].AsSpan().TrimStart();
+
 			// Stop if next line looks like a different block type
-			if (lines[i].TrimStart().StartsWith("#")
-				|| lines[i].TrimStart().StartsWith(">")
-				|| lines[i].TrimStart().StartsWith("```")
-				|| lines[i].TrimStart().StartsWith("~~~")
-				|| IsUnorderedListItem(lines[i])
-				|| IsOrderedListItem(lines[i]))
+			if (trimmedSpan.StartsWith("#")
+				|| trimmedSpan.StartsWith(">")
+				|| trimmedSpan.StartsWith("```")
+				|| trimmedSpan.StartsWith("~~~")
+				|| IsUnorderedListItem(trimmedSpan)
+				|| IsOrderedListItem(trimmedSpan))
 			{
-				// Check for HR
-				if (TryParseHorizontalRule(lines[i], out _))
-				{
-					break;
-				}
 				break;
 			}
 
-			// Check for HR within paragraph
+			// Check for HR within paragraph (--- doesn't match any prefix above)
 			if (TryParseHorizontalRule(lines[i], out _))
 			{
 				break;
@@ -465,15 +473,23 @@ internal static partial class MarkdownParser
 
 	private static void RenderCodeBlock(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
 	{
-		var code = WebUtility.HtmlEncode(string.Join("\n", block.Lines));
+		sb.Append("<pre><code");
 		if (!string.IsNullOrEmpty(block.CodeLanguage))
 		{
-			sb.Append($"<pre><code class=\"language-{WebUtility.HtmlEncode(block.CodeLanguage)}\">{code}</code></pre>");
+			sb.Append(" class=\"language-").Append(WebUtility.HtmlEncode(block.CodeLanguage)).Append('"');
 		}
-		else
+		sb.Append('>');
+
+		for (int i = 0; i < block.Lines.Count; i++)
 		{
-			sb.Append($"<pre><code>{code}</code></pre>");
+			if (i > 0)
+			{
+				sb.Append('\n');
+			}
+			sb.Append(WebUtility.HtmlEncode(block.Lines[i]));
 		}
+
+		sb.Append("</code></pre>");
 	}
 
 	private static void RenderBlockquote(StringBuilder sb, MarkdownBlock block, MarkdownRenderOptions options)
@@ -557,22 +573,30 @@ internal static partial class MarkdownParser
 
 	private static string JoinLines(List<string> lines)
 	{
-		return string.Join("\n", lines);
+		if (lines.Count == 0)
+		{
+			return string.Empty;
+		}
+		if (lines.Count == 1)
+		{
+			return lines[0];
+		}
+		return string.Join('\n', lines);
 	}
 
-	private static List<string> SplitTableRow(string row)
+	private static string[] SplitTableRow(string row)
 	{
 		// Remove leading/trailing |
-		var trimmed = row.Trim();
-		if (trimmed.StartsWith("|"))
+		var span = row.AsSpan().Trim();
+		if (span.Length > 0 && span[0] == '|')
 		{
-			trimmed = trimmed.Substring(1);
+			span = span.Slice(1);
 		}
-		if (trimmed.EndsWith("|"))
+		if (span.Length > 0 && span[span.Length - 1] == '|')
 		{
-			trimmed = trimmed.Substring(0, trimmed.Length - 1);
+			span = span.Slice(0, span.Length - 1);
 		}
-		return trimmed.Split('|').ToList();
+		return span.ToString().Split('|');
 	}
 
 	#endregion

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownRenderOptions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownRenderOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+/// <summary>
+/// Options for the markdown-to-HTML rendering.
+/// </summary>
+internal class MarkdownRenderOptions
+{
+	public bool SanitizeHtml { get; set; } = true;
+	public string TableCssClass { get; set; }
+	public string BlockquoteCssClass { get; set; }
+	public string ImageCssClass { get; set; }
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/MarkdownSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/MarkdownSettings.cs
@@ -1,0 +1,36 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Settings for the <see cref="HxMarkdown"/> and derived components.
+/// </summary>
+public record MarkdownSettings
+{
+	/// <summary>
+	/// When <c>true</c> (default), HTML tags in the input are escaped.
+	/// When <c>false</c>, raw HTML in the input passes through to the output (use only with trusted content).
+	/// </summary>
+	public bool? SanitizeHtml { get; set; }
+
+	/// <summary>
+	/// CSS class for the wrapper <c>&lt;div&gt;</c> element.
+	/// </summary>
+	public string CssClass { get; set; }
+
+	/// <summary>
+	/// CSS class for <c>&lt;table&gt;</c> elements rendered from markdown tables.
+	/// Default is <c>"table"</c> (Bootstrap table).
+	/// </summary>
+	public string TableCssClass { get; set; }
+
+	/// <summary>
+	/// CSS class for <c>&lt;blockquote&gt;</c> elements rendered from markdown blockquotes.
+	/// Default is <c>"blockquote"</c> (Bootstrap blockquote).
+	/// </summary>
+	public string BlockquoteCssClass { get; set; }
+
+	/// <summary>
+	/// CSS class for <c>&lt;img&gt;</c> elements rendered from markdown images.
+	/// Default is <c>"img-fluid"</c> (Bootstrap responsive image).
+	/// </summary>
+	public string ImageCssClass { get; set; }
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Basic.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Basic.razor
@@ -1,0 +1,7 @@
+﻿<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		**Hello, Markdown!** This is a paragraph with *italic* and `inline code`.
+		""";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_CodeBlocks.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_CodeBlocks.razor
@@ -1,0 +1,17 @@
+﻿<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		```csharp
+		public class HelloWorld
+		{
+		    public static void Main()
+		    {
+		        Console.WriteLine("Hello, World!");
+		    }
+		}
+		```
+
+		Inline code: `var x = 42;`
+		""";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_CustomCss.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_CustomCss.razor
@@ -1,0 +1,12 @@
+﻿<HxMarkdown Content="@_markdown" TableCssClass="table table-striped" BlockquoteCssClass="blockquote border-start border-3 ps-3" ImageCssClass="img-thumbnail" />
+
+@code {
+	private string _markdown = """
+		| Header 1 | Header 2 |
+		|----------|----------|
+		| Cell A   | Cell B   |
+		| Cell C   | Cell D   |
+
+		> A styled blockquote with custom CSS.
+		""";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_RichContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_RichContent.razor
@@ -1,0 +1,24 @@
+﻿<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		# Heading 1
+		## Heading 2
+
+		A paragraph with **bold**, *italic*, ~~strikethrough~~, and `code`.
+
+		> This is a blockquote.
+
+		- First item
+		- Second item
+		- Third item
+
+		1. Ordered one
+		2. Ordered two
+		3. Ordered three
+
+		---
+
+		Visit [Havit Blazor](https://havit.blazor.eu "Havit Blazor documentation").
+		""";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Sanitization.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Sanitization.razor
@@ -1,0 +1,11 @@
+﻿<p><strong>Default (sanitized):</strong></p>
+<HxMarkdown Content="@_markdownWithHtml" />
+
+<p class="mt-3"><strong>With <code>SanitizeHtml="false"</code>:</strong></p>
+<HxMarkdown Content="@_markdownWithHtml" SanitizeHtml="false" />
+
+@code {
+	private string _markdownWithHtml = """
+		This has <strong>raw HTML bold</strong> and a <span style="color: red;">red span</span>.
+		""";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Tables.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Tables.razor
@@ -1,0 +1,11 @@
+﻿<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		| Name   | Role       | Status |
+		|--------|------------|--------|
+		| Alice  | Developer  | Active |
+		| Bob    | Designer   | Active |
+		| Carol  | Manager    | Away   |
+		""";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Wrapper.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Wrapper.razor
@@ -1,0 +1,9 @@
+﻿<p><strong>Without wrapper (default):</strong></p>
+<HxMarkdown Content="@_markdown" />
+
+<p class="mt-3"><strong>With wrapper (CssClass set):</strong></p>
+<HxMarkdown Content="@_markdown" CssClass="p-3 bg-light border rounded" />
+
+@code {
+	private string _markdown = "A simple **paragraph** rendered from Markdown.";
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Documentation.razor
@@ -1,9 +1,9 @@
 ﻿@attribute [Route("/components/" + nameof(HxMarkdown))]
 
 <ApiDoc Type="typeof(HxMarkdown)">
-	<DocHeading Title="Basic usage" Tabs="false" />
+	<DocHeading Title="Basic usage" />
 	<p>Pass a Markdown string to the <code>Content</code> parameter.</p>
-	<Demo Type="typeof(HxMarkdown_Demo_Basic)" />
+	<Demo Type="typeof(HxMarkdown_Demo_Basic)"  Tabs="false" />
 
 	<DocHeading Title="Rich content" />
 	<p>Supports headings, lists, blockquotes, code blocks, tables, and inline formatting (bold, italic, strikethrough, inline code, links, images).</p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Documentation.razor
@@ -1,9 +1,7 @@
 ﻿@attribute [Route("/components/" + nameof(HxMarkdown))]
 
 <ApiDoc Type="typeof(HxMarkdown)">
-	<p>Renders Markdown content as HTML using Bootstrap typography. Standalone implementation with no external dependencies.</p>
-
-	<DocHeading Title="Basic usage" />
+	<DocHeading Title="Basic usage" Tabs="false" />
 	<p>Pass a Markdown string to the <code>Content</code> parameter.</p>
 	<Demo Type="typeof(HxMarkdown_Demo_Basic)" />
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Documentation.razor
@@ -1,0 +1,33 @@
+﻿@attribute [Route("/components/" + nameof(HxMarkdown))]
+
+<ApiDoc Type="typeof(HxMarkdown)">
+	<p>Renders Markdown content as HTML using Bootstrap typography. Standalone implementation with no external dependencies.</p>
+
+	<DocHeading Title="Basic usage" />
+	<p>Pass a Markdown string to the <code>Content</code> parameter.</p>
+	<Demo Type="typeof(HxMarkdown_Demo_Basic)" />
+
+	<DocHeading Title="Rich content" />
+	<p>Supports headings, lists, blockquotes, code blocks, tables, and inline formatting (bold, italic, strikethrough, inline code, links, images).</p>
+	<Demo Type="typeof(HxMarkdown_Demo_RichContent)" />
+
+	<DocHeading Title="Code blocks" />
+	<p>Fenced code blocks are rendered inside <code>&lt;pre&gt;&lt;code&gt;</code> with an optional <code>language-*</code> class.</p>
+	<Demo Type="typeof(HxMarkdown_Demo_CodeBlocks)" />
+
+	<DocHeading Title="Tables" />
+	<p>Markdown tables are rendered with a configurable CSS class (default <code>table</code> for Bootstrap styling).</p>
+	<Demo Type="typeof(HxMarkdown_Demo_Tables)" />
+
+	<DocHeading Title="HTML sanitization" />
+	<p>By default, HTML tags in the input are escaped. Set <code>SanitizeHtml="false"</code> to allow raw HTML pass-through (use only with trusted content).</p>
+	<Demo Type="typeof(HxMarkdown_Demo_Sanitization)" />
+
+	<DocHeading Title="Custom CSS classes" />
+	<p>Override the Bootstrap CSS classes applied to tables, blockquotes, and images via parameters or <code>HxMarkdown.Defaults</code>.</p>
+	<Demo Type="typeof(HxMarkdown_Demo_CustomCss)" />
+
+	<DocHeading Title="Wrapper element" />
+	<p>By default, no wrapper <code>&lt;div&gt;</code> is rendered. A wrapper is automatically added when you set <code>CssClass</code> or <code>AdditionalAttributes</code>.</p>
+	<Demo Type="typeof(HxMarkdown_Demo_Wrapper)" />
+</ApiDoc>

--- a/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
+++ b/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
@@ -135,6 +135,7 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/types/InputTagsSettings", "InputTags Settings", "defaults", DefaultsLevel),
 		new("/types/InputFileCoreSettings", "InputFileCore Settings", "defaults", DefaultsLevel),
 		new("/types/ListLayoutSettings", "ListLayout Settings", "defaults", DefaultsLevel),
+		new("/types/MarkdownSettings", "Markdown Settings", "defaults", DefaultsLevel),
 		new("/types/MultiSelect Settings", "MultiSelect Settings", "defaults", DefaultsLevel),
 		new("/types/Modal Settings", "Modal Settings", "defaults", DefaultsLevel),
 		new("/types/MessengerServiceExtensionsSettings", "MessengerServiceExtensions Settings", "defaults", DefaultsLevel),

--- a/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
+++ b/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
@@ -71,6 +71,7 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/components/HxInputTextArea", "HxInputTextArea", "field multiline"),
 		new("/components/HxListGroup", "HxListGroup", "item"),
 		new("/components/HxListLayout", "HxListLayout", "data presentation filter"),
+		new("/components/HxMarkdown", "HxMarkdown", "markdown rendering html text content typography"),
 		new("/components/HxMessageBox", "HxMessageBox", "pop-up full-screen dialog modal confirm"),
 		new("/components/HxMessenger", "HxMessenger", "popup warning alert toaster"),
 		new("/components/HxModal", "HxModal", "popup fullscreen dialog messagebox"),

--- a/Havit.Blazor.Documentation/Shared/Sidebar.razor
+++ b/Havit.Blazor.Documentation/Shared/Sidebar.razor
@@ -86,6 +86,7 @@
             <HxSidebarItem Href="@($"/components/{nameof(HxTabPanel)}")" Text="@nameof(HxTabPanel)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxListGroup)}")" Text="@(nameof(HxListGroup))" />
             <HxSidebarItem Href="@($"/components/{nameof(HxListLayout)}")" Text="@(nameof(HxListLayout))" />
+            <HxSidebarItem Href="@($"/components/{nameof(HxMarkdown)}")" Text="@nameof(HxMarkdown)" />
         </HxSidebarItem>
 
         <HxSidebarItem Text="Navigation" Icon="BootstrapIcon.SignpostSplit">
@@ -185,6 +186,7 @@
             <HxSidebarItem Href="@($"/components/{nameof(HxInputTextArea)}")" Text="@(nameof(HxInputTextArea))" />
             <HxSidebarItem Href="@($"/components/{nameof(HxListGroup)}")" Text="@(nameof(HxListGroup))" />
             <HxSidebarItem Href="@($"/components/{nameof(HxListLayout)}")" Text="@(nameof(HxListLayout))" />
+            <HxSidebarItem Href="@($"/components/{nameof(HxMarkdown)}")" Text="@nameof(HxMarkdown)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxMessageBox)}")" Text="@nameof(HxMessageBox)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxMessenger)}")" Text="@nameof(HxMessenger)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxModal)}")" Text="@nameof(HxModal)" />

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2643,6 +2643,142 @@
             Processes inline markdown elements (bold, italic, code, links, images, strikethrough, line breaks).
             </summary>
         </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.InlineCodeRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>`([^`]+)`</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match '`'.<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '`' atomically at least once.<br/>
+            ○ Match '`'.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.ImageRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>!\\[([^\\]]*)\\]\\(([^\\s\\)]+)(?:\\s+"([^"]*)")?\\)</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match the string "![".<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than ']' atomically any number of times.<br/>
+            ○ Match the string "](".<br/>
+            ○ 2nd capture group.<br/>
+                ○ Match a character in the set [^)\s] greedily at least once.<br/>
+            ○ Optional (greedy).<br/>
+                ○ Match a whitespace character atomically at least once.<br/>
+                ○ Match '"'.<br/>
+                ○ 3rd capture group.<br/>
+                    ○ Match a character other than '"' atomically any number of times.<br/>
+                ○ Match '"'.<br/>
+            ○ Match ')'.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.LinkRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>\\[([^\\]]+)\\]\\(([^\\s\\)]+)(?:\\s+"([^"]*)")?\\)</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match '['.<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than ']' atomically at least once.<br/>
+            ○ Match the string "](".<br/>
+            ○ 2nd capture group.<br/>
+                ○ Match a character in the set [^)\s] greedily at least once.<br/>
+            ○ Optional (greedy).<br/>
+                ○ Match a whitespace character atomically at least once.<br/>
+                ○ Match '"'.<br/>
+                ○ 3rd capture group.<br/>
+                    ○ Match a character other than '"' atomically any number of times.<br/>
+                ○ Match '"'.<br/>
+            ○ Match ')'.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.BoldAsteriskRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>\\*\\*(.+?)\\*\\*</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match the string "**".<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '\n' lazily at least once.<br/>
+            ○ Match the string "**".<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.BoldUnderscoreRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>__(.+?)__</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match the string "__".<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '\n' lazily at least once.<br/>
+            ○ Match the string "__".<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.ItalicAsteriskRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>\\*(.+?)\\*</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match '*'.<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '\n' lazily at least once.<br/>
+            ○ Match '*'.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.ItalicUnderscoreRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>(?&lt;!\\w)_(.+?)_(?!\\w)</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Zero-width negative lookbehind.<br/>
+                ○ Match a word character right-to-left.<br/>
+            ○ Match '_'.<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '\n' lazily at least once.<br/>
+            ○ Match '_'.<br/>
+            ○ Zero-width negative lookahead.<br/>
+                ○ Match a word character.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.StrikethroughRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>~~(.+?)~~</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match the string "~~".<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '\n' lazily at least once.<br/>
+            ○ Match the string "~~".<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.LineBreakRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>  \\n</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match the string "  \n".<br/>
+            </code>
+            </remarks>
+        </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.ProcessInlineElements(System.String,Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownRenderOptions)">
             <summary>
             Converts inline markdown syntax to HTML within a text block.
@@ -2652,6 +2788,49 @@
             <summary>
             Standalone markdown-to-HTML parser. Converts markdown text to HTML using Bootstrap typography classes.
             </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser.TableSeparatorCellRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>^:?-{1,}:?$</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at the beginning of the string.<br/>
+            ○ Match ':' atomically, optionally.<br/>
+            ○ Match '-' atomically at least once.<br/>
+            ○ Match ':' atomically, optionally.<br/>
+            ○ Match if at the end of the string or if before an ending newline.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser.OrderedListItemRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>^\\d+\\.\\s</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at the beginning of the string.<br/>
+            ○ Match a Unicode digit atomically at least once.<br/>
+            ○ Match '.'.<br/>
+            ○ Match a whitespace character.<br/>
+            </code>
+            </remarks>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser.OrderedListItemContentRegex">
+            <remarks>
+            Pattern:<br/>
+            <code>^\\d+\\.\\s(.*)$</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match if at the beginning of the string.<br/>
+            ○ Match a Unicode digit atomically at least once.<br/>
+            ○ Match '.'.<br/>
+            ○ Match a whitespace character.<br/>
+            ○ 1st capture group.<br/>
+                ○ Match a character other than '\n' greedily any number of times.<br/>
+            ○ Match if at the end of the string or if before an ending newline.<br/>
+            </code>
+            </remarks>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser.ToHtml(System.String,Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownRenderOptions)">
             <summary>
@@ -12252,6 +12431,385 @@
             <param name="inputSpan">The text being scanned by the regular expression.</param>
             <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
         </member>
+        <member name="T:System.Text.RegularExpressions.Generated.InlineCodeRegex_14">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the InlineCodeRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.InlineCodeRegex_14.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ImageRegex_15">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the ImageRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.ImageRegex_15.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ImageRegex_15.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ImageRegex_15.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ImageRegex_15.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ImageRegex_15.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ImageRegex_15.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ImageRegex_15.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ImageRegex_15.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.LinkRegex_16">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the LinkRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.LinkRegex_16.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LinkRegex_16.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.LinkRegex_16.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LinkRegex_16.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.LinkRegex_16.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LinkRegex_16.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LinkRegex_16.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LinkRegex_16.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the BoldAsteriskRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldAsteriskRegex_17.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the BoldUnderscoreRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.BoldUnderscoreRegex_18.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the ItalicAsteriskRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicAsteriskRegex_19.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the ItalicUnderscoreRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ItalicUnderscoreRegex_20.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.StrikethroughRegex_21">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the StrikethroughRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.StrikethroughRegex_21.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.LineBreakRegex_22">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the LineBreakRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.LineBreakRegex_22.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LineBreakRegex_22.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.LineBreakRegex_22.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LineBreakRegex_22.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.LineBreakRegex_22.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LineBreakRegex_22.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.LineBreakRegex_22.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the TableSeparatorCellRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.TableSeparatorCellRegex_23.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the OrderedListItemRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemRegex_24.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the OrderedListItemContentRegex method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.OrderedListItemContentRegex_25.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
         <member name="T:System.Text.RegularExpressions.Generated.Utilities">
             <summary>Helper methods used by generated <see cref="T:System.Text.RegularExpressions.Regex"/>-derived implementations.</summary>
         </member>
@@ -12264,11 +12822,29 @@
         <member name="M:System.Text.RegularExpressions.Generated.Utilities.IsWordChar(System.Char)">
             <summary>Determines whether the character is part of the [\w] set.</summary>
         </member>
+        <member name="M:System.Text.RegularExpressions.Generated.Utilities.StackPush(System.Int32[]@,System.Int32@,System.Int32,System.Int32)">
+            <summary>Pushes 2 values onto the backtracking stack.</summary>
+        </member>
         <member name="F:System.Text.RegularExpressions.Generated.Utilities.WordCategoriesMask">
             <summary>Provides a mask of Unicode categories that combine to form [\w].</summary>
         </member>
         <member name="P:System.Text.RegularExpressions.Generated.Utilities.WordCharBitmap">
             <summary>Gets a bitmap for whether each character 0 through 127 is in [\w]</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString_4B938BB3612E6695167AB8A3A3AD73E3F6DB0CC76E502A73DB7C1EC79B5A2092">
+            <summary>Supports searching for the string "**".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString_A35D34A63ABD1CA9D7860076AA22A8E02AF70FE7A4FEF864363EC52527771C59">
+            <summary>Supports searching for the string "![".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString_B5982FF4EF1FB3EFB5D43B8974BA97ED3128DD3DAD9F1B1F4BAE2F75FB3DBAF3">
+            <summary>Supports searching for the string "  \n".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString_CD52C9D118B084D434A4D219ABB8EA35B16B26BDCD7FAADC77802968479904D4">
+            <summary>Supports searching for the string "~~".</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_indexOfString____Ordinal">
+            <summary>Supports searching for the string "__".</summary>
         </member>
     </members>
 </doc>

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2784,6 +2784,13 @@
             Converts inline markdown syntax to HTML within a text block.
             </summary>
         </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.EncodeAttributeValue(System.String,System.Boolean)">
+            <summary>
+            Encodes a value for safe use inside an HTML attribute (double-quoted).
+            When <paramref name="ampAlreadyEncoded"/> is true, <c>&amp;</c> is assumed to already
+            be encoded by an earlier sanitization pass (SanitizeHtml=true).
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser">
             <summary>
             Standalone markdown-to-HTML parser. Converts markdown text to HTML using Bootstrap typography classes.

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2608,6 +2608,64 @@
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxMultiSelectGridColumnInternal`1.GetDefaultSortingOrder">
             <inheritdoc />
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlockType">
+            <summary>
+            Represents a parsed block-level markdown element.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock">
+            <summary>
+            A single block-level element parsed from markdown.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock.Lines">
+            <summary>
+            Raw text lines of the block (before inline parsing).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock.HeadingLevel">
+            <summary>
+            Heading level (1-6). Only relevant for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlockType.Heading"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock.CodeLanguage">
+            <summary>
+            Language hint for code blocks (e.g. "csharp"). Only relevant for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlockType.CodeBlock"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock.Children">
+            <summary>
+            Child blocks (e.g. list items contain paragraph blocks).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser">
+            <summary>
+            Processes inline markdown elements (bold, italic, code, links, images, strikethrough, line breaks).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser.ProcessInlineElements(System.String,Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownRenderOptions)">
+            <summary>
+            Converts inline markdown syntax to HTML within a text block.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser">
+            <summary>
+            Standalone markdown-to-HTML parser. Converts markdown text to HTML using Bootstrap typography classes.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser.ToHtml(System.String,Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownRenderOptions)">
+            <summary>
+            Converts markdown text to HTML.
+            </summary>
+            <param name="markdown">The markdown text to convert.</param>
+            <param name="options">Rendering options.</param>
+            <returns>HTML string.</returns>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownRenderOptions">
+            <summary>
+            Options for the markdown-to-HTML rendering.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.HxNavLinkInternal">
             <summary>
             Variation of <see cref="T:Microsoft.AspNetCore.Components.Routing.NavLink"/> that adds <see cref="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxNavLinkInternal.OnClick"/> and related functionality.
@@ -8499,6 +8557,111 @@
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ListGroupHorizontal.Always">
             <summary>
             Always horizontal, never vertical.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown">
+            <summary>
+            Renders Markdown content as HTML using Bootstrap typography.<br />
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxMarkdown">https://havit.blazor.eu/components/HxMarkdown</see>
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.Defaults">
+            <summary>
+            Application-wide defaults for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown"/> and derived components.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.GetDefaults">
+            <summary>
+            Returns application-wide defaults for the component.
+            Enables overriding defaults in descendants (use a separate set of defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.Settings">
+            <summary>
+            Set of settings to be applied to the component instance (overrides <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.Defaults"/>, overridden by individual parameters).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.GetSettings">
+            <summary>
+            Returns an optional set of component settings.
+            </summary>
+            <remarks>
+            Similar to <see cref="M:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.GetDefaults"/>, enables defining wider <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.Settings"/> in component descendants (by returning a derived settings class).
+            </remarks>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.Content">
+            <summary>
+            Markdown text to render as HTML.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.SanitizeHtml">
+            <summary>
+            When <c>true</c> (default), HTML tags in the input are escaped.
+            When <c>false</c>, raw HTML in the input passes through to the output (use only with trusted content).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.TableCssClass">
+            <summary>
+            CSS class for <c>&lt;table&gt;</c> elements rendered from markdown tables.
+            Default is <c>"table"</c> (Bootstrap table).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.BlockquoteCssClass">
+            <summary>
+            CSS class for <c>&lt;blockquote&gt;</c> elements rendered from markdown blockquotes.
+            Default is <c>"blockquote"</c> (Bootstrap blockquote).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.ImageCssClass">
+            <summary>
+            CSS class for <c>&lt;img&gt;</c> elements rendered from markdown images.
+            Default is <c>"img-fluid"</c> (Bootstrap responsive image).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.CssClass">
+            <summary>
+            Any additional CSS class to apply to the wrapper element.
+            When set (or when <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.AdditionalAttributes"/> is used), the output is wrapped in a <c>&lt;div&gt;</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown.AdditionalAttributes">
+            <summary>
+            Additional attributes to be splatted onto the wrapper <c>&lt;div&gt;</c> element.
+            When set, the output is wrapped in a <c>&lt;div&gt;</c>.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.MarkdownSettings">
+            <summary>
+            Settings for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxMarkdown"/> and derived components.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.MarkdownSettings.SanitizeHtml">
+            <summary>
+            When <c>true</c> (default), HTML tags in the input are escaped.
+            When <c>false</c>, raw HTML in the input passes through to the output (use only with trusted content).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.MarkdownSettings.CssClass">
+            <summary>
+            CSS class for the wrapper <c>&lt;div&gt;</c> element.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.MarkdownSettings.TableCssClass">
+            <summary>
+            CSS class for <c>&lt;table&gt;</c> elements rendered from markdown tables.
+            Default is <c>"table"</c> (Bootstrap table).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.MarkdownSettings.BlockquoteCssClass">
+            <summary>
+            CSS class for <c>&lt;blockquote&gt;</c> elements rendered from markdown blockquotes.
+            Default is <c>"blockquote"</c> (Bootstrap blockquote).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.MarkdownSettings.ImageCssClass">
+            <summary>
+            CSS class for <c>&lt;img&gt;</c> elements rendered from markdown images.
+            Default is <c>"img-fluid"</c> (Bootstrap responsive image).
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.DialogResult`1">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2608,11 +2608,6 @@
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxMultiSelectGridColumnInternal`1.GetDefaultSortingOrder">
             <inheritdoc />
         </member>
-        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlockType">
-            <summary>
-            Represents a parsed block-level markdown element.
-            </summary>
-        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock">
             <summary>
             A single block-level element parsed from markdown.
@@ -2636,6 +2631,11 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlock.Children">
             <summary>
             Child blocks (e.g. list items contain paragraph blocks).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownBlockType">
+            <summary>
+            Represents a parsed block-level markdown element.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownInlineParser">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -2840,6 +2840,11 @@
             <param name="options">Rendering options.</param>
             <returns>HTML string.</returns>
         </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownParser.GetColumnAlignments(System.String)">
+            <summary>
+            Parses the separator row and returns the text-align value for each column, or null when no alignment is specified.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.MarkdownRenderOptions">
             <summary>
             Options for the markdown-to-HTML rendering.

--- a/docs/generated/HxMarkdown.md
+++ b/docs/generated/HxMarkdown.md
@@ -6,9 +6,9 @@ Renders Markdown content as HTML using Bootstrap typography.
 
 | Name | Type | Description |
 |------|------|-------------|
+| Content **[REQUIRED]** | `string` | Markdown text to render as HTML. |
 | AdditionalAttributes | `Dictionary<string, object>` | Additional attributes to be splatted onto the wrapper `<div>` element. When set, the output is wrapped in a `<div>`. |
 | BlockquoteCssClass | `string` | CSS class for `<blockquote>` elements rendered from markdown blockquotes. Default is `"blockquote"` (Bootstrap blockquote). |
-| Content | `string` | Markdown text to render as HTML. |
 | CssClass | `string` | Any additional CSS class to apply to the wrapper element. When set (or when `AdditionalAttributes` is used), the output is wrapped in a `<div>`. |
 | ImageCssClass | `string` | CSS class for `<img>` elements rendered from markdown images. Default is `"img-fluid"` (Bootstrap responsive image). |
 | SanitizeHtml | `bool?` | When `true` (default), HTML tags in the input are escaped. When `false`, raw HTML in the input passes through to the output (use only with trusted content). |

--- a/docs/generated/HxMarkdown.md
+++ b/docs/generated/HxMarkdown.md
@@ -1,0 +1,33 @@
+﻿# HxMarkdown
+
+Renders Markdown content as HTML using Bootstrap typography.
+
+## Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| AdditionalAttributes | `Dictionary<string, object>` | Additional attributes to be splatted onto the wrapper `<div>` element. When set, the output is wrapped in a `<div>`. |
+| BlockquoteCssClass | `string` | CSS class for `<blockquote>` elements rendered from markdown blockquotes. Default is `"blockquote"` (Bootstrap blockquote). |
+| Content | `string` | Markdown text to render as HTML. |
+| CssClass | `string` | Any additional CSS class to apply to the wrapper element. When set (or when `AdditionalAttributes` is used), the output is wrapped in a `<div>`. |
+| ImageCssClass | `string` | CSS class for `<img>` elements rendered from markdown images. Default is `"img-fluid"` (Bootstrap responsive image). |
+| SanitizeHtml | `bool?` | When `true` (default), HTML tags in the input are escaped. When `false`, raw HTML in the input passes through to the output (use only with trusted content). |
+| Settings | `MarkdownSettings` | Set of settings to be applied to the component instance (overrides `Defaults`, overridden by individual parameters). |
+| TableCssClass | `string` | CSS class for `<table>` elements rendered from markdown tables. Default is `"table"` (Bootstrap table). |
+
+## Static properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| Defaults | `MarkdownSettings` | Application-wide defaults for `HxMarkdown` and derived components. |
+
+## Available demo samples
+
+- HxMarkdown_Demo_Basic.razor
+- HxMarkdown_Demo_CodeBlocks.razor
+- HxMarkdown_Demo_CustomCss.razor
+- HxMarkdown_Demo_RichContent.razor
+- HxMarkdown_Demo_Sanitization.razor
+- HxMarkdown_Demo_Tables.razor
+- HxMarkdown_Demo_Wrapper.razor
+

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Basic.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Basic.md
@@ -1,0 +1,12 @@
+﻿# HxMarkdown_Demo_Basic.razor
+
+```razor
+<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		**Hello, Markdown!** This is a paragraph with *italic* and `inline code`.
+		""";
+}
+
+```

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_CodeBlocks.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_CodeBlocks.md
@@ -1,0 +1,22 @@
+﻿# HxMarkdown_Demo_CodeBlocks.razor
+
+```razor
+<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		```csharp
+		public class HelloWorld
+		{
+		    public static void Main()
+		    {
+		        Console.WriteLine("Hello, World!");
+		    }
+		}
+		```
+
+		Inline code: `var x = 42;`
+		""";
+}
+
+```

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_CustomCss.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_CustomCss.md
@@ -1,0 +1,17 @@
+﻿# HxMarkdown_Demo_CustomCss.razor
+
+```razor
+<HxMarkdown Content="@_markdown" TableCssClass="table table-striped" BlockquoteCssClass="blockquote border-start border-3 ps-3" ImageCssClass="img-thumbnail" />
+
+@code {
+	private string _markdown = """
+		| Header 1 | Header 2 |
+		|----------|----------|
+		| Cell A   | Cell B   |
+		| Cell C   | Cell D   |
+
+		> A styled blockquote with custom CSS.
+		""";
+}
+
+```

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_RichContent.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_RichContent.md
@@ -1,0 +1,29 @@
+﻿# HxMarkdown_Demo_RichContent.razor
+
+```razor
+<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		# Heading 1
+		## Heading 2
+
+		A paragraph with **bold**, *italic*, ~~strikethrough~~, and `code`.
+
+		> This is a blockquote.
+
+		- First item
+		- Second item
+		- Third item
+
+		1. Ordered one
+		2. Ordered two
+		3. Ordered three
+
+		---
+
+		Visit [Havit Blazor](https://havit.blazor.eu "Havit Blazor documentation").
+		""";
+}
+
+```

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Sanitization.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Sanitization.md
@@ -1,0 +1,16 @@
+﻿# HxMarkdown_Demo_Sanitization.razor
+
+```razor
+<p><strong>Default (sanitized):</strong></p>
+<HxMarkdown Content="@_markdownWithHtml" />
+
+<p class="mt-3"><strong>With <code>SanitizeHtml="false"</code>:</strong></p>
+<HxMarkdown Content="@_markdownWithHtml" SanitizeHtml="false" />
+
+@code {
+	private string _markdownWithHtml = """
+		This has <strong>raw HTML bold</strong> and a <span style="color: red;">red span</span>.
+		""";
+}
+
+```

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Tables.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Tables.md
@@ -1,0 +1,16 @@
+﻿# HxMarkdown_Demo_Tables.razor
+
+```razor
+<HxMarkdown Content="@_markdown" />
+
+@code {
+	private string _markdown = """
+		| Name   | Role       | Status |
+		|--------|------------|--------|
+		| Alice  | Developer  | Active |
+		| Bob    | Designer   | Active |
+		| Carol  | Manager    | Away   |
+		""";
+}
+
+```

--- a/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Wrapper.md
+++ b/docs/generated/demos/HxMarkdown/HxMarkdown_Demo_Wrapper.md
@@ -1,0 +1,14 @@
+﻿# HxMarkdown_Demo_Wrapper.razor
+
+```razor
+<p><strong>Without wrapper (default):</strong></p>
+<HxMarkdown Content="@_markdown" />
+
+<p class="mt-3"><strong>With wrapper (CssClass set):</strong></p>
+<HxMarkdown Content="@_markdown" CssClass="p-3 bg-light border rounded" />
+
+@code {
+	private string _markdown = "A simple **paragraph** rendered from Markdown.";
+}
+
+```

--- a/docs/generated/types/MarkdownSettings.md
+++ b/docs/generated/types/MarkdownSettings.md
@@ -1,0 +1,14 @@
+﻿# MarkdownSettings
+
+Settings for the `HxMarkdown` and derived components.
+
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| BlockquoteCssClass | `string` | CSS class for `<blockquote>` elements rendered from markdown blockquotes. Default is `"blockquote"` (Bootstrap blockquote). |
+| CssClass | `string` | CSS class for the wrapper `<div>` element. |
+| ImageCssClass | `string` | CSS class for `<img>` elements rendered from markdown images. Default is `"img-fluid"` (Bootstrap responsive image). |
+| SanitizeHtml | `bool?` | When `true` (default), HTML tags in the input are escaped. When `false`, raw HTML in the input passes through to the output (use only with trusted content). |
+| TableCssClass | `string` | CSS class for `<table>` elements rendered from markdown tables. Default is `"table"` (Bootstrap table). |
+

--- a/plans/HxMarkdown.md
+++ b/plans/HxMarkdown.md
@@ -1,0 +1,151 @@
+# HxMarkdown – implementační plán
+
+## Problém
+Potřebujeme komponentu `HxMarkdown`, která převede Markdown text na HTML a vykreslí ho s využitím Bootstrap typografie. Bez externích závislostí – standalone parser.
+
+## Navržené API
+
+```razor
+@* Primární API – Content parametr *@
+<HxMarkdown Content="@markdownString" />
+
+@* S CSS třídou *@
+<HxMarkdown Content="@markdownString" CssClass="my-custom-class" />
+```
+
+### Proč nedoporučuji ChildContent pro markdown
+`<HxMarkdown>` **text** `</HxMarkdown>` by vyžadovalo extrakci stringu z `RenderFragment`, což je v Blazoru netriviální a křehké. Navíc Razor syntaxe koliduje s markdown (`@` znaky, `<` tagy vyžadují escaping). Parametr `Content` je čistější a spolehlivější.
+
+### Wrapper element
+**Doporučuji volitelný wrapper** – komponenta bude standardně renderovat bez wrapper elementu (holý HTML výstup z markdown). Pokud uživatel zadá `CssClass` nebo `AdditionalAttributes`, automaticky se obalí do `<div>`. Důvody:
+- Bez wrapperu je výstup čistší a lépe se integruje do existujícího layoutu
+- Wrapper je potřeba jen když chceme na výstup aplikovat CSS třídu nebo atributy
+- Implementace přes `BuildRenderTree` umožňuje podmíněné renderování wrapperu
+
+### Parametry komponenty
+
+| Parametr | Typ | Default | Popis |
+|----------|-----|---------|-------|
+| `Content` | `string` | `null` | Markdown text k vykreslení |
+| `SanitizeHtml` | `bool?` | `true` | Pokud `true`, HTML tagy ve vstupu budou escaped. Pokud `false`, raw HTML ve vstupu projde do výstupu. |
+| `TableCssClass` | `string` | `null` | CSS třída pro `<table>` (default z Settings: `"table"`) |
+| `BlockquoteCssClass` | `string` | `null` | CSS třída pro `<blockquote>` (default z Settings: `"blockquote"`) |
+| `ImageCssClass` | `string` | `null` | CSS třída pro `<img>` (default z Settings: `"img-fluid"`) |
+| `CssClass` | `string` | `null` | CSS třída pro wrapper `<div>` (volitelný wrapper) |
+| `AdditionalAttributes` | `Dictionary<string, object>` | `null` | Další HTML atributy (aktivuje wrapper) |
+| `Settings` | `MarkdownSettings` | `null` | Instance-level nastavení |
+
+### MarkdownSettings
+```csharp
+public class MarkdownSettings
+{
+    public bool? SanitizeHtml { get; set; }
+    public string CssClass { get; set; }
+    public string TableCssClass { get; set; }          // default "table"
+    public string BlockquoteCssClass { get; set; }     // default "blockquote"
+    public string ImageCssClass { get; set; }           // default "img-fluid"
+}
+```
+
+### Statické defaults
+```csharp
+public static MarkdownSettings Defaults { get; set; }
+
+// Globální konfigurace:
+// HxMarkdown.Defaults.SanitizeHtml = false;  // povolí raw HTML globálně
+```
+
+## Architektura
+
+### Standalone Markdown Parser
+Dvou-fázový parser (block-level → inline-level), inspirovaný CommonMark specifikací:
+
+**Block-level elementy (fáze 1):**
+1. Headings (`# ` až `###### `)
+2. Code blocks (``` fenced code blocks ```)
+3. Blockquotes (`> `)
+4. Unordered lists (`- `, `* `, `+ `)
+5. Ordered lists (`1. `)
+6. Horizontal rules (`---`, `***`, `___`)
+7. **Tabulky** (`| col1 | col2 |` s `|---|---|` oddělovačem)
+8. Paragraphs (vše ostatní)
+
+**Inline elementy (fáze 2):**
+1. Bold (`**text**` a `__text__`)
+2. Italic (`*text*` a `_text_`)
+3. **Strikethrough** (`~~text~~`)
+4. Inline code (`` `code` ``)
+5. Links (`[text](url)`)
+6. Images (`![alt](url)`)
+7. Line breaks (dvojitá mezera na konci řádku / `<br>`)
+
+### Bezpečnost
+- Vstupní text je standardně HTML-encoded před zpracováním (`SanitizeHtml = true`)
+- Markdown syntaxe generuje bezpečné HTML tagy
+- Parametr `SanitizeHtml` (default `true`) řídí, zda se HTML tagy ve vstupu escapují:
+  - `true` (default): HTML tagy escaped → bezpečný výstup
+  - `false`: raw HTML ve vstupu projde do výstupu (pro důvěryhodný obsah)
+- Konfigurovatelné globálně přes `HxMarkdown.Defaults.SanitizeHtml = false`
+
+### Bootstrap typografie mapování
+| Markdown | HTML výstup | Bootstrap styl |
+|----------|------------|----------------|
+| `# Heading` | `<h1>` - `<h6>` | Nativní Bootstrap headings |
+| `**bold**` | `<strong>` | Nativní |
+| `*italic*` | `<em>` | Nativní |
+| `` `code` `` | `<code>` | Bootstrap `<code>` |
+| Code block | `<pre><code>` | Bootstrap `<pre>` |
+| `> quote` | `<blockquote class="blockquote">` | Bootstrap blockquote |
+| Lists | `<ul>/<ol>` + `<li>` | Nativní |
+| `~~strike~~` | `<s>` | Nativní |
+| Table | `<table class="table">` | Bootstrap tabulka |
+| `---` | `<hr>` | Nativní |
+| `[text](url)` | `<a href="url">` | Nativní |
+| `![alt](url)` | `<img class="img-fluid">` | Bootstrap responsive image |
+| Paragraph | `<p>` | Nativní |
+
+## Struktura souborů
+
+```
+Havit.Blazor.Components.Web.Bootstrap/
+  Markdown/
+    HxMarkdown.razor             # Šablona (nebo BuildRenderTree)
+    HxMarkdown.razor.cs          # Code-behind s parametry a logikou
+    MarkdownSettings.cs           # Settings třída
+    Internal/
+      MarkdownParser.cs           # Hlavní parser (block-level)
+      MarkdownInlineParser.cs     # Inline parser
+      MarkdownBlock.cs            # Model pro block elementy
+
+Havit.Blazor.Components.Web.Bootstrap.Tests/
+  Markdown/
+    HxMarkdownTests.cs            # Testy komponenty
+    MarkdownParserTests.cs        # Unit testy parseru
+```
+
+## Implementační kroky
+
+### 1. Markdown parser – block-level
+Implementace parseru pro block-level elementy (headings, code blocks, paragraphs, lists, blockquotes, HR).
+
+### 2. Markdown parser – inline
+Implementace inline parseru (bold, italic, code, links, images, line breaks).
+
+### 3. Komponenta HxMarkdown
+Blazor komponenta s parametry, settings pattern, volitelný wrapper, `BuildRenderTree`.
+
+### 4. Unit testy parseru
+Pokrytí všech markdown elementů unit testy.
+
+### 5. Testy komponenty
+Bunit testy pro renderování komponenty.
+
+### 6. Dokumentace
+Dokumentační stránka s demo ukázkami.
+
+## Poznámky a rozhodnutí
+- **Bez externích závislostí** – parser je součástí knihovny
+- **SanitizeHtml** – volitelný parametr (default `true`), konfigurovatelný globálně přes `MarkdownSettings`. Pokud `false`, raw HTML ve vstupu projde do výstupu.
+- **Volitelný wrapper** – čistý výstup bez zbytečného `<div>`
+- Parser bude `internal static` třída – není součástí veřejného API
+- Nested seznamy (vnořené odrážky) v první verzi nepodporujeme pro jednoduchost


### PR DESCRIPTION
## What

Adds a new `HxMarkdown` component that renders Markdown content as HTML using Bootstrap typography — with no external dependencies.

## API

```razor

```

## Features

- **Block elements**: headings (H1–H6), paragraphs, blockquotes (nested), code blocks (with language hint), horizontal rules, ordered and unordered lists, tables (with alignment)
- **Inline elements**: bold, italic, strikethrough, inline code, links, images, hard line breaks
- **HTML sanitization**: `SanitizeHtml` (default `true`) escapes dangerous characters; set to `false` to allow raw HTML passthrough
- **Bootstrap integration**: outputs semantic HTML compatible with Bootstrap typography; configurable CSS classes via `MarkdownSettings` (`CssClass`, `TableCssClass`, `BlockquoteCssClass`, `ImageCssClass`)
- **Global defaults**: `HxMarkdown.Defaults` / `Settings` parameter pattern consistent with the rest of the library

## Implementation notes

- Fully standalone parser — no NuGet dependencies added
- Targets net8.0 / net9.0 / net10.0
- Source-generated `[GeneratedRegex]` via partial methods (compatible with all three TFMs)
- Performance: `StringBuilder` for code block and HTML sanitization rendering; `ReadOnlySpan` for list/table parsing; fast-path skips in `JoinLines` and `ProcessInlineElements`
- `Content` is `[EditorRequired]`

## Tests

104 tests (83 parser unit tests + 21 bUnit component tests), all passing.

## Documentation

Documentation page with 7 demo sections added. RepoDumpGenerator re-run. `MarkdownSettings` registered in `DocumentationCatalogService`.

## Code review fixes (latest commit)

- **Bug fix**: `ParseParagraph` now breaks on table-start lines (`|` followed by separator), so tables immediately after paragraphs without a blank line are parsed separately
- **Performance**: `HxMarkdown.OnParametersSet` memoizes parsed content — skips re-parse when `Content` and settings parameters haven't changed
- **Infinite loop fix**: `ParseParagraph` now always consumes the first line unconditionally (guaranteed fallback by `ParseBlocks`); break checks only apply to continuation lines, eliminating the class of infinite-loop bugs where a line matches a break condition but isn't consumed by any block parser
- **Catalog**: `MarkdownSettings` registered in `DocumentationCatalogService`
