### PR TITLE
Docs: trim Havit.Blazor.Storage browser storage page

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Concepts/BrowserStorage_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Concepts/BrowserStorage_Documentation.razor
@@ -36,7 +36,6 @@ builder.Services.AddHavitBlazorStorage();
 """)</CodeSnippet>
 <p>
 	This registers both <code>ILocalStorageService</code> and <code>ISessionStorageService</code> with a <code>Scoped</code> lifetime.
-	No <code>&lt;script&gt;</code> reference is required &ndash; the small supporting JavaScript module is loaded automatically by the Blazor JS initializer.
 </p>
 
 <DocHeading Title="Basic usage" />
@@ -160,11 +159,6 @@ builder.Services.AddHavitBlazorStorage(options =>
 	<li><code>GetLength</code> &ndash; the number of keys stored.</li>
 	<li><code>GetKeyByIndex</code> / <code>TryGetKeyByIndex</code> &ndash; enumerate the keys by their zero-based index.</li>
 </ul>
-<DocAlert Type="DocAlertType.Info">
-	The <code>Get*</code> / <code>GetKeyByIndex</code> methods throw <code>StorageKeyNotFoundException</code> /
-	<code>StorageIndexOutOfRangeException</code> when the requested key/index is not present.
-	Use the <code>TryGet*</code> overloads when a missing value is an expected, non-exceptional case.
-</DocAlert>
 
 <DocHeading Title="Error handling" Id="error-handling" />
 <p>The storage methods can throw the following exceptions:</p>


### PR DESCRIPTION
## What changed

Two edits to the **Browser Web Storage** documentation page (`BrowserStorage_Documentation.razor`), based on review feedback:

1. **Removed an internals note** from the "Register services" section — the sentence about no `<script>` reference being required and the supporting JavaScript module being loaded automatically by the Blazor JS initializer. This describes implementation internals that aren't relevant to consumers.
2. **Removed a duplicate info box** from the "API overview" section — the `DocAlert` about `Get*`/`GetKeyByIndex` throwing `StorageKeyNotFoundException`/`StorageIndexOutOfRangeException`. The very next "Error handling" section already conveys the same information.

## Why

Tightens the docs by dropping consumer-irrelevant internals and removing duplicated content.

## Notes for reviewer

Documentation-only change; no code or API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)