### PR TITLE
Bootstrap 6 breakpoints (lg/xl raised, xxl -> 2xl) and prefix-based responsive class syntax

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Carousel/HxCarouselCaption.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Carousel/HxCarouselCaption.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
 
-<div class="@CssClassHelper.Combine("carousel-caption d-none d-md-block", CssClass)">
+<div class="@CssClassHelper.Combine("carousel-caption d-none md:d-block", CssClass)">
     @ChildContent
 </div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor
@@ -56,7 +56,7 @@
 
 		@if (pageFromInclusive > 0)
 		{
-			<li class="page-item d-none d-md-block"><button type="button" class="page-link" aria-label="@HxPagerLocalizer["PreviousPages"]" @onclick="async () => await SetCurrentPageIndexTo(pageFromInclusive - 1)" @onclick:stopPropagation>...</button></li>
+			<li class="page-item d-none md:d-block"><button type="button" class="page-link" aria-label="@HxPagerLocalizer["PreviousPages"]" @onclick="async () => await SetCurrentPageIndexTo(pageFromInclusive - 1)" @onclick:stopPropagation>...</button></li>
 		}
 
 		@for (int i = pageFromInclusive; i < pageToExclusive; i++)
@@ -70,13 +70,13 @@
 			}
 			else
 			{
-				<li class="page-item d-none d-md-block"><button type="button" class="page-link" aria-label="@HxPagerLocalizer["GoToPage", (j + 1).ToString("N0")]" @onclick="async () => await SetCurrentPageIndexTo(j)" @onclick:stopPropagation>@((j + 1).ToString("N0"))</button></li>
+				<li class="page-item d-none md:d-block"><button type="button" class="page-link" aria-label="@HxPagerLocalizer["GoToPage", (j + 1).ToString("N0")]" @onclick="async () => await SetCurrentPageIndexTo(j)" @onclick:stopPropagation>@((j + 1).ToString("N0"))</button></li>
 			}
 		}
 
 		@if (pageToExclusive < (TotalPages - 1))
 		{
-			<li class="page-item d-none d-md-block"><button type="button" class="page-link" aria-label="@HxPagerLocalizer["NextPages"]" @onclick="async () => await SetCurrentPageIndexTo(pageToExclusive)" @onclick:stopPropagation>...</button></li>
+			<li class="page-item d-none md:d-block"><button type="button" class="page-link" aria-label="@HxPagerLocalizer["NextPages"]" @onclick="async () => await SetCurrentPageIndexTo(pageToExclusive)" @onclick:stopPropagation>...</button></li>
 		}
 
 		@if (showPreviousNext)

