### PR TITLE
HxGrid: enlarge multi-select checkbox click target to the whole cell

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.css
@@ -10,6 +10,24 @@
 	white-space: nowrap;
 }
 
+/* Multi-select column: enlarge the checkbox click target to the whole cell.
+   The cell padding is moved onto the wrapping <label> so the entire cell (including
+   former padding) acts as the checkbox label - a click anywhere in it toggles the
+   checkbox, with no JavaScript. */
+td.hx-grid-multiselect-cell {
+	padding: 0;
+}
+
+td.hx-grid-multiselect-cell ::deep .hx-grid-multiselect-checkbox {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	margin: 0;
+	padding: var(--bs-table-cell-padding-y, .5rem) var(--bs-table-cell-padding-x, .5rem);
+	cursor: pointer;
+}
+
 th:hover.hx-grid-sortable ::deep .hx-grid-sort-icon {
 	visibility: visible;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.css
@@ -16,6 +16,8 @@
    checkbox, with no JavaScript. */
 td.hx-grid-multiselect-cell {
 	padding: 0;
+	height: 1px; /* table cells treat height as a minimum, so this is a definite base that lets the
+	                label's height: 100% resolve while the cell still grows to the full row height */
 }
 
 td.hx-grid-multiselect-cell ::deep .hx-grid-multiselect-checkbox {

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/Internal/HxMultiSelectGridColumnInternal.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/Internal/HxMultiSelectGridColumnInternal.cs
@@ -23,24 +23,33 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 		{
 			return new GridCellTemplate
 			{
-				CssClass = "text-center",
+				CssClass = "text-center hx-grid-multiselect-cell",
 				Template = (RenderTreeBuilder builder) =>
 				{
-					builder.OpenElement(100, "input");
-					builder.AddAttribute(101, "type", "checkbox");
-					builder.AddAttribute(102, "class", "form-check-input");
+					// The label wraps the checkbox so that a click anywhere in the cell toggles it
+					// (native <label> behavior, no JavaScript). stopPropagation keeps the cell click
+					// from bubbling to the row click handler.
+					builder.OpenElement(100, "label");
+					builder.AddAttribute(101, "class", "hx-grid-multiselect-checkbox");
+					builder.AddEventStopPropagationAttribute(102, "onclick", true);
 
-					builder.AddAttribute(103, "checked", AllDataItemsSelected);
-					builder.AddAttribute(104, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectAllOrNoneClick));
+					builder.OpenElement(110, "input");
+					builder.AddAttribute(111, "type", "checkbox");
+					builder.AddAttribute(112, "class", "form-check-input");
+
+					builder.AddAttribute(113, "checked", AllDataItemsSelected);
+					builder.AddAttribute(114, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectAllOrNoneClick));
 					builder.SetUpdatesAttributeName("checked");
-					builder.AddEventStopPropagationAttribute(105, "onclick", true);
+					builder.AddEventStopPropagationAttribute(115, "onclick", true);
 
 					if ((context.TotalCount is null) || (context.TotalCount == 0))
 					{
-						builder.AddAttribute(102, "disabled");
+						builder.AddAttribute(116, "disabled");
 					}
 
 					builder.CloseElement(); // input
+
+					builder.CloseElement(); // label
 				}
 			};
 		}
