### PR TITLE
[HxGrid] Reject RefreshDataAsync with InvalidOperationException when grid is already disposed

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Basic_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Basic_Tests.cs
@@ -174,4 +174,26 @@ public class HxGrid_Basic_Tests : BunitTestBase
 		Assert.Null(header.GetAttribute("role"));
 	}
 
+	[Fact]
+	public async Task HxGrid_RefreshDataAsync_AfterDispose_ThrowsInvalidOperationException()
+	{
+		// Arrange
+		var items = Enumerable.Range(1, 3).Select(i => new TestItem(i, $"Item {i}")).ToList();
+		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) =>
+			Task.FromResult(request.ApplyTo(items));
+
+		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+			.Add(p => p.DataProvider, dataProvider)
+			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
+				.Add(c => c.HeaderText, "Name")
+				.Add(c => c.ItemTextSelector, item => item.Name)));
+
+		var grid = cut.Instance;
+		await grid.DisposeAsync();
+
+		// Act + Assert
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => cut.InvokeAsync(() => grid.RefreshDataAsync()));
+		Assert.Equal("Cannot call RefreshDataAsync method on disposed component.", exception.Message);
+	}
+
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -676,6 +676,8 @@ public partial class HxGrid<TItem> : ComponentBase, IAsyncDisposable
 	/// <param name="resetOptions">Specifies which aspects of the grid state should be reset before refreshing data (e.g., position).</param>
 	public async Task RefreshDataAsync(GridStateResetOptions resetOptions)
 	{
+		Contract.Requires<InvalidOperationException>(_isDisposed == false, "Cannot call RefreshDataAsync method on disposed component.");
+
 		await ResetGridStateAsync(resetOptions);
 
 		if (_firstRenderCompleted)
@@ -691,6 +693,11 @@ public partial class HxGrid<TItem> : ComponentBase, IAsyncDisposable
 	/// </summary>
 	protected async Task RefreshDataCoreAsync()
 	{
+		if (_isDisposed)
+		{
+			return; // NOOP (explicit check in RefreshDataAsync)
+		}
+
 		switch (ContentNavigationModeEffective)
 		{
 			case GridContentNavigationMode.Pagination:

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -676,7 +676,7 @@ public partial class HxGrid<TItem> : ComponentBase, IAsyncDisposable
 	/// <param name="resetOptions">Specifies which aspects of the grid state should be reset before refreshing data (e.g., position).</param>
 	public async Task RefreshDataAsync(GridStateResetOptions resetOptions)
 	{
-		Contract.Requires<InvalidOperationException>(_isDisposed == false, "Cannot call RefreshDataAsync method on disposed component.");
+		Contract.Requires<InvalidOperationException>(!_isDisposed, "Cannot call RefreshDataAsync method on disposed component.");
 
 		await ResetGridStateAsync(resetOptions);
 


### PR DESCRIPTION
## What changed

- `RefreshDataAsync(GridStateResetOptions)` now throws `InvalidOperationException` (via `Contract.Requires`) if called after the component has been disposed.
- `RefreshDataCoreAsync` has an early-return guard for the disposed state, preventing silent no-ops when the internal refresh path is triggered after disposal.

## Why

When `HxGrid` is disposed (e.g. the page navigates away) while an async operation is still holding a reference to it, subsequent calls to `RefreshDataAsync` would silently proceed and potentially cause `ObjectDisposedException` or corrupted state deeper in the call chain. Failing fast with a clear `InvalidOperationException` makes misuse explicit and easier to diagnose.

## Reviewer notes

- The public API throws immediately via `Contract.Requires<InvalidOperationException>`.
- `RefreshDataCoreAsync` has a secondary guard with an early return (noted as NOOP) to stay safe even when invoked via internal code paths after disposal.