--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor
@@ -77,7 +77,7 @@
 
             @if (FilterModel != null)
             {
-                <HxChipList Chips="_chips" OnChipRemoveClick="HandleChipRemoveClick" CssClass="flex-nowrap flex-md-wrap overflow-x-auto" />
+                <HxChipList Chips="_chips" OnChipRemoveClick="HandleChipRemoveClick" CssClass="flex-nowrap md:flex-wrap overflow-x-auto" />
             }
             @if (FilterTemplate != null)
             {

--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/ILayoutColumnComponent.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/ILayoutColumnComponent.cs
@@ -24,19 +24,19 @@ public interface ILayoutColumnComponent
 	string ColumnsMediumUp { get; set; }
 
 	/// <summary>
-	/// Number of template columns to span for viewports above the "large" breakpoint (<c>992px</c>).<br/>
+	/// Number of template columns to span for viewports above the "large" breakpoint (<c>1024px</c>).<br/>
 	/// The value can be any integer number between <c>1</c> and <c>12</c>, <c>auto</c>, or <c>true</c>.
 	/// </summary>
 	string ColumnsLargeUp { get; set; }
 
 	/// <summary>
-	/// Number of template columns to span for viewports above the "extra-large" breakpoint (<c>1200px</c>).<br/>
+	/// Number of template columns to span for viewports above the "extra-large" breakpoint (<c>1280px</c>).<br/>
 	/// The value can be any integer number between <c>1</c> and <c>12</c>, <c>auto</c>, or <c>true</c>.
 	/// </summary>
 	string ColumnsExtraLargeUp { get; set; }
 
 	/// <summary>
-	/// Number of template columns to span for viewports above the "XXL" breakpoint (<c>1400px</c>).<br/>
+	/// Number of template columns to span for viewports above the "2xl" breakpoint (<c>1536px</c>).<br/>
 	/// The value can be any integer number between <c>1</c> and <c>12</c>, <c>auto</c>, or <c>true</c>.
 	/// </summary>
 	string ColumnsXxlUp { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/LayoutColumnComponentExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/LayoutColumnComponentExtensions.cs
@@ -13,22 +13,20 @@ public static class LayoutColumnComponentExtensions
 			GetColumnCssClass(columnComponent.ColumnsMediumUp, "md"),
 			GetColumnCssClass(columnComponent.ColumnsLargeUp, "lg"),
 			GetColumnCssClass(columnComponent.ColumnsExtraLargeUp, "xl"),
-			GetColumnCssClass(columnComponent.ColumnsXxlUp, "xxl"));
+			GetColumnCssClass(columnComponent.ColumnsXxlUp, "2xl"));
 	}
 
