### PR TITLE
Resolve MSB3277 DI/Logging.Abstractions version conflict on net8.0/net9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,10 +35,19 @@
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" Condition="'$(TargetFramework)' != 'net10.0'" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(AspNetCoreVersion10)" />
-		<PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.8" />
-		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.8" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion10)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(AspNetCoreVersion10)" />
+		<!-- TFM-conditional so transitive references stay aligned with the target framework's shared assembly version (avoids MSB3277 conflicts on net8.0/net9.0). The non-net8/net9 entry is the default and also applies to net10.0 and netstandard2.0. -->
+		<PackageVersion Include="Microsoft.Extensions.Localization" Version="$(AspNetCoreVersion10)" Condition="'$(TargetFramework)' != 'net9.0' AND '$(TargetFramework)' != 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Localization" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' == 'net9.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Localization" Version="$(AspNetCoreVersion8)" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="$(AspNetCoreVersion10)" Condition="'$(TargetFramework)' != 'net9.0' AND '$(TargetFramework)' != 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' == 'net9.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="$(AspNetCoreVersion8)" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" Condition="'$(TargetFramework)' != 'net9.0' AND '$(TargetFramework)' != 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.8" Condition="'$(TargetFramework)' != 'net9.0' AND '$(TargetFramework)' != 'net8.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageVersion Include="Microsoft.Playwright.Xunit.v3" Version="1.60.0" />
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
 		<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />

--- a/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj
@@ -13,6 +13,11 @@
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 
+	<!-- On net8.0 this project uses the .NET 9 EF Core stack (see Directory.Packages.props), which requires Microsoft.Extensions.Logging.Abstractions >= 9.0.16, higher than the net8.0 central pin. Override here only; the project is not packable, so it does not cause assembly-version conflicts in shipped packages. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.16" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Havit.Blazor.Components.Web.Bootstrap\Havit.Blazor.Components.Web.Bootstrap.csproj" />
 		<ProjectReference Include="..\Havit.Blazor.Components.Web\Havit.Blazor.Components.Web.csproj" />

--- a/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj
@@ -15,7 +15,7 @@
 
 	<!-- On net8.0 this project uses the .NET 9 EF Core stack (see Directory.Packages.props), which requires Microsoft.Extensions.Logging.Abstractions >= 9.0.16, higher than the net8.0 central pin. Override here only; the project is not packable, so it does not cause assembly-version conflicts in shipped packages. -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.16" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="$(AspNetCoreVersion9)" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## What

Fixes the `MSB3277` build warning about conflicting versions of `Microsoft.Extensions.DependencyInjection.Abstractions` (and `Microsoft.Extensions.Logging.Abstractions`) on the `net8.0`/`net9.0` builds.

## Why

`Directory.Packages.props` pinned `Microsoft.Extensions.Localization`, `…Localization.Abstractions`, `…Logging.Abstractions` and `…Logging.Configuration` **unconditionally to the .NET 10 version (10.0.8)**. With `CentralPackageTransitivePinningEnabled=true`, that 10.0.8 pin was forced onto the `net8.0`/`net9.0` builds as well, via:

`Localization 10.0.8` → `Logging.Abstractions 10.0.8` → `DependencyInjection.Abstractions 10.0.8`

As a result, the shipped `Havit.Blazor.Grpc.Client.dll` (net8.0/net9.0) was compiled against assembly version **10.0.0.0**, while a downstream consumer (`Havit.Blazor.Grpc.Client.ServerSideRendering`) resolves **8.0.0.0 / 9.0.0.0** from its shared framework — the unresolvable conflict reported as MSB3277.

## Changes

- **`Directory.Packages.props`** — make the four `Microsoft.Extensions.*` packages **per-TFM conditional** (mirroring the existing `Microsoft.AspNetCore.Components.Web` pattern), so each target framework references its matching shared-framework assembly version:
  - net8.0 → 8.0.x
  - net9.0 → 9.0.16
  - net10.0 / netstandard2.0 (default) → 10.0.8 (unchanged from before)
- **`Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj`** — add a `net8.0`-scoped `VersionOverride` for `Logging.Abstractions` to 9.0.16. This project deliberately uses the **.NET 9 EF Core stack on net8.0** (per the existing `EntityFrameworkCore.SqlServer` pin), which requires `Logging.Abstractions >= 9.0.16`. It is `IsPackable=false`, so the override causes no assembly-version conflict in shipped packages.

## Dependency bump

Reviewed all packages against NuGet (`dotnet list package --outdated`). The repo is already on the latest compatible versions; nothing else is safely bumpable:
- The 10.0.8 "updates" flagged for net8/net9 are the intentional per-TFM pins (forcing them is what triggers MSB3277).
- `Microsoft.Testing.Extensions.TrxReport` 1.9.1 → 2.2.3 is **incompatible** — it requires Microsoft.Testing.Platform 2.2.3, while `xunit.v3` 3.2.2 (latest) pins MTP 1.9.1 (mtp-v1).
- `SmartComponents.*` are preview packages not on the public feed.

## Verification

- Full solution build (`-c Release`, `TreatWarningsAsErrors`): **0 warnings, 0 errors** — MSB3277 gone.
- net8.0 tests pass for affected projects: `Grpc.Client.Tests`, `Grpc.Core.Tests`, `Components.Web.Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)