### PR TITLE
Bump dependencies; migrate xUnit v3 to Microsoft.Testing.Platform v2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,9 @@
 	<PropertyGroup>
 <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-<AspNetCoreVersion8>8.0.27</AspNetCoreVersion8>
-<AspNetCoreVersion9>9.0.16</AspNetCoreVersion9>
-<AspNetCoreVersion10>10.0.8</AspNetCoreVersion10>
+<AspNetCoreVersion8>8.0.28</AspNetCoreVersion8>
+<AspNetCoreVersion9>9.0.17</AspNetCoreVersion9>
+<AspNetCoreVersion10>10.0.9</AspNetCoreVersion10>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
@@ -49,10 +49,10 @@
 		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageVersion Include="Microsoft.Playwright.Xunit.v3" Version="1.60.0" />
-		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
+		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
 		<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
 		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="xunit.v3" Version="3.2.2" />
+		<PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
 		<PackageVersion Include="protobuf-net" Version="3.2.56" />
 		<PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
 		<PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />

--- a/Havit.Blazor.ApplicationInsights.E2ETests/Havit.Blazor.ApplicationInsights.E2ETests.csproj
+++ b/Havit.Blazor.ApplicationInsights.E2ETests/Havit.Blazor.ApplicationInsights.E2ETests.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Playwright.Xunit.v3" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 		

--- a/Havit.Blazor.ApplicationInsights.Tests/Havit.Blazor.ApplicationInsights.Tests.csproj
+++ b/Havit.Blazor.ApplicationInsights.Tests/Havit.Blazor.ApplicationInsights.Tests.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests/Havit.Blazor.Components.Web.Bootstrap.EntityFrameworkCore.Tests.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Havit.Blazor.Components.Web.Bootstrap.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Havit.Blazor.Components.Web.Bootstrap.Tests.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="bunit.web" />
 		<PackageReference Include="Moq" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.Components.Web.Tests/Havit.Blazor.Components.Web.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Tests/Havit.Blazor.Components.Web.Tests.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="bunit.web" />
 		<PackageReference Include="Moq" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.Documentation.Tests/Havit.Blazor.Documentation.Tests.csproj
+++ b/Havit.Blazor.Documentation.Tests/Havit.Blazor.Documentation.Tests.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="bunit.web" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.E2ETests/Havit.Blazor.E2ETests.csproj
+++ b/Havit.Blazor.E2ETests/Havit.Blazor.E2ETests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Playwright.Xunit.v3" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
   </ItemGroup>
 

--- a/Havit.Blazor.Grpc.Client.Tests/Havit.Blazor.Grpc.Client.Tests.csproj
+++ b/Havit.Blazor.Grpc.Client.Tests/Havit.Blazor.Grpc.Client.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.Grpc.Core.Tests/Havit.Blazor.Grpc.Core.Tests.csproj
+++ b/Havit.Blazor.Grpc.Core.Tests/Havit.Blazor.Grpc.Core.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="xunit.v3" />
+	  <PackageReference Include="xunit.v3.mtp-v2" />
 	  <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
   </ItemGroup>
 

--- a/Havit.Blazor.Grpc.Server.Tests/Havit.Blazor.Grpc.Server.Tests.csproj
+++ b/Havit.Blazor.Grpc.Server.Tests/Havit.Blazor.Grpc.Server.Tests.csproj
@@ -12,7 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 

--- a/Havit.Blazor.Storage.E2ETests/Havit.Blazor.Storage.E2ETests.csproj
+++ b/Havit.Blazor.Storage.E2ETests/Havit.Blazor.Storage.E2ETests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Playwright.Xunit.v3" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
   </ItemGroup>
 

--- a/Havit.SourceGenerators.StrongApiStringLocalizers.Tests/Havit.SourceGenerators.StrongApiStringLocalizers.Tests.csproj
+++ b/Havit.SourceGenerators.StrongApiStringLocalizers.Tests/Havit.SourceGenerators.StrongApiStringLocalizers.Tests.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
-		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>
 


### PR DESCRIPTION
## What changed

**Dependency bumps** (latest patch per TFM band in `Directory.Packages.props`):
- `AspNetCoreVersion8`: 8.0.27 → 8.0.28
- `AspNetCoreVersion9`: 9.0.16 → 9.0.17
- `AspNetCoreVersion10`: 10.0.8 → 10.0.9

**xUnit / Microsoft.Testing.Platform v2 migration:**
- All 12 test projects switched from `xunit.v3` to `xunit.v3.mtp-v2` — the same xUnit 3.2.2, just built against Microsoft.Testing.Platform v2 (per [xUnit MTP docs](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform); from xunit.v3 4.0 onward MTP v2 becomes the default and the plain `xunit.v3` package can be restored)
- `Microsoft.Testing.Extensions.TrxReport` 1.9.1 → 2.2.3 (2.x requires MTP v2; incompatible with the previous setup)

## Notes for reviewers

- `Microsoft.Playwright.Xunit.v3` depends only on `xunit.v3.extensibility.core`, so it is flavor-agnostic and unaffected by the MTP v2 switch.
- `global.json` already configures `"test": { "runner": "Microsoft.Testing.Platform" }` — no change needed there.
- Other packages (Grpc, bunit, Playwright, Moq, protobuf-net, Havit.*, analyzers, …) are already at latest stable. SmartComponents previews are delisted upstream and left as-is.
- The net8.0 pins for `Microsoft.Extensions.Logging.Abstractions` (8.0.3) and `Logging.Configuration` (8.0.1) are already the latest 8.0.x.

## Verification

- `dotnet build -warnaserror` — 0 warnings
- `dotnet test` — all 2075 tests pass (incl. Playwright E2E suites)
- TRX report generation verified with TrxReport 2.2.3 (`--report-trx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)