-	private static string GetColumnCssClass(string value, string infix)
+	private static string GetColumnCssClass(string value, string breakpoint)
 	{
-		if (!String.IsNullOrWhiteSpace(infix))
-		{
-			infix = "-" + infix;
-		}
+		// Bootstrap 6 uses prefix syntax for responsive grid classes (col-md-6 -> md:col-6).
+		string prefix = String.IsNullOrWhiteSpace(breakpoint) ? String.Empty : breakpoint + ":";
 		return value switch
 		{
 			null => null,
 			"" => null,
-			"1" or "2" or "3" or "4" or "5" or "6" or "7" or "8" or "9" or "10" or "11" or "12" => "col" + infix + "-" + value,
-			"auto" => "col" + infix + "-auto",
-			"true" => "col" + infix,
+			"1" or "2" or "3" or "4" or "5" or "6" or "7" or "8" or "9" or "10" or "11" or "12" => prefix + "col-" + value,
+			"auto" => prefix + "col-auto",
+			"true" => prefix + "col",
 			_ => throw new ArgumentException($"Unknown column value {value}")
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/ListGroups/HxListGroup.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/ListGroups/HxListGroup.razor.cs
@@ -53,11 +53,11 @@ public partial class HxListGroup
 		{
 			ListGroupHorizontal.Never => null,
 			ListGroupHorizontal.Always => "list-group-horizontal",
-			ListGroupHorizontal.SmallUp => "list-group-horizontal-sm",
-			ListGroupHorizontal.MediumUp => "list-group-horizontal-md",
-			ListGroupHorizontal.LargeUp => "list-group-horizontal-lg",
-			ListGroupHorizontal.ExtraLargeUp => "list-group-horizontal-xl",
-			ListGroupHorizontal.XxlUp => "list-group-horizontal-xxl",
+			ListGroupHorizontal.SmallUp => "sm:list-group-horizontal",
+			ListGroupHorizontal.MediumUp => "md:list-group-horizontal",
+			ListGroupHorizontal.LargeUp => "lg:list-group-horizontal",
+			ListGroupHorizontal.ExtraLargeUp => "xl:list-group-horizontal",
+			ListGroupHorizontal.XxlUp => "2xl:list-group-horizontal",
 			_ => throw new InvalidOperationException($"Unknown {nameof(ListGroupHorizontal)} value {Horizontal}.")
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/ListGroups/ListGroupHorizontal.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/ListGroups/ListGroupHorizontal.cs
@@ -22,17 +22,17 @@ public enum ListGroupHorizontal
 	MediumUp,
 
 	/// <summary>
-	/// Horizontal for viewports above the "large" breakpoint (<c>992px</c>).
+	/// Horizontal for viewports above the "large" breakpoint (<c>1024px</c>).
 	/// </summary>
 	LargeUp,
 
 	/// <summary>
-	/// Horizontal for viewports above the "extra-large" breakpoint (<c>1200px</c>).
+	/// Horizontal for viewports above the "extra-large" breakpoint (<c>1280px</c>).
 	/// </summary>
 	ExtraLargeUp,
 
 	/// <summary>
-	/// Horizontal for viewports above the "XXL" breakpoint (<c>1400px</c>).
+	/// Horizontal for viewports above the "2xl" breakpoint (<c>1536px</c>).
 	/// </summary>
 	XxlUp,
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Modals/ModalFullscreen.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Modals/ModalFullscreen.cs
@@ -26,17 +26,17 @@ public enum ModalFullscreen
 	MediumDown = 3,
 
 	/// <summary>
-	/// Fullscreen for viewports below the "large" breakpoint (<c>992px</c>).
+	/// Fullscreen for viewports below the "large" breakpoint (<c>1024px</c>).
 	/// </summary>
 	LargeDown = 4,
 
 	/// <summary>
-	/// Fullscreen for viewports below the "extra-large" breakpoint (<c>1200px</c>).
+	/// Fullscreen for viewports below the "extra-large" breakpoint (<c>1280px</c>).
 	/// </summary>
 	ExtraLargeDown = 5,
 
 	/// <summary>
-	/// Fullscreen for viewports below the "XXL" breakpoint (<c>1400px</c>).
+	/// Fullscreen for viewports below the "2xl" breakpoint (<c>1536px</c>).
 	/// </summary>
 	XxlDown = 6,
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNavbar.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNavbar.razor.cs
@@ -56,11 +56,11 @@ public partial class HxNavbar
 		return Expand switch
 		{
 			NavbarExpand.Always => "navbar-expand",
-			NavbarExpand.SmallUp => "navbar-expand-sm",
-			NavbarExpand.MediumUp => "navbar-expand-md",
-			NavbarExpand.LargeUp => "navbar-expand-lg",
-			NavbarExpand.ExtraLargeUp => "navbar-expand-xl",
-			NavbarExpand.XxlUp => "navbar-expand-xxl",
+			NavbarExpand.SmallUp => "sm:navbar-expand",
+			NavbarExpand.MediumUp => "md:navbar-expand",
+			NavbarExpand.LargeUp => "lg:navbar-expand",
+			NavbarExpand.ExtraLargeUp => "xl:navbar-expand",
+			NavbarExpand.XxlUp => "2xl:navbar-expand",
 			NavbarExpand.Never => null,
 			_ => throw new InvalidOperationException($"Unknown {nameof(NavbarExpand)} value {Expand}.")
 		};

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/NavbarExpand.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/NavbarExpand.cs
@@ -21,17 +21,17 @@ public enum NavbarExpand
 	MediumUp,
 
 	/// <summary>
-	/// Expanded for viewports above the "large" breakpoint (<c>992px</c>).
+	/// Expanded for viewports above the "large" breakpoint (<c>1024px</c>).
 	/// </summary>
 	LargeUp,
 
 	/// <summary>
-	/// Expanded for viewports above the "extra-large" breakpoint (<c>1200px</c>).
+	/// Expanded for viewports above the "extra-large" breakpoint (<c>1280px</c>).
 	/// </summary>
 	ExtraLargeUp,
 
 	/// <summary>
-	/// Expanded for viewports above the "XXL" breakpoint (<c>1400px</c>).
+	/// Expanded for viewports above the "2xl" breakpoint (<c>1536px</c>).
 	/// </summary>
 	XxlUp,
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarResponsiveBreakpoint.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarResponsiveBreakpoint.cs
@@ -18,17 +18,17 @@ public enum SidebarResponsiveBreakpoint
 	Medium = 3,
 
 	/// <summary>
-	/// Mobile for viewports below the "large" breakpoint (<c>992px</c>, exclusive).
+	/// Mobile for viewports below the "large" breakpoint (<c>1024px</c>, exclusive).
 	/// </summary>
 	Large = 4,
 
 	/// <summary>
-	/// Mobile for viewports below the "extra-large" breakpoint (<c>1200px</c>, exclusive).
+	/// Mobile for viewports below the "extra-large" breakpoint (<c>1280px</c>, exclusive).
 	/// </summary>
 	ExtraLarge = 5,
 
 	/// <summary>
-	/// Mobile for viewports below the "XXL" breakpoint (<c>1400px</c>, exclusive).
+	/// Mobile for viewports below the "2xl" breakpoint (<c>1536px</c>, exclusive).
 	/// </summary>
 	Xxl = 6,
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarResponsiveBreakpointExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/SidebarResponsiveBreakpointExtensions.cs
@@ -4,14 +4,17 @@ public static class SidebarResponsiveBreakpointExtensions
 {
 	public static string GetCssClass(this SidebarResponsiveBreakpoint breakpoint, string cssClassPattern)
 	{
+		// Bootstrap 6 uses prefix syntax for responsive utilities (d-md-none -> md:d-none).
+		// The "-??-" placeholder in the pattern marks the former v5 infix position; the breakpoint is now emitted as a prefix.
+		string baseClass = cssClassPattern.Replace("-??-", "-"); // !!! Simplified for the use case of this component.
 		return breakpoint switch
 		{
-			SidebarResponsiveBreakpoint.None => cssClassPattern.Replace("-??-", "-"), // !!! Simplified for the use case of this component.
-			SidebarResponsiveBreakpoint.Small => cssClassPattern.Replace("??", "sm"),
-			SidebarResponsiveBreakpoint.Medium => cssClassPattern.Replace("??", "md"),
-			SidebarResponsiveBreakpoint.Large => cssClassPattern.Replace("??", "lg"),
-			SidebarResponsiveBreakpoint.ExtraLarge => cssClassPattern.Replace("??", "xl"),
-			SidebarResponsiveBreakpoint.Xxl => cssClassPattern.Replace("??", "xxl"),
+			SidebarResponsiveBreakpoint.None => baseClass,
+			SidebarResponsiveBreakpoint.Small => "sm:" + baseClass,
+			SidebarResponsiveBreakpoint.Medium => "md:" + baseClass,
+			SidebarResponsiveBreakpoint.Large => "lg:" + baseClass,
+			SidebarResponsiveBreakpoint.ExtraLarge => "xl:" + baseClass,
+			SidebarResponsiveBreakpoint.Xxl => "2xl:" + baseClass,
 			_ => throw new InvalidOperationException($"Unknown {nameof(SidebarResponsiveBreakpoint)} value {breakpoint}.")
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Offcanvas/OffcanvasResponsiveBreakpoint.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Offcanvas/OffcanvasResponsiveBreakpoint.cs
@@ -21,17 +21,17 @@ public enum OffcanvasResponsiveBreakpoint
 	Medium = 3,
 
 	/// <summary>
-	/// Render contents outside the viewport in an offcanvas when below the "large" breakpoint (<c>992px</c>, exclusive).
+	/// Render contents outside the viewport in an offcanvas when below the "large" breakpoint (<c>1024px</c>, exclusive).
 	/// </summary>
 	Large = 4,
 
 	/// <summary>
-	/// Render contents outside the viewport in an offcanvas when below the "extra-large" breakpoint (<c>1200px</c>, exclusive).
+	/// Render contents outside the viewport in an offcanvas when below the "extra-large" breakpoint (<c>1280px</c>, exclusive).
 	/// </summary>
 	ExtraLarge = 5,
 
 	/// <summary>
-	/// Render contents outside the viewport in an offcanvas when below the "XXL" breakpoint (<c>1400px</c>, exclusive).
+	/// Render contents outside the viewport in an offcanvas when below the "2xl" breakpoint (<c>1536px</c>, exclusive).
 	/// </summary>
 	Xxl = 6,
 }

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -8623,19 +8623,19 @@
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.ILayoutColumnComponent.ColumnsLargeUp">
             <summary>
-            Number of template columns to span for viewports above the "large" breakpoint (<c>992px</c>).<br/>
+            Number of template columns to span for viewports above the "large" breakpoint (<c>1024px</c>).<br/>
             The value can be any integer number between <c>1</c> and <c>12</c>, <c>auto</c>, or <c>true</c>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.ILayoutColumnComponent.ColumnsExtraLargeUp">
             <summary>
-            Number of template columns to span for viewports above the "extra-large" breakpoint (<c>1200px</c>).<br/>
+            Number of template columns to span for viewports above the "extra-large" breakpoint (<c>1280px</c>).<br/>
             The value can be any integer number between <c>1</c> and <c>12</c>, <c>auto</c>, or <c>true</c>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.ILayoutColumnComponent.ColumnsXxlUp">
             <summary>
-            Number of template columns to span for viewports above the "XXL" breakpoint (<c>1400px</c>).<br/>
+            Number of template columns to span for viewports above the "2xl" breakpoint (<c>1536px</c>).<br/>
             The value can be any integer number between <c>1</c> and <c>12</c>, <c>auto</c>, or <c>true</c>.
             </summary>
         </member>
@@ -8853,17 +8853,17 @@
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ListGroupHorizontal.LargeUp">
             <summary>
-            Horizontal for viewports above the "large" breakpoint (<c>992px</c>).
+            Horizontal for viewports above the "large" breakpoint (<c>1024px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ListGroupHorizontal.ExtraLargeUp">
             <summary>
-            Horizontal for viewports above the "extra-large" breakpoint (<c>1200px</c>).
+            Horizontal for viewports above the "extra-large" breakpoint (<c>1280px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ListGroupHorizontal.XxlUp">
             <summary>
-            Horizontal for viewports above the "XXL" breakpoint (<c>1400px</c>).
+            Horizontal for viewports above the "2xl" breakpoint (<c>1536px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ListGroupHorizontal.Always">
@@ -9525,17 +9525,17 @@
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ModalFullscreen.LargeDown">
             <summary>
-            Fullscreen for viewports below the "large" breakpoint (<c>992px</c>).
+            Fullscreen for viewports below the "large" breakpoint (<c>1024px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ModalFullscreen.ExtraLargeDown">
             <summary>
-            Fullscreen for viewports below the "extra-large" breakpoint (<c>1200px</c>).
+            Fullscreen for viewports below the "extra-large" breakpoint (<c>1280px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.ModalFullscreen.XxlDown">
             <summary>
-            Fullscreen for viewports below the "XXL" breakpoint (<c>1400px</c>).
+            Fullscreen for viewports below the "2xl" breakpoint (<c>1536px</c>).
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.ModalHidingEventArgs.Cancel">
@@ -10259,17 +10259,17 @@
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.NavbarExpand.LargeUp">
             <summary>
-            Expanded for viewports above the "large" breakpoint (<c>992px</c>).
+            Expanded for viewports above the "large" breakpoint (<c>1024px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.NavbarExpand.ExtraLargeUp">
             <summary>
-            Expanded for viewports above the "extra-large" breakpoint (<c>1200px</c>).
+            Expanded for viewports above the "extra-large" breakpoint (<c>1280px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.NavbarExpand.XxlUp">
             <summary>
-            Expanded for viewports above the "XXL" breakpoint (<c>1400px</c>).
+            Expanded for viewports above the "2xl" breakpoint (<c>1536px</c>).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.NavbarExpand.Never">
@@ -10360,17 +10360,17 @@
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.SidebarResponsiveBreakpoint.Large">
             <summary>
-            Mobile for viewports below the "large" breakpoint (<c>992px</c>, exclusive).
+            Mobile for viewports below the "large" breakpoint (<c>1024px</c>, exclusive).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.SidebarResponsiveBreakpoint.ExtraLarge">
             <summary>
-            Mobile for viewports below the "extra-large" breakpoint (<c>1200px</c>, exclusive).
+            Mobile for viewports below the "extra-large" breakpoint (<c>1280px</c>, exclusive).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.SidebarResponsiveBreakpoint.Xxl">
             <summary>
-            Mobile for viewports below the "XXL" breakpoint (<c>1400px</c>, exclusive).
+            Mobile for viewports below the "2xl" breakpoint (<c>1536px</c>, exclusive).
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.SidebarTogglerTemplateContext">
@@ -10674,17 +10674,17 @@
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.OffcanvasResponsiveBreakpoint.Large">
             <summary>
-            Render contents outside the viewport in an offcanvas when below the "large" breakpoint (<c>992px</c>, exclusive).
+            Render contents outside the viewport in an offcanvas when below the "large" breakpoint (<c>1024px</c>, exclusive).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.OffcanvasResponsiveBreakpoint.ExtraLarge">
             <summary>
-            Render contents outside the viewport in an offcanvas when below the "extra-large" breakpoint (<c>1200px</c>, exclusive).
+            Render contents outside the viewport in an offcanvas when below the "extra-large" breakpoint (<c>1280px</c>, exclusive).
             </summary>
         </member>
         <member name="F:Havit.Blazor.Components.Web.Bootstrap.OffcanvasResponsiveBreakpoint.Xxl">
             <summary>
-            Render contents outside the viewport in an offcanvas when below the "XXL" breakpoint (<c>1400px</c>, exclusive).
+            Render contents outside the viewport in an offcanvas when below the "2xl" breakpoint (<c>1536px</c>, exclusive).
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.OffcanvasSettings">


### PR DESCRIPTION
Fixes #1469

Bootstrap 6 raises the `lg`/`xl` breakpoints, renames `xxl` → `2xl`, and switches responsive/state classes from infix to Tailwind-style **prefix syntax** (`.navbar-expand-md` → `.md:navbar-expand`).

**Class generation updated:**
- `HxNavbar` expand: `navbar-expand-{bp}` → `{bp}:navbar-expand` (incl. `2xl:`)
- `HxListGroup` horizontal: `list-group-horizontal-{bp}` → `{bp}:list-group-horizontal`
- `ILayoutColumnComponent` (all form inputs, layout columns): `col-{bp}-{n}` → `{bp}:col-{n}`
- `HxSidebar` responsive utilities: `d-{bp}-none` → `{bp}:d-none` etc. (prefix emitted by `SidebarResponsiveBreakpointExtensions`)
- Inline responsive utilities in library markup (`HxCarouselCaption`, `HxPager`, `HxListLayout` chips)

**Docs:**
- Breakpoint doc comments updated to v6 values: `lg` 1024px, `xl` 1280px, `2xl` 1536px

**Intentionally out of scope:**
- `HxModal` fullscreen (`modal-fullscreen-*-down`) and `HxOffcanvas` responsive (`offcanvas-*`) class generation — those components' markup changes wholesale in #1439 (Dialog) and #1438 (Drawer); converting their class names alone would not make them functional.
- Public enum member names (`XxlUp`, …) are unchanged — only emitted classes and docs; no breaking API change in this PR.
- The custom HAVIT `xxxl: 1600px` breakpoint from the v5 Sass overrides — to be re-added as `3xl` when porting `_variables.scss` (tracked in #1472's notes).

**Note:** .NET SDK hosts are blocked in my environment — CI is the build verification.

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_