### PR TITLE
[HxToastContainer] messages are not positioned correctly because of the applied margin

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToastContainer.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToastContainer.razor.css
@@ -1,4 +1,4 @@
 ﻿.hx-toast-container {
 	z-index: 1080;
-	margin: var(--hx-toast-container-margin);
+	padding: var(--hx-toast-container-padding);
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
@@ -1,4 +1,4 @@
-:root, 
+:root,
 [data-bs-theme=dark] {
 	/* HxAutosuggest */
 	--hx-autosuggest-input-close-icon-opacity: 						.25;
@@ -43,7 +43,7 @@
 	--hx-sidebar-subitem-margin: 									0 0 0 2rem;
 	--hx-sidebar-header-padding: 									1rem;
 	--hx-sidebar-body-padding: 										0 1rem 1rem 1rem;
-	--hx-sidebar-body-nav-gap: 										.25rem;														
+	--hx-sidebar-body-nav-gap: 										.25rem;
 	--hx-sidebar-brand-logo-width: 									2.5rem;
 	--hx-sidebar-brand-logo-height: 								2.5rem;
 	--hx-sidebar-brand-shortname-width: 							2.5rem;
@@ -196,7 +196,7 @@
 	--hx-progress-indicator-spinner-color: 							var(--bs-primary);
 
 	/* HxToastContainer */
-	--hx-toast-container-margin: 									.5rem;
+	--hx-toast-container-padding: 									.5rem;
 
 	/* HxSearchBox */
 	--hx-search-box-item-icon-margin: 								0 .5rem 0 0;

--- a/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Documentation.razor
@@ -20,8 +20,8 @@
 		</DocAlert>
 	</MainContent>
 	<CssVariables>
-		<ApiDocCssVariable Name="--hx-toast-container-margin" Default="0.5rem">
-			Margin of the container.
+		<ApiDocCssVariable Name="--hx-toast-container-padding" Default="0.5rem">
+			Padding of the container.
 		</ApiDocCssVariable>
 	</CssVariables>
 </ApiDoc>


### PR DESCRIPTION
Implements the suggested change.

@hakenr It is a breaking change. Margin could be preserved but that would require substantially more code as you would need to incorporate the `--hx-toast-container-margin` variable into the translation calculation or something like that...