### PR TITLE
Add .claude/launch.json with dev server launch configurations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,8 +1,27 @@
 {
-  "version": "0.0.1",
-  "configurations": [
-    {
-      "name": "Documentation.Server",
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "Documentation.Server",
+			"runtimeExecutable": "dotnet",
+			"runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Server/Havit.Blazor.Documentation.Server.csproj", "--launch-profile", "Havit.Blazor.Documentation.Server"],
+			"port": 5000
+		},
+		{
+			"name": "TestApp",
+			"runtimeExecutable": "dotnet",
+			"runtimeArgs": ["watch", "--project", "Havit.Blazor.TestApp/Havit.Blazor.TestApp/Havit.Blazor.TestApp.csproj", "--launch-profile", "http"],
+			"port": 5277
+		},
+		{
+			"name": "ApplicationInsights.TestApp",
+			"runtimeExecutable": "dotnet",
+			"runtimeArgs": ["watch", "--project", "Havit.Blazor.ApplicationInsights.TestApp/Havit.Blazor.ApplicationInsights.TestApp.csproj", "--launch-profile", "http"],
+			"port": 5024
+		},
+		{
+			"name": "Documentation.Mcp",
+			"runtimeExecutable": "dotnet",
       "runtimeExecutable": "dotnet",
       "runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Server/Havit.Blazor.Documentation.Server.csproj", "--launch-profile", "Havit.Blazor.Documentation.Server"],
       "port": 5000

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,45 +4,50 @@
 		{
 			"name": "Documentation.Server",
 			"runtimeExecutable": "dotnet",
-			"runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Server/Havit.Blazor.Documentation.Server.csproj", "--launch-profile", "Havit.Blazor.Documentation.Server"],
+			"runtimeArgs": [
+				"watch",
+				"--project",
+				"Havit.Blazor.Documentation.Server/Havit.Blazor.Documentation.Server.csproj",
+				"--launch-profile",
+				"Havit.Blazor.Documentation.Server"
+			],
 			"port": 5000
 		},
 		{
 			"name": "TestApp",
 			"runtimeExecutable": "dotnet",
-			"runtimeArgs": ["watch", "--project", "Havit.Blazor.TestApp/Havit.Blazor.TestApp/Havit.Blazor.TestApp.csproj", "--launch-profile", "http"],
+			"runtimeArgs": [
+				"watch",
+				"--project",
+				"Havit.Blazor.TestApp/Havit.Blazor.TestApp/Havit.Blazor.TestApp.csproj",
+				"--launch-profile",
+				"http"
+			],
 			"port": 5277
 		},
 		{
 			"name": "ApplicationInsights.TestApp",
 			"runtimeExecutable": "dotnet",
-			"runtimeArgs": ["watch", "--project", "Havit.Blazor.ApplicationInsights.TestApp/Havit.Blazor.ApplicationInsights.TestApp.csproj", "--launch-profile", "http"],
+			"runtimeArgs": [
+				"watch",
+				"--project",
+				"Havit.Blazor.ApplicationInsights.TestApp/Havit.Blazor.ApplicationInsights.TestApp.csproj",
+				"--launch-profile",
+				"http"
+			],
 			"port": 5024
 		},
 		{
 			"name": "Documentation.Mcp",
 			"runtimeExecutable": "dotnet",
-      "runtimeExecutable": "dotnet",
-      "runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Server/Havit.Blazor.Documentation.Server.csproj", "--launch-profile", "Havit.Blazor.Documentation.Server"],
-      "port": 5000
-    },
-    {
-      "name": "TestApp",
-      "runtimeExecutable": "dotnet",
-      "runtimeArgs": ["watch", "--project", "Havit.Blazor.TestApp/Havit.Blazor.TestApp/Havit.Blazor.TestApp.csproj", "--launch-profile", "http"],
-      "port": 5277
-    },
-    {
-      "name": "ApplicationInsights.TestApp",
-      "runtimeExecutable": "dotnet",
-      "runtimeArgs": ["watch", "--project", "Havit.Blazor.ApplicationInsights.TestApp/Havit.Blazor.ApplicationInsights.TestApp.csproj", "--launch-profile", "http"],
-      "port": 5024
-    },
-    {
-      "name": "Documentation.Mcp",
-      "runtimeExecutable": "dotnet",
-      "runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Mcp/Havit.Blazor.Documentation.Mcp.csproj", "--launch-profile", "http"],
-      "port": 6156
-    }
-  ]
+			"runtimeArgs": [
+				"watch",
+				"--project",
+				"Havit.Blazor.Documentation.Mcp/Havit.Blazor.Documentation.Mcp.csproj",
+				"--launch-profile",
+				"http"
+			],
+			"port": 6156
+		}
+	]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Documentation.Server",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Server/Havit.Blazor.Documentation.Server.csproj", "--launch-profile", "Havit.Blazor.Documentation.Server"],
+      "port": 5000
+    },
+    {
+      "name": "TestApp",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["watch", "--project", "Havit.Blazor.TestApp/Havit.Blazor.TestApp/Havit.Blazor.TestApp.csproj", "--launch-profile", "http"],
+      "port": 5277
+    },
+    {
+      "name": "ApplicationInsights.TestApp",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["watch", "--project", "Havit.Blazor.ApplicationInsights.TestApp/Havit.Blazor.ApplicationInsights.TestApp.csproj", "--launch-profile", "http"],
+      "port": 5024
+    },
+    {
+      "name": "Documentation.Mcp",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["watch", "--project", "Havit.Blazor.Documentation.Mcp/Havit.Blazor.Documentation.Mcp.csproj", "--launch-profile", "http"],
+      "port": 6156
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
Adds `.claude/launch.json` with launch configurations for the solution's runnable web projects, so the dev servers can be started directly from Claude Code's preview tooling.

Configured servers (all via `dotnet watch`):
- **Documentation.Server** — main docs web app (port 5000)
- **TestApp** — `Havit.Blazor.TestApp` component test app (port 5277)
- **ApplicationInsights.TestApp** (port 5024)
- **Documentation.Mcp** — MCP server (port 6156)

Ports and launch profiles were derived from each project's `Properties/launchSettings.json`.

## Why
Convenience for local development with Claude Code — lets the preview tooling discover and start the dev servers without re-detecting them each session. `.claude/` is already tracked in the repo (it contains `CLAUDE.md`), so this fits the existing convention.

## Notes for reviewers
- This is tooling/config only; no application code is affected.
- Split out from the documentation PR (#1426) so it can be reviewed/merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)