@@ -55,20 +64,29 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 	{
 		return new GridCellTemplate
 		{
-			CssClass = "text-center",
+			CssClass = "text-center hx-grid-multiselect-cell",
 			Template = (RenderTreeBuilder builder) =>
 			{
-				builder.OpenElement(100, "input");
-				builder.AddAttribute(101, "type", "checkbox");
-				builder.AddAttribute(102, "class", "form-check-input");
+				// The label wraps the checkbox so that a click anywhere in the cell toggles it
+				// (native <label> behavior, no JavaScript). stopPropagation keeps the cell click
+				// from bubbling to the row click handler.
+				builder.OpenElement(100, "label");
+				builder.AddAttribute(101, "class", "hx-grid-multiselect-checkbox");
+				builder.AddEventStopPropagationAttribute(102, "onclick", true);
+
+				builder.OpenElement(110, "input");
+				builder.AddAttribute(111, "type", "checkbox");
+				builder.AddAttribute(112, "class", "form-check-input");
 
 				bool selected = SelectedDataItems?.Contains(item) ?? false;
-				builder.AddAttribute(103, "checked", selected);
-				builder.AddAttribute(104, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectDataItemClick(item, selected)));
+				builder.AddAttribute(113, "checked", selected);
+				builder.AddAttribute(114, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectDataItemClick(item, selected)));
 				builder.SetUpdatesAttributeName("checked");
-				builder.AddEventStopPropagationAttribute(105, "onclick", true);
+				builder.AddEventStopPropagationAttribute(115, "onclick", true);
 
 				builder.CloseElement(); // input
+
+				builder.CloseElement(); // label
 			}
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/Internal/HxMultiSelectGridColumnInternal.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/Internal/HxMultiSelectGridColumnInternal.cs
@@ -23,7 +23,7 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 		{
 			return new GridCellTemplate
 			{
-				CssClass = "text-center hx-grid-multiselect-cell",
+				CssClass = "hx-grid-multiselect-cell",
 				Template = (RenderTreeBuilder builder) =>
 				{
 					// The label wraps the checkbox so that a click anywhere in the cell toggles it
@@ -33,18 +33,18 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 					builder.AddAttribute(101, "class", "hx-grid-multiselect-checkbox");
 					builder.AddEventStopPropagationAttribute(102, "onclick", true);
 
-					builder.OpenElement(110, "input");
-					builder.AddAttribute(111, "type", "checkbox");
-					builder.AddAttribute(112, "class", "form-check-input");
+					builder.OpenElement(103, "input");
+					builder.AddAttribute(104, "type", "checkbox");
+					builder.AddAttribute(105, "class", "form-check-input");
 
-					builder.AddAttribute(113, "checked", AllDataItemsSelected);
-					builder.AddAttribute(114, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectAllOrNoneClick));
+					builder.AddAttribute(106, "checked", AllDataItemsSelected);
+					builder.AddAttribute(107, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectAllOrNoneClick));
 					builder.SetUpdatesAttributeName("checked");
-					builder.AddEventStopPropagationAttribute(115, "onclick", true);
+					builder.AddEventStopPropagationAttribute(108, "onclick", true);
 
 					if ((context.TotalCount is null) || (context.TotalCount == 0))
 					{
-						builder.AddAttribute(116, "disabled");
+						builder.AddAttribute(109, "disabled");
 					}
 
 					builder.CloseElement(); // input
@@ -64,7 +64,7 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 	{
 		return new GridCellTemplate
 		{
-			CssClass = "text-center hx-grid-multiselect-cell",
+			CssClass = "hx-grid-multiselect-cell",
 			Template = (RenderTreeBuilder builder) =>
 			{
 				// The label wraps the checkbox so that a click anywhere in the cell toggles it
@@ -74,15 +74,15 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 				builder.AddAttribute(101, "class", "hx-grid-multiselect-checkbox");
 				builder.AddEventStopPropagationAttribute(102, "onclick", true);
 
-				builder.OpenElement(110, "input");
-				builder.AddAttribute(111, "type", "checkbox");
-				builder.AddAttribute(112, "class", "form-check-input");
+				builder.OpenElement(103, "input");
+				builder.AddAttribute(104, "type", "checkbox");
+				builder.AddAttribute(105, "class", "form-check-input");
 
 				bool selected = SelectedDataItems?.Contains(item) ?? false;
-				builder.AddAttribute(113, "checked", selected);
-				builder.AddAttribute(114, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectDataItemClick(item, selected)));
+				builder.AddAttribute(106, "checked", selected);
+				builder.AddAttribute(107, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectDataItemClick(item, selected)));
 				builder.SetUpdatesAttributeName("checked");
-				builder.AddEventStopPropagationAttribute(115, "onclick", true);
+				builder.AddEventStopPropagationAttribute(108, "onclick", true);
 
 				builder.CloseElement(); // input
 


### PR DESCRIPTION
## Summary
Fixes #1411 — in `HxGrid` with `MultiSelectionEnabled`, only the small checkbox glyph was clickable. Clicks landing in the rest of the cell bubbled to the row click handler and toggled row selection / opened detail instead of the checkbox.

## Change
- `HxMultiSelectGridColumnInternal`: wrap the checkbox `<input>` in a `<label class="hx-grid-multiselect-checkbox">` (both the per-row checkbox and the header "select all"). A native `<label>` toggles its inner checkbox on click — **no JavaScript**. `stopPropagation` on the label keeps the cell click from reaching the row click handler.
- `HxGrid.razor.css`: move the cell padding onto the label and stretch it to fill the cell (`display:flex`, `height:100%`, `cursor:pointer`), so the whole cell — including former padding — is the click target. Visual layout is unchanged.

## Notes
- No public API change; behavior is scoped to the internal multi-select column only.
- Builds clean on net8.0 / net9.0 / net10.0 (0 warnings, 0 errors).

## Test plan
- [ ] Grid with `MultiSelectionEnabled`: click anywhere in the first-column cell of a row → checkbox toggles, the row click action does **not** fire.
- [ ] Clicking other cells still triggers the row action as before.
- [ ] Header "select all" checkbox toggles when clicking anywhere in its cell; disabled state (empty grid) is respected.
- [ ] Column alignment / row height unchanged versus before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
