### PR TITLE
HxButton: Bootstrap 6 variant system (Variant parameter, Outline removed, btn-xs)

### DIFF
--- a/BlazorAppTest/Pages/HxButtonTest.razor
+++ b/BlazorAppTest/Pages/HxButtonTest.razor
@@ -8,7 +8,7 @@
 <HxButton Icon="BootstrapIcon.Filter" Color="ThemeColor.Secondary" />
 
 <HxButton Text="Click me..." Color="ThemeColor.Warning" />
-<HxButton Text="Outline..." Color="ThemeColor.Danger" Outline="true" />
+<HxButton Text="Outline..." Color="ThemeColor.Danger" Variant="ButtonVariant.Outline" />
 <HxButton Icon="BootstrapIcon.X" Color="ThemeColor.Warning" />
 <HxButton Text="With Tooltip" Icon="BootstrapIcon.ClockHistory" Color="ThemeColor.Warning" Tooltip="This is a tooltip with  very very long text. Is this tooltip text length enought? No. So let's make it even longer. And is the tooltip text long enought now? OK..." />
 

--- a/BlazorAppTest/Pages/HxInputDateTest.razor
+++ b/BlazorAppTest/Pages/HxInputDateTest.razor
@@ -15,20 +15,20 @@
     <HxInputDate Label="HxInputDate (default, DateOnly?)" @bind-Value="@model.NullableDateOnly" />
     <HxInputDate Label="HxInputDate (InputGroupStart, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime">
 	<InputGroupStartTemplate>
-		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 	</InputGroupStartTemplate>
 	</HxInputDate>
 	<HxInputDate Label="HxInputDate (InputGroupEnd, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime" >
 	<InputGroupEndTemplate>
-		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 	</InputGroupEndTemplate>
 	</HxInputDate>
 	<HxInputDate Label="HxInputDate (InputGroups, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime" >
 	<InputGroupStartTemplate>
-		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 	</InputGroupStartTemplate>
 	<InputGroupEndTemplate>
-		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 	</InputGroupEndTemplate>
 	</HxInputDate>
 	<HxInputDate Label="HxInputDate (InputGroups, w/ CalendarIcon)" CalendarIcon="BootstrapIcon.Calendar" @bind-Value="@model.DateTime" InputGroupEndText="InputGroupEndText" />

--- a/BlazorAppTest/Pages/HxMultiSelectTest.razor
+++ b/BlazorAppTest/Pages/HxMultiSelectTest.razor
@@ -15,10 +15,10 @@
 	<HxMultiSelect TItem="CultureInfo" TValue="string" Label="Cultures" EmptyText="-- choose here --" TextSelector="@(item => item.EnglishName)" ValueSelector="@(item => item.EnglishName)" Data="@data" @bind-Value="@model.CultureInfos" NullDataText="Loading languages..." Enabled="@enabled">
 
 		<InputGroupStartTemplate>
-			<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+			<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 		</InputGroupStartTemplate>
 		<InputGroupEndTemplate>
-			<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
+			<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 		</InputGroupEndTemplate>
 
 	</HxMultiSelect>

--- a/BlazorAppTest/Pages/InputsTest.razor
+++ b/BlazorAppTest/Pages/InputsTest.razor
@@ -22,7 +22,7 @@
 					<InputGroupEndTemplate>
 						<HxMenu>
 							<Toggle>
-								<HxMenuToggleButton Text="Menu" Color="ThemeColor.Secondary" Outline="true" />
+								<HxMenuToggleButton Text="Menu" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 							</Toggle>
 							<Content>
 								<HxMenuItemNavLink Href="#">Item 1</HxMenuItemNavLink>

--- a/BlazorAppTest/Shared/ColorModeToggle.razor
+++ b/BlazorAppTest/Shared/ColorModeToggle.razor
@@ -1,6 +1,6 @@
 ﻿<HxMenu>
 	<Toggle>
-		<HxMenuToggleButton Outline="true" Color="ThemeColor.Primary" CssClass="align-self-center ms-auto">Color mode</HxMenuToggleButton>
+		<HxMenuToggleButton Variant="ButtonVariant.Outline" Color="ThemeColor.Primary" CssClass="align-self-center ms-auto">Color mode</HxMenuToggleButton>
 	</Toggle>
 	<Content>
 		<HxMenuItem OnClick="() => SetColorModeAsync(ColorMode.Dark)">Dark color mode</HxMenuItem>

--- a/Havit.Blazor.Components.Web.Bootstrap.Smart/HxSmartPasteButton.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Smart/HxSmartPasteButton.cs
@@ -28,7 +28,7 @@ public class HxSmartPasteButton : SmartPasteButton
 			IconPlacement = ButtonIconPlacement.Start,
 			Color = ThemeColor.None,
 			CssClass = null,
-			Outline = false,
+			Variant = ButtonVariant.Solid,
 			Icon = null
 		};
 	}
@@ -83,10 +83,10 @@ public class HxSmartPasteButton : SmartPasteButton
 	protected ButtonSize SizeEffective => Size ?? GetSettings()?.Size ?? GetDefaults().Size ?? throw new InvalidOperationException(nameof(Size) + " default for " + nameof(HxSmartPasteButton) + " has to be set.");
 
 	/// <summary>
-	/// <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" button</see> style.
+	/// Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">variant</see> of the button (solid, outline, subtle, text, link), composed with <see cref="Color"/>.
 	/// </summary>
-	[Parameter] public bool? Outline { get; set; }
-	protected bool OutlineEffective => Outline ?? GetSettings()?.Outline ?? GetDefaults().Outline ?? throw new InvalidOperationException(nameof(Outline) + " default for " + nameof(HxSmartPasteButton) + " has to be set.");
+	[Parameter] public ButtonVariant? Variant { get; set; }
+	protected ButtonVariant VariantEffective => Variant ?? GetSettings()?.Variant ?? GetDefaults().Variant ?? throw new InvalidOperationException(nameof(Variant) + " default for " + nameof(HxSmartPasteButton) + " has to be set.");
 
 	/// <summary>
 	/// Custom CSS class to render with the <c>&lt;button /&gt;</c>.<br />
@@ -137,8 +137,8 @@ public class HxSmartPasteButton : SmartPasteButton
 				case nameof(Size):
 					Size = (ButtonSize)parameter.Value;
 					break;
-				case nameof(Outline):
-					Outline = (bool)parameter.Value;
+				case nameof(Variant):
+					Variant = (ButtonVariant)parameter.Value;
 					break;
 				case nameof(AdditionalAttributes):
 					additionalAttributesParameter = (Dictionary<string, object>)parameter.Value;
@@ -250,7 +250,7 @@ public class HxSmartPasteButton : SmartPasteButton
 	{
 		return CssClassHelper.Combine(
 			CoreCssClass,
-			ColorEffective.ToButtonColorCss(OutlineEffective),
+			VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective),
 			SizeEffective.ToButtonSizeCssClass(),
 			CssClassEffective);
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonSettings.cs
@@ -36,9 +36,9 @@ public record ButtonSettings
 	public ThemeColor? Color { get; set; }
 
 	/// <summary>
-	/// <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap outline button style</see>.
+	/// Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">variant</see> of the button (solid, outline, subtle, text, link), composed with <see cref="Color"/>.
 	/// </summary>
-	public bool? Outline { get; set; } = false;
+	public ButtonVariant? Variant { get; set; } = ButtonVariant.Solid;
 
 	/// <summary>
 	/// Tooltip settings.

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonSize.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonSize.cs
@@ -7,5 +7,9 @@ public enum ButtonSize
 {
 	Regular = 0,
 	Small,
-	Large
+	Large,
+	/// <summary>
+	/// Extra small button (new in Bootstrap 6).
+	/// </summary>
+	ExtraSmall
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonSizeExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonSizeExtensions.cs
@@ -16,6 +16,7 @@ public static class ButtonSizeExtensions
 			ButtonSize.Regular => null,
 			ButtonSize.Small => "btn-sm",
 			ButtonSize.Large => "btn-lg",
+			ButtonSize.ExtraSmall => "btn-xs",
 			_ => throw new InvalidOperationException($"Unknown button size: {size:g}.")
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonVariant.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonVariant.cs
@@ -1,0 +1,33 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Visual variant of the <see cref="HxButton"/> (composed with a theme color, see <see cref="HxButton.Color"/>).
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">Bootstrap 6 buttons</see>.
+/// </summary>
+public enum ButtonVariant
+{
+	/// <summary>
+	/// Solid (filled) button. Default.
+	/// </summary>
+	Solid = 0,
+
+	/// <summary>
+	/// Outlined button.
+	/// </summary>
+	Outline,
+
+	/// <summary>
+	/// Button with a subtle (light) background.
+	/// </summary>
+	Subtle,
+
+	/// <summary>
+	/// Text-only button (no background or border).
+	/// </summary>
+	Text,
+
+	/// <summary>
+	/// Link-styled button.
+	/// </summary>
+	Link
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonVariantExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/ButtonVariantExtensions.cs
@@ -1,0 +1,38 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+public static class ButtonVariantExtensions
+{
+	/// <summary>
+	/// Bootstrap 6 buttons compose a variant class (<c>btn-solid</c>, <c>btn-outline</c>, ...) with a theme color class (<c>theme-*</c>).
+	/// Without a color, the variant classes have no theme tokens to consume, so no variant class is emitted (a plain neutral <c>btn</c> look),
+	/// with the exception of the standalone <c>btn-link</c> variant.
+	/// </summary>
+	public static string ToButtonVariantAndColorCssClass(this ButtonVariant variant, ThemeColor color)
+	{
+		if (color == ThemeColor.Link)
+		{
+			return ButtonVariant.Link.ToButtonVariantCssClass();
+		}
+		if (color == ThemeColor.None)
+		{
+			return (variant == ButtonVariant.Link) ? ButtonVariant.Link.ToButtonVariantCssClass() : null;
+		}
+		return CssClassHelper.Combine(
+			variant.ToButtonVariantCssClass(),
+			(variant == ButtonVariant.Link) ? null : color.ToThemeCss());
+	}
+
+
+	public static string ToButtonVariantCssClass(this ButtonVariant variant)
+	{
+		return variant switch
+		{
+			ButtonVariant.Solid => "btn-solid",
+			ButtonVariant.Outline => "btn-outline",
+			ButtonVariant.Subtle => "btn-subtle",
+			ButtonVariant.Text => "btn-text",
+			ButtonVariant.Link => "btn-link",
+			_ => throw new InvalidOperationException($"Unknown {nameof(ButtonVariant)} value {variant}.")
+		};
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButton.razor.cs
@@ -22,7 +22,7 @@ public partial class HxButton : ComponentBase, ICascadeEnabledComponent
 			IconPlacement = ButtonIconPlacement.Start,
 			Color = ThemeColor.None,
 			CssClass = null,
-			Outline = false,
+			Variant = ButtonVariant.Solid,
 			Icon = null,
 			TooltipSettings = new TooltipSettings()
 		};
@@ -83,10 +83,11 @@ public partial class HxButton : ComponentBase, ICascadeEnabledComponent
 	protected ButtonSize SizeEffective => Size ?? GetSettings()?.Size ?? GetDefaults().Size ?? throw new InvalidOperationException(nameof(Size) + " default for " + nameof(HxButton) + " has to be set.");
 
 	/// <summary>
-	/// <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" button</see> style.
+	/// Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">variant</see> of the button (solid, outline, subtle, text, link), composed with <see cref="Color"/>.
+	/// The default is <see cref="ButtonVariant.Solid"/>.
 	/// </summary>
-	[Parameter] public bool? Outline { get; set; }
-	protected bool OutlineEffective => Outline ?? GetSettings()?.Outline ?? GetDefaults().Outline ?? throw new InvalidOperationException(nameof(Outline) + " default for " + nameof(HxButton) + " has to be set.");
+	[Parameter] public ButtonVariant? Variant { get; set; }
+	protected ButtonVariant VariantEffective => Variant ?? GetSettings()?.Variant ?? GetDefaults().Variant ?? throw new InvalidOperationException(nameof(Variant) + " default for " + nameof(HxButton) + " has to be set.");
 
 	/// <summary>
 	/// Custom CSS class to render with the <c>&lt;button /&gt;</c>.<br />
@@ -229,10 +230,11 @@ public partial class HxButton : ComponentBase, ICascadeEnabledComponent
 	{
 		return CssClassHelper.Combine(
 			CoreCssClass,
-			ColorEffective.ToButtonColorCss(OutlineEffective),
+			VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective),
 			SizeEffective.ToButtonSizeCssClass(),
 			CssClassEffective);
 	}
+
 
 	protected string GetTooltipWrapperCssClass()
 	{

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/CheckboxListSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/CheckboxListSettings.cs
@@ -14,7 +14,7 @@ public record CheckboxListSettings : InputSettings
 	/// Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
 	/// for <see cref="CheckboxListRenderMode.ToggleButtons"/> and <see cref="CheckboxListRenderMode.ButtonGroup"/>.
 	/// </summary>
-	public bool? Outline { get; set; }
+	public ButtonVariant? Variant { get; set; }
 
 	/// <summary>
 	/// Size of buttons for <see cref="CheckboxListRenderMode.ToggleButtons"/> and <see cref="CheckboxListRenderMode.ButtonGroup"/>.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/CheckboxSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/CheckboxSettings.cs
@@ -14,7 +14,7 @@ public record CheckboxSettings : InputSettings
 	/// Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
 	/// for <see cref="CheckboxRenderMode.ToggleButton"/>.
 	/// </summary>
-	public bool? Outline { get; set; }
+	public ButtonVariant? Variant { get; set; }
 
 	/// <summary>
 	/// Size of the button for <see cref="CheckboxRenderMode.ToggleButton"/>.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckbox.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckbox.cs
@@ -17,7 +17,7 @@ public class HxCheckbox : HxCheckboxBase
 		Defaults = new CheckboxSettings()
 		{
 			Color = ThemeColor.None,
-			Outline = false,
+			Variant = ButtonVariant.Solid,
 			RenderMode = CheckboxRenderMode.Checkbox,
 			ButtonSize = global::Havit.Blazor.Components.Web.Bootstrap.ButtonSize.Regular
 		};
@@ -57,8 +57,8 @@ public class HxCheckbox : HxCheckboxBase
 	/// <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" button</see> style.
 	/// For <see cref="CheckboxRenderMode.ToggleButton"/>.
 	/// </summary>
-	[Parameter] public bool? Outline { get; set; }
-	protected override bool OutlineEffective => Outline ?? GetSettings()?.Outline ?? GetDefaults().Outline ?? throw new InvalidOperationException(nameof(Outline) + " default for " + nameof(HxCheckbox) + " has to be set.");
+	[Parameter] public ButtonVariant? Variant { get; set; }
+	protected override ButtonVariant VariantEffective => Variant ?? GetSettings()?.Variant ?? GetDefaults().Variant ?? throw new InvalidOperationException(nameof(Variant) + " default for " + nameof(HxCheckbox) + " has to be set.");
 
 	/// <summary>
 	/// Size of the button for <see cref="CheckboxRenderMode.ToggleButton"/>.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxBase.cs
@@ -37,7 +37,7 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 
 	protected abstract ThemeColor ColorEffective { get; }
 
-	protected abstract bool OutlineEffective { get; }
+	protected abstract ButtonVariant VariantEffective { get; }
 
 	protected virtual ButtonSize ButtonSizeEffective => ButtonSize.Regular;
 
@@ -164,7 +164,7 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 		builder.OpenElement(2000, "label");
 		builder.AddAttribute(2001, "class", CssClassHelper.Combine(
 			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? "btn" : "form-check-label",
-			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? ColorEffective.ToButtonColorCss(OutlineEffective) : null,
+			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective) : null,
 			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? ButtonSizeEffective.ToButtonSizeCssClass() : null,
 			TextCssClass));
 		builder.AddAttribute(2002, "for", InputId);

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxList.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxList.cs
@@ -127,8 +127,8 @@ public class HxCheckboxList<TValue, TItem> : HxInputBase<List<TValue>> // cannot
 	/// Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
 	/// for <see cref="CheckboxListRenderMode.ToggleButtons"/> and <see cref="CheckboxListRenderMode.ButtonGroup"/>.
 	/// </summary>
-	[Parameter] public bool? Outline { get; set; }
-	protected bool? OutlineEffective => Outline ?? GetSettings()?.Outline ?? GetDefaults().Outline; // can be null, HxCheckbox.Outline remains unset
+	[Parameter] public ButtonVariant? Variant { get; set; }
+	protected ButtonVariant? VariantEffective => Variant ?? GetSettings()?.Variant ?? GetDefaults().Variant; // can be null, HxCheckbox.Variant remains unset
 
 	/// <summary>
 	/// Size of buttons for <see cref="CheckboxListRenderMode.ToggleButtons"/> and <see cref="CheckboxListRenderMode.ButtonGroup"/>.
@@ -198,7 +198,7 @@ public class HxCheckboxList<TValue, TItem> : HxInputBase<List<TValue>> // cannot
 
 			builder.AddAttribute(9, nameof(HxCheckbox.RenderMode), checkboxRenderMode);
 			builder.AddAttribute(10, nameof(HxCheckbox.Color), ColorEffective);
-			builder.AddAttribute(11, nameof(HxCheckbox.Outline), OutlineEffective);
+			builder.AddAttribute(11, nameof(HxCheckbox.Variant), VariantEffective);
 			builder.AddAttribute(12, nameof(HxCheckbox.ButtonSize), ButtonSizeEffective);
 
 			// We need ValueExpression. Ehm, HxCheckbox needs ValueExpression. Because it is InputBase<T> which needs ValueExpression.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxList.nongeneric.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxList.nongeneric.cs
@@ -16,7 +16,7 @@ public sealed class HxCheckboxList
 		{
 			// ValidationMessageMode = null, HxInputBase sets the default
 			// Color = null, HxCheckbox.Color is not set, HxCheckbox uses its own default then
-			// Outline = null, HxCheckbox.Outline is not set, HxCheckbox uses its own default then
+			// Variant = null, HxCheckbox.Variant is not set, HxCheckbox uses its own default then
 		};
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonList.nongeneric.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonList.nongeneric.cs
@@ -16,7 +16,7 @@ public sealed class HxRadioButtonList
 		{
 			// ValidationMessageMode = null, HxInputBase sets the default
 			Color = ThemeColor.None, // we do not have HxRadioButton to provide a default here
-			Outline = false, // we do not have HxRadioButton to provide a default here
+			Variant = ButtonVariant.Solid, // we do not have HxRadioButton to provide a default here
 			ButtonSize = ButtonSize.Regular,
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonListBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonListBase.cs
@@ -29,8 +29,8 @@ public abstract class HxRadioButtonListBase<TValue, TItem> : HxInputBase<TValue>
 	/// Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
 	/// for <see cref="RadioButtonListRenderMode.ToggleButtons"/> and <see cref="RadioButtonListRenderMode.ButtonGroup"/>.
 	/// </summary>
-	[Parameter] public bool? Outline { get; set; }
-	protected bool OutlineEffective => Outline ?? GetSettings()?.Outline ?? GetDefaults()?.Outline ?? throw new InvalidOperationException(nameof(Outline) + " default for " + nameof(HxRadioButtonListBase<,>) + " has to be set.");
+	[Parameter] public ButtonVariant? Variant { get; set; }
+	protected ButtonVariant VariantEffective => Variant ?? GetSettings()?.Variant ?? GetDefaults()?.Variant ?? throw new InvalidOperationException(nameof(Variant) + " default for " + nameof(HxRadioButtonListBase<,>) + " has to be set.");
 
 	/// <summary>
 	/// Size of buttons for <see cref="RadioButtonListRenderMode.ToggleButtons"/> and <see cref="RadioButtonListRenderMode.ButtonGroup"/>.
@@ -238,7 +238,7 @@ public abstract class HxRadioButtonListBase<TValue, TItem> : HxInputBase<TValue>
 			builder.OpenElement(300, "label");
 			builder.AddAttribute(301, "class", CssClassHelper.Combine(
 				isToggleButton ? "btn" : "form-check-label",
-				isToggleButton ? ColorEffective.ToButtonColorCss(OutlineEffective) : null,
+				isToggleButton ? VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective) : null,
 				isToggleButton ? ButtonSizeEffective.ToButtonSizeCssClass() : null,
 				ItemTextCssClassImpl,
 				ItemTextCssClassSelectorImpl?.Invoke(item)));

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSwitch.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSwitch.cs
@@ -47,7 +47,7 @@ public class HxSwitch : HxCheckboxBase
 
 	protected override ThemeColor ColorEffective => throw new NotSupportedException();
 
-	protected override bool OutlineEffective => throw new NotSupportedException();
+	protected override ButtonVariant VariantEffective => throw new NotSupportedException();
 
 	protected override ButtonSize ButtonSizeEffective => throw new NotSupportedException();
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/RadioButtonListSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/RadioButtonListSettings.cs
@@ -14,7 +14,7 @@ public record RadioButtonListSettings : InputSettings
 	/// Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
 	/// for <see cref="RadioButtonListRenderMode.ToggleButtons"/> and <see cref="RadioButtonListRenderMode.ButtonGroup"/>.
 	/// </summary>
-	public bool? Outline { get; set; }
+	public ButtonVariant? Variant { get; set; }
 
 	/// <summary>
 	/// Size of buttons for <see cref="RadioButtonListRenderMode.ToggleButtons"/> and <see cref="RadioButtonListRenderMode.ButtonGroup"/>.

--- a/Havit.Blazor.Components.Web.Bootstrap/ThemeColorExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/ThemeColorExtensions.cs
@@ -60,31 +60,4 @@ public static class ThemeColorExtensions
 		};
 	}
 
-	public static string ToButtonColorCss(this ThemeColor themeColor, bool outline = false)
-	{
-		// TODO v6 (#1442): Bootstrap 6 replaces per-color button classes (btn-primary, btn-outline-primary)
-		// with a composition of a variant class (btn-solid, btn-outline, btn-subtle, btn-text) and a theme-* class.
-		return (themeColor, outline) switch
-		{
-			(ThemeColor.Primary, false) => "btn-primary",
-			(ThemeColor.Primary, true) => "btn-outline-primary",
-			(ThemeColor.Secondary, false) => "btn-secondary",
-			(ThemeColor.Secondary, true) => "btn-outline-secondary",
-			(ThemeColor.Success, false) => "btn-success",
-			(ThemeColor.Success, true) => "btn-outline-success",
-			(ThemeColor.Danger, false) => "btn-danger",
-			(ThemeColor.Danger, true) => "btn-outline-danger",
-			(ThemeColor.Warning, false) => "btn-warning",
-			(ThemeColor.Warning, true) => "btn-outline-warning",
-			(ThemeColor.Info, false) => "btn-info",
-			(ThemeColor.Info, true) => "btn-outline-info",
-			(ThemeColor.Accent, false) => "btn-accent",
-			(ThemeColor.Accent, true) => "btn-outline-accent",
-			(ThemeColor.Inverse, false) => "btn-inverse",
-			(ThemeColor.Inverse, true) => "btn-outline-inverse",
-			(ThemeColor.Link, _) => "btn-link",
-			(ThemeColor.None, _) => null,
-			_ => throw new InvalidOperationException($"Unknown color {themeColor:g}.")
-		};
-	}
 }

--- a/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Demo_InputGroups.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Demo_InputGroups.razor
@@ -7,13 +7,13 @@
 
 <HxInputText Label="Input groups (template with button/menu)" @bind-Value="@value">
 	<InputGroupStartTemplate>
-		<HxButton Text="Button" Color="ThemeColor.Secondary" Outline="true" />
-		<HxButton Text="Button 2" Color="ThemeColor.Secondary" Outline="true" />
+		<HxButton Text="Button" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+		<HxButton Text="Button 2" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 	</InputGroupStartTemplate>
 	<InputGroupEndTemplate>
 		<HxMenu>
 			<Toggle>
-				<HxMenuToggleButton Text="Menu" Color="ThemeColor.Secondary" Outline="true" />
+				<HxMenuToggleButton Text="Menu" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 			</Toggle>
 			<Content>
 				<HxMenuItem>Item 1</HxMenuItem>

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonDoc/HxButton_Demo_Outline.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonDoc/HxButton_Demo_Outline.razor
@@ -1,9 +1,0 @@
-﻿<HxButton Outline="true" Color="ThemeColor.Primary" Text="Primary" />
-<HxButton Outline="true" Color="ThemeColor.Secondary" Text="Secondary" />
-<HxButton Outline="true" Color="ThemeColor.Success" Text="Success" />
-<HxButton Outline="true" Color="ThemeColor.Danger" Text="Danger" />
-<HxButton Outline="true" Color="ThemeColor.Warning" Text="Warning" />
-<HxButton Outline="true" Color="ThemeColor.Info" Text="Info" />
-<HxButton Outline="true" Color="ThemeColor.Secondary" Text="Light" />
-<HxButton Outline="true" Color="ThemeColor.Inverse" Text="Dark" />
-<HxButton Outline="true" Color="ThemeColor.Link" Text="Link" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonDoc/HxButton_Demo_Variants.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonDoc/HxButton_Demo_Variants.razor
@@ -1,0 +1,16 @@
+﻿<div class="d-flex flex-wrap gap-2 align-items-center">
+	<HxButton Variant="ButtonVariant.Solid" Color="ThemeColor.Primary" Text="Solid" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Primary" Text="Outline" />
+	<HxButton Variant="ButtonVariant.Subtle" Color="ThemeColor.Primary" Text="Subtle" />
+	<HxButton Variant="ButtonVariant.Text" Color="ThemeColor.Primary" Text="Text" />
+	<HxButton Variant="ButtonVariant.Link" Text="Link" />
+</div>
+<div class="d-flex flex-wrap gap-2 align-items-center mt-2">
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Secondary" Text="Secondary" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Success" Text="Success" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Danger" Text="Danger" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Warning" Text="Warning" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Info" Text="Info" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Accent" Text="Accent" />
+	<HxButton Variant="ButtonVariant.Outline" Color="ThemeColor.Inverse" Text="Inverse" />
+</div>

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonDoc/HxButton_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonDoc/HxButton_Documentation.razor
@@ -1,4 +1,4 @@
-@attribute [Route("/components/" + nameof(HxButton))]
+﻿@attribute [Route("/components/" + nameof(HxButton))]
 @attribute [Route("/components/" + nameof(HxSubmit))]
 
 <ApiDoc Type="typeof(HxButton)">
@@ -9,9 +9,9 @@
 		<p>Several predefined button styles are included, each serving its own semantic purpose, with a few extras thrown in for more control.</p>
 		<Demo Type="typeof(HxButton_Demo_Colors)" />
 
-		<DocHeading Title="Outline buttons" />
-		<p>You can remove the background with <code>Outline="true"</code>:</p>
-		<Demo Type="typeof(HxButton_Demo_Outline)" />
+		<DocHeading Title="Variants" />
+		<p>Bootstrap 6 buttons compose a visual variant (<code>ButtonVariant.Solid</code>, <code>Outline</code>, <code>Subtle</code>, <code>Text</code>, <code>Link</code>) with a theme color:</p>
+		<Demo Type="typeof(HxButton_Demo_Variants)" />
 
 		<DocHeading Title="Sizes" />
 		<Demo Type="typeof(HxButton_Demo_Sizes)" Tabs="false" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Checkboxes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Checkboxes.razor
@@ -1,8 +1,8 @@
 ﻿<EditForm Model="@model">
     <HxButtonGroup>
-        <HxCheckbox Text="Checkbox 1" @bind-Value="@model.checkbox1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Primary" Outline="true" />
-        <HxCheckbox Text="Checkbox 2" @bind-Value="@model.checkbox2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Primary" Outline="true" />
-        <HxCheckbox Text="Checkbox 3" @bind-Value="@model.checkbox3" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Primary" Outline="true" />
+        <HxCheckbox Text="Checkbox 1" @bind-Value="@model.checkbox1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" />
+        <HxCheckbox Text="Checkbox 2" @bind-Value="@model.checkbox2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" />
+        <HxCheckbox Text="Checkbox 3" @bind-Value="@model.checkbox3" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" />
     </HxButtonGroup>
 </EditForm>
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Outlined.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Outlined.razor
@@ -1,5 +1,5 @@
 ﻿<HxButtonGroup>
-    <HxButton Text="Left" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Text="Middle" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Text="Right" Color="ThemeColor.Secondary" Outline="true" />
+    <HxButton Text="Left" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Text="Middle" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Text="Right" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 </HxButtonGroup>

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Sizes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Sizes.razor
@@ -1,19 +1,19 @@
 ﻿<HxButtonGroup>
-    <HxButton Size="ButtonSize.Large" Text="Left" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Size="ButtonSize.Large" Text="Middle" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Size="ButtonSize.Large" Text="Right" Color="ThemeColor.Secondary" Outline="true" />
+    <HxButton Size="ButtonSize.Large" Text="Left" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Size="ButtonSize.Large" Text="Middle" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Size="ButtonSize.Large" Text="Right" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 </HxButtonGroup>
 <br /><br />
 
 <HxButtonGroup>
-    <HxButton Text="Left" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Text="Middle" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Text="Right" Color="ThemeColor.Secondary" Outline="true" />
+    <HxButton Text="Left" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Text="Middle" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Text="Right" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 </HxButtonGroup>
 <br /><br />
 
 <HxButtonGroup>
-    <HxButton Size="ButtonSize.Small" Text="Left" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Size="ButtonSize.Small" Text="Middle" Color="ThemeColor.Secondary" Outline="true" />
-    <HxButton Size="ButtonSize.Small" Text="Right" Color="ThemeColor.Secondary" Outline="true" />
+    <HxButton Size="ButtonSize.Small" Text="Left" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Size="ButtonSize.Small" Text="Middle" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+    <HxButton Size="ButtonSize.Small" Text="Right" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 </HxButtonGroup>

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Tooltips.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonGroup_Demo_Tooltips.razor
@@ -1,5 +1,5 @@
 ﻿<HxButtonGroup>
-    <HxButton Text="Left" Color="ThemeColor.Primary" Outline="true" Tooltip="Tooltip breaks the structure" />
-    <HxButton Text="Middle" Color="ThemeColor.Primary" Outline="true" Tooltip="Tooltip breaks the structure" />
-    <HxButton Text="Right" Color="ThemeColor.Primary" Outline="true" Tooltip="Tooltip breaks the structure" />
+    <HxButton Text="Left" Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" Tooltip="Tooltip breaks the structure" />
+    <HxButton Text="Middle" Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" Tooltip="Tooltip breaks the structure" />
+    <HxButton Text="Right" Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" Tooltip="Tooltip breaks the structure" />
 </HxButtonGroup>

--- a/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonToolbar_Demo_2.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxButtonGroupDoc/HxButtonToolbar_Demo_2.razor
@@ -1,19 +1,19 @@
 ﻿<HxButtonToolbar CssClass="mb-2">
     <HxButtonGroup CssClass="me-2">
-        <HxButton Text="1" Color="ThemeColor.Secondary" Outline="true" />
-        <HxButton Text="2" Color="ThemeColor.Secondary" Outline="true" />
-        <HxButton Text="3" Color="ThemeColor.Secondary" Outline="true" />
-        <HxButton Text="4" Color="ThemeColor.Secondary" Outline="true" />
+        <HxButton Text="1" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+        <HxButton Text="2" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+        <HxButton Text="3" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+        <HxButton Text="4" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
     </HxButtonGroup>
     <HxInputText InputGroupStartText="@("@")" Placeholder="Input text example" @bind-Value="text" />
 </HxButtonToolbar>
 
 <HxButtonToolbar CssClass="justify-content-between">
     <HxButtonGroup>
-        <HxButton Text="1" Color="ThemeColor.Secondary" Outline="true" />
-        <HxButton Text="2" Color="ThemeColor.Secondary" Outline="true" />
-        <HxButton Text="3" Color="ThemeColor.Secondary" Outline="true" />
-        <HxButton Text="4" Color="ThemeColor.Secondary" Outline="true" />
+        <HxButton Text="1" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+        <HxButton Text="2" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+        <HxButton Text="3" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
+        <HxButton Text="4" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
     </HxButtonGroup>
     <HxInputText InputGroupStartText="@("@")" Placeholder="Input text example" @bind-Value="text" />
 </HxButtonToolbar>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCheckboxDoc/HxCheckbox_Demo_RenderModes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCheckboxDoc/HxCheckbox_Demo_RenderModes.razor
@@ -1,4 +1,4 @@
-<HxCheckbox Text="Checkbox (default)"
+﻿<HxCheckbox Text="Checkbox (default)"
 			RenderMode="CheckboxRenderMode.Checkbox"
 			@bind-Value="isChecked" />
 
@@ -14,7 +14,7 @@
 			RenderMode="CheckboxRenderMode.ToggleButton"
 			@bind-Value="isChecked"
 			Color="ThemeColor.Secondary"
-			Outline="true" />
+			Variant="ButtonVariant.Outline" />
 
 @code
 {

--- a/Havit.Blazor.Documentation/Pages/Components/HxCheckboxListDoc/HxCheckboxList_Demo_Inline.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCheckboxListDoc/HxCheckboxList_Demo_Inline.razor
@@ -29,7 +29,7 @@
 				ItemValueSelector="@(employee => employee.Id)"
 				RenderMode="CheckboxListRenderMode.ToggleButtons"
 				Color="ThemeColor.Secondary"
-				Outline="true" />
+				Variant="ButtonVariant.Outline" />
 
 <HxCheckboxList Label="Button group"
 				TItem="EmployeeDto"
@@ -41,7 +41,7 @@
 				ItemValueSelector="@(employee => employee.Id)"
 				RenderMode="CheckboxListRenderMode.ButtonGroup"
 				Color="ThemeColor.Secondary"
-				Outline="true" />
+				Variant="ButtonVariant.Outline" />
 
 @code
 {

--- a/Havit.Blazor.Documentation/Pages/Components/HxCheckboxListDoc/HxCheckboxList_Demo_RenderModes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCheckboxListDoc/HxCheckboxList_Demo_RenderModes.razor
@@ -1,4 +1,4 @@
-@inject IDemoDataService DemoDataService
+﻿@inject IDemoDataService DemoDataService
 
 <HxCheckboxList Label="Checkboxes (default)"
 				TItem="EmployeeDto"
@@ -28,7 +28,7 @@
 				ItemValueSelector="@(employee => employee.Id)"
 				RenderMode="CheckboxListRenderMode.ToggleButtons"
 				Color="ThemeColor.Secondary"
-				Outline="true"
+				Variant="ButtonVariant.Outline"
 				CssClass="mt-2" />
 
 <HxCheckboxList Label="Button group"
@@ -40,7 +40,7 @@
 				ItemValueSelector="@(employee => employee.Id)"
 				RenderMode="CheckboxListRenderMode.ButtonGroup"
 				Color="ThemeColor.Secondary"
-				Outline="true"
+				Variant="ButtonVariant.Outline"
 				CssClass="mt-2" />
 
 @code

--- a/Havit.Blazor.Documentation/Pages/Components/HxIconDoc/HxIcon_Demo_CustomIcons.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxIconDoc/HxIcon_Demo_CustomIcons.razor
@@ -1,3 +1,3 @@
 ﻿<HxIcon Icon="MyCustomIcon.Poo" />
 <HxIcon Icon="MyCustomIcon.ThumbUp" />
-<HxButton Icon="MyCustomIcon.ThumbUp" Text="Button with icon" Color="ThemeColor.Secondary" Outline="true" />
+<HxButton Icon="MyCustomIcon.ThumbUp" Text="Button with icon" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_Basic.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_Basic.razor
@@ -21,7 +21,7 @@
         <EditForm Model="@query">
             <div class="d-flex">
                 <HxInputText CssClass="me-2" Placeholder="Search" @bind-Value="@query" />
-                <HxSubmit Color="ThemeColor.Success" Outline="true">Search</HxSubmit>
+                <HxSubmit Color="ThemeColor.Success" Variant="ButtonVariant.Outline">Search</HxSubmit>
             </div>
         </EditForm>
     </HxNavbarCollapse>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_ColorSchemes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_ColorSchemes.razor
@@ -20,7 +20,7 @@
 		</HxNav>
 		<div class="d-flex">
 			<HxInputText CssClass="me-2" Placeholder="Search" @bind-Value="@query" />
-			<HxSubmit Color="ThemeColor.Secondary" Outline="true">Search</HxSubmit>
+			<HxSubmit Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline">Search</HxSubmit>
 		</div>
 	</HxNavbarCollapse>
 </HxNavbar>
@@ -47,7 +47,7 @@
 		</HxNav>
 		<div class="d-flex">
 			<HxInputText CssClass="me-2" Placeholder="Search" @bind-Value="@query" />
-			<HxSubmit Color="ThemeColor.Secondary" Outline="true">Search</HxSubmit>
+			<HxSubmit Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline">Search</HxSubmit>
 		</div>
 	</HxNavbarCollapse>
 </HxNavbar>
@@ -74,7 +74,7 @@
 		</HxNav>
 		<div class="d-flex">
 			<HxInputText CssClass="me-2" Placeholder="Search" @bind-Value="@query" />
-			<HxSubmit Color="ThemeColor.Secondary" Outline="true">Search</HxSubmit>
+			<HxSubmit Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline">Search</HxSubmit>
 		</div>
 	</HxNavbarCollapse>
 </HxNavbar>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_EnableDisable.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_EnableDisable.razor
@@ -1,8 +1,8 @@
 ﻿<HxPopover @ref="popover1" Title="Popover title" Content="And here's some amazing content. It's very engaging. Right?">
 	<HxButton Color="ThemeColor.Primary">Click to toggle popover</HxButton>
 </HxPopover>
-<HxButton Text="Disable" OnClick="HandleDisableClick" Color="ThemeColor.Warning" Outline="@(!enabled)" Spinner="false" />
-<HxButton Text="Enable" OnClick="HandleEnableClick" Color="ThemeColor.Success" Outline="@enabled" Spinner="false" />
+<HxButton Text="Disable" OnClick="HandleDisableClick" Color="ThemeColor.Warning" Variant="@(!enabled ? ButtonVariant.Outline : ButtonVariant.Solid)" Spinner="false" />
+<HxButton Text="Enable" OnClick="HandleEnableClick" Color="ThemeColor.Success" Variant="@(enabled ? ButtonVariant.Outline : ButtonVariant.Solid)" Spinner="false" />
 
 @code
 {

--- a/Havit.Blazor.Documentation/Pages/Components/HxRadioButtonListDoc/HxRadioButtonList_Demo_Inline.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxRadioButtonListDoc/HxRadioButtonList_Demo_Inline.razor
@@ -20,7 +20,7 @@
 				   ItemValueSelector="@(employee => employee.Id)"
 				   RenderMode="RadioButtonListRenderMode.ToggleButtons"
 				   Color="ThemeColor.Secondary"
-				   Outline="true"
+				   Variant="ButtonVariant.Outline"
 				   CssClass="mt-2" />
 
 <HxRadioButtonList Label="Button group"
@@ -33,7 +33,7 @@
 				   ItemValueSelector="@(employee => employee.Id)"
 				   RenderMode="RadioButtonListRenderMode.ButtonGroup"
 				   Color="ThemeColor.Secondary"
-				   Outline="true"
+				   Variant="ButtonVariant.Outline"
 				   CssClass="mt-2" />
 
 @code

--- a/Havit.Blazor.Documentation/Pages/Components/HxRadioButtonListDoc/HxRadioButtonList_Demo_RenderModes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxRadioButtonListDoc/HxRadioButtonList_Demo_RenderModes.razor
@@ -1,4 +1,4 @@
-@inject IDemoDataService DemoDataService
+﻿@inject IDemoDataService DemoDataService
 
 <HxRadioButtonList Label="Radio buttons (default)"
 				   TItem="EmployeeDto"
@@ -18,7 +18,7 @@
 				   ItemValueSelector="@(employee => employee.Id)"
 				   RenderMode="RadioButtonListRenderMode.ToggleButtons"
 				   Color="ThemeColor.Secondary"
-				   Outline="true"
+				   Variant="ButtonVariant.Outline"
 				   CssClass="mt-2" />
 
 <HxRadioButtonList Label="Button group"
@@ -30,7 +30,7 @@
 				   ItemValueSelector="@(employee => employee.Id)"
 				   RenderMode="RadioButtonListRenderMode.ButtonGroup"
 				   Color="ThemeColor.Secondary"
-				   Outline="true"
+				   Variant="ButtonVariant.Outline"
 				   CssClass="mt-2" />
 
 @code

--- a/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Demo_EnableDisable.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Demo_EnableDisable.razor
@@ -1,8 +1,8 @@
 ﻿<HxTooltip @ref="tooltipComponent" Text="Tooltip on top">
 	<HxButton Color="ThemeColor.Secondary" Text="Tooltip on top (default)" />
 </HxTooltip>
-<HxButton Text="Disable" OnClick="HandleDisableClick" Color="ThemeColor.Warning" Outline="@(!enabled)" Spinner="false" />
-<HxButton Text="Enable" OnClick="HandleEnableClick" Color="ThemeColor.Success" Outline="@enabled" Spinner="false" />
+<HxButton Text="Disable" OnClick="HandleDisableClick" Color="ThemeColor.Warning" Variant="@(!enabled ? ButtonVariant.Outline : ButtonVariant.Solid)" Spinner="false" />
+<HxButton Text="Enable" OnClick="HandleEnableClick" Color="ThemeColor.Success" Variant="@(enabled ? ButtonVariant.Outline : ButtonVariant.Solid)" Spinner="false" />
 
 @code
 {

--- a/Havit.Blazor.Documentation/Pages/Concepts/AppButtonSettings.CodeSnippet.cs
+++ b/Havit.Blazor.Documentation/Pages/Concepts/AppButtonSettings.CodeSnippet.cs
@@ -9,13 +9,13 @@
 	public static ButtonSettings SecondaryButton { get; } = new()
 	{
 		Color = ThemeColor.Secondary,
-		Outline = true
+		Variant = ButtonVariant.Outline
 	};
 
 	public static ButtonSettings CloseButton { get; } = new()
 	{
 		Color = ThemeColor.Danger,
-		Outline = true,
+		Variant = ButtonVariant.Outline,
 		Icon = BootstrapIcon.XLg
 	};
 }

--- a/Havit.Blazor.Documentation/Pages/Concepts/AppButtonSettings.cs
+++ b/Havit.Blazor.Documentation/Pages/Concepts/AppButtonSettings.cs
@@ -11,13 +11,13 @@ public static class AppButtonSettings
 	public static ButtonSettings SecondaryButton { get; } = new()
 	{
 		Color = ThemeColor.Secondary,
-		Outline = true
+		Variant = ButtonVariant.Outline
 	};
 
 	public static ButtonSettings CloseButton { get; } = new()
 	{
 		Color = ThemeColor.Danger,
-		Outline = true,
+		Variant = ButtonVariant.Outline,
 		Icon = BootstrapIcon.XLg
 	};
 }

--- a/Havit.Blazor.Documentation/Pages/Concepts/SettingsAndDefaults_Demo_Overriding.razor
+++ b/Havit.Blazor.Documentation/Pages/Concepts/SettingsAndDefaults_Demo_Overriding.razor
@@ -2,13 +2,13 @@
 <HxButton Settings="settings" Color="ThemeColor.Danger" Text="Fullscreen" />
 
 @* Although Settings are set, the directly set parameters have higher priority, so the button has no outline and the icon is set to the BS icon Door. *@
-<HxButton Settings="settings" Outline="false" Icon="BootstrapIcon.DoorClosed" Text="Open" />
+<HxButton Settings="settings" Icon="BootstrapIcon.DoorClosed" Text="Open" />
 
 @code {
     private ButtonSettings settings = new()
         {
             Color = ThemeColor.Primary,
             Icon = BootstrapIcon.Fullscreen,
-            Outline = true
+            Variant = ButtonVariant.Outline
         };
 }

--- a/Havit.Blazor.Documentation/Pages/Concepts/SettingsAndDefaults_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Concepts/SettingsAndDefaults_Documentation.razor
@@ -8,7 +8,7 @@
 <DocHeading Title="Defaults" />
 <p>You can set application-wide defaults for individual components by modifying the static <code>Defaults</code> property located on most components (generic components have their non-generic class for that).</p>
 
-<CodeSnippet Language="cs">HxButton.Defaults.Outline = true;
+<CodeSnippet Language="cs">HxButton.Defaults.Variant = ButtonVariant.Outline;
 HxButton.Defaults.Icon = BootstrapIcon.Fullscreen;
 </CodeSnippet>
 

--- a/Havit.Blazor.Documentation/Shared/Components/ResponsiveOnThisPageNavigation.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/ResponsiveOnThisPageNavigation.razor
@@ -3,7 +3,7 @@
 </OnThisPageNavigation>
 
 <div class="my-4 d-md-none">
-	<HxCollapseToggleButton Text="On this page" Icon="BootstrapIcon.ChevronExpand" Outline="true" Color="ThemeColor.Primary" CollapseTarget="#on-this-page-navigation-collapse" />
+	<HxCollapseToggleButton Text="On this page" Icon="BootstrapIcon.ChevronExpand" Variant="ButtonVariant.Outline" Color="ThemeColor.Primary" CollapseTarget="#on-this-page-navigation-collapse" />
 	<HxCollapse Id="on-this-page-navigation-collapse" CssClass="mt-2">
 		<HxCard>
 			<BodyTemplate>

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.Smart.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.Smart.xml
@@ -143,9 +143,9 @@
             Button size. The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ButtonSize.Regular"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Smart.HxSmartPasteButton.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Smart.HxSmartPasteButton.Variant">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" button</see> style.
+            Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">variant</see> of the button (solid, outline, subtle, text, link), composed with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.Smart.HxSmartPasteButton.Color"/>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Smart.HxSmartPasteButton.CssClass">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -290,9 +290,9 @@
             Bootstrap button color (style).
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.ButtonSettings.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.ButtonSettings.Variant">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap outline button style</see>.
+            Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">variant</see> of the button (solid, outline, subtle, text, link), composed with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.ButtonSettings.Color"/>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.ButtonSettings.TooltipSettings">
@@ -303,6 +303,49 @@
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.ButtonSize">
             <summary>
             Represents the size for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxButton"/>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ButtonSize.ExtraSmall">
+            <summary>
+            Extra small button (new in Bootstrap 6).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant">
+            <summary>
+            Visual variant of the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxButton"/> (composed with a theme color, see <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.Color"/>).
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">Bootstrap 6 buttons</see>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant.Solid">
+            <summary>
+            Solid (filled) button. Default.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant.Outline">
+            <summary>
+            Outlined button.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant.Subtle">
+            <summary>
+            Button with a subtle (light) background.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant.Text">
+            <summary>
+            Text-only button (no background or border).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant.Link">
+            <summary>
+            Link-styled button.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.ButtonVariantExtensions.ToButtonVariantAndColorCssClass(Havit.Blazor.Components.Web.Bootstrap.ButtonVariant,Havit.Blazor.Components.Web.Bootstrap.ThemeColor)">
+            <summary>
+            Bootstrap 6 buttons compose a variant class (<c>btn-solid</c>, <c>btn-outline</c>, ...) with a theme color class (<c>theme-*</c>).
+            Without a color, the variant classes have no theme tokens to consume, so no variant class is emitted (a plain neutral <c>btn</c> look),
+            with the exception of the standalone <c>btn-link</c> variant.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.CloseButtonSettings">
@@ -377,9 +420,10 @@
             Button size. The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ButtonSize.Regular"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.Variant">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" button</see> style.
+            Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/button/">variant</see> of the button (solid, outline, subtle, text, link), composed with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.Color"/>.
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ButtonVariant.Solid"/>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxButton.CssClass">
@@ -3247,7 +3291,7 @@
             Color for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxListRenderMode.ToggleButtons"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.CheckboxListSettings.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.CheckboxListSettings.Variant">
             <summary>
             Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
             for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxListRenderMode.ToggleButtons"/> and <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxListRenderMode.ButtonGroup"/>.
@@ -3293,7 +3337,7 @@
             Color for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxRenderMode.ToggleButton"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.CheckboxSettings.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.CheckboxSettings.Variant">
             <summary>
             Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
             for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxRenderMode.ToggleButton"/>.
@@ -3359,7 +3403,7 @@
             For <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxRenderMode.ToggleButton"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckbox.Variant">
             <summary>
             <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" button</see> style.
             For <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxRenderMode.ToggleButton"/>.
@@ -3555,7 +3599,7 @@
             Color for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxListRenderMode.ToggleButtons"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxList`2.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxList`2.Variant">
             <summary>
             Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
             for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxListRenderMode.ToggleButtons"/> and <see cref="F:Havit.Blazor.Components.Web.Bootstrap.CheckboxListRenderMode.ButtonGroup"/>.
@@ -4906,7 +4950,7 @@
             Color for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ToggleButtons"/> and <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ButtonGroup"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxRadioButtonListBase`2.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxRadioButtonListBase`2.Variant">
             <summary>
             Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
             for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ToggleButtons"/> and <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ButtonGroup"/>.
@@ -5950,7 +5994,7 @@
             Color for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ToggleButtons"/> and <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ButtonGroup"/>.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListSettings.Outline">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListSettings.Variant">
             <summary>
             Indicates whether to use <see href="https://getbootstrap.com/docs/5.3/components/buttons/#outline-buttons">Bootstrap "outline" buttons</see>.
             for <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ToggleButtons"/> and <see cref="F:Havit.Blazor.Components.Web.Bootstrap.RadioButtonListRenderMode.ButtonGroup"/>.

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxCheckboxListTests/HxCheckboxList_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxCheckboxListTests/HxCheckboxList_Test.razor
@@ -24,7 +24,7 @@
 				RenderMode="CheckboxListRenderMode.ToggleButtons"
 				Label="Toggle buttons"
 				Color="ThemeColor.Secondary"
-				Outline="true"
+				Variant="ButtonVariant.Outline"
 				InputCssClass="d-flex gap-1" />
 
 <h3>Button group</h3>
@@ -33,7 +33,7 @@
 				RenderMode="CheckboxListRenderMode.ButtonGroup"
 				Label="Button group"
 				Color="ThemeColor.Secondary"
-				Outline="true"
+				Variant="ButtonVariant.Outline"
 				Inline="true" />
 
 @code {

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxCheckboxTests/HxCheckbox_ToggleButtons_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxCheckboxTests/HxCheckbox_ToggleButtons_Test.razor
@@ -11,21 +11,21 @@
 
 <h3>Toggle buttons in a button group</h3>
 <HxButtonGroup>
-    <HxCheckbox Text="Value 1" @bind-Value="@model.Value1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Success" Outline="true" />
-    <HxCheckbox Text="Value 2" @bind-Value="@model.Value2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Info" Outline="true" />
+    <HxCheckbox Text="Value 1" @bind-Value="@model.Value1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Success" Variant="ButtonVariant.Outline" />
+    <HxCheckbox Text="Value 2" @bind-Value="@model.Value2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Info" Variant="ButtonVariant.Outline" />
 </HxButtonGroup>
 
 <h3>Toggle buttons with Label</h3>
-<HxCheckbox Label="Toggle button 1" Text="Value 1" @bind-Value="@model.Value1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Success" Outline="true" />
-<HxCheckbox Label="Toggle button 2" Text="Value 2" @bind-Value="@model.Value2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Info" Outline="true" />
+<HxCheckbox Label="Toggle button 1" Text="Value 1" @bind-Value="@model.Value1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Success" Variant="ButtonVariant.Outline" />
+<HxCheckbox Label="Toggle button 2" Text="Value 2" @bind-Value="@model.Value2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Info" Variant="ButtonVariant.Outline" />
 
 <h3>In edit form</h3>
 <EditForm @bind-Model="@model">
     <DataAnnotationsValidator />
     <ValidationSummary />
 
-    <HxCheckbox Text="Value 1" @bind-Value="@model.Value1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Success" Outline="true" />
-    <HxCheckbox Text="Value 2" @bind-Value="@model.Value2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Info" Outline="true" />
+    <HxCheckbox Text="Value 1" @bind-Value="@model.Value1" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Success" Variant="ButtonVariant.Outline" />
+    <HxCheckbox Text="Value 2" @bind-Value="@model.Value2" RenderMode="CheckboxRenderMode.ToggleButton" Color="ThemeColor.Info" Variant="ButtonVariant.Outline" />
 
     <HxSubmit Icon="@BootstrapIcon.Check" Color="ThemeColor.Primary">Submit</HxSubmit>
 </EditForm>

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxGridTests/HxGrid_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxGridTests/HxGrid_Test.razor
@@ -10,7 +10,7 @@
 		<HxGridColumn Order="3" TItem="CultureInfo" HeaderText="Link">
 			<ItemTemplate>
 				<a href="https://www.havit.cz" @onclick:stopPropagation>link to a page</a>
-				<HxButton Text="Go" Color="ThemeColor.Secondary" Outline="true" />
+				<HxButton Text="Go" Color="ThemeColor.Secondary" Variant="ButtonVariant.Outline" />
 			</ItemTemplate>
 		</HxGridColumn>
 		<HxGridColumn Id="Name" Order="2" TItem="CultureInfo" HeaderText="Name" ItemTextSelector="@(item => item.Name)" SortKeySelector="@(item => item.Name)" ItemCssClassSelector="@(item => item.Name.Contains('Z') ? "text-end" : null)" />

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxRadioButtonListTests/HxRadioButtonList_ToggleButtons_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxRadioButtonListTests/HxRadioButtonList_ToggleButtons_Test.razor
@@ -1,4 +1,4 @@
-@page "/HxRadioButtonList_ToggleButtons"
+﻿@page "/HxRadioButtonList_ToggleButtons"
 @rendermode InteractiveServer
 @using System.ComponentModel.DataAnnotations
 
@@ -13,7 +13,7 @@
 				   ItemValueSelector="@(item => item)"
 				   RenderMode="RadioButtonListRenderMode.ToggleButtons"
 				   Color="ThemeColor.Success"
-				   Outline="true" />
+				   Variant="ButtonVariant.Outline" />
 
 <h3>Toggle buttons - Inline</h3>
 <HxRadioButtonList TItem="string"
@@ -25,7 +25,7 @@
 				   RenderMode="RadioButtonListRenderMode.ToggleButtons"
 				   Color="ThemeColor.Info"
 				   Inline="true"
-				   Outline="true" />
+				   Variant="ButtonVariant.Outline" />
 
 <h3>Toggle buttons in a button group</h3>
 <HxRadioButtonList TItem="string"
@@ -36,7 +36,7 @@
 				   ItemValueSelector="@(item => item)"
 				   RenderMode="RadioButtonListRenderMode.ButtonGroup"
 				   Color="ThemeColor.Primary"
-				   Outline="true" />
+				   Variant="ButtonVariant.Outline" />
 
 <h3>Toggle buttons in a vertical button group (inline)</h3>
 <HxRadioButtonList TItem="string"
@@ -48,7 +48,7 @@
 				   RenderMode="RadioButtonListRenderMode.ButtonGroup"
 				   Inline="true"
 				   Color="ThemeColor.Secondary"
-				   Outline="true" />
+				   Variant="ButtonVariant.Outline" />
 
 <h3>In edit form</h3>
 <EditForm @bind-Model="@model">
@@ -63,7 +63,7 @@
 					   ItemValueSelector="@(item => item)"
 					   RenderMode="RadioButtonListRenderMode.ToggleButtons"
 					   Color="ThemeColor.Success"
-					   Outline="true"
+					   Variant="ButtonVariant.Outline"
 					   Label="Select an option" />
 
 	<HxSubmit Icon="@BootstrapIcon.Check" Color="ThemeColor.Primary">Submit</HxSubmit>


### PR DESCRIPTION
Fixes #1442

Bootstrap 6 replaces per-color button classes (`btn-primary`, `btn-outline-primary`, …) with a composition of a **variant class** and a **theme color class** (`btn-solid theme-primary`). Per the agreed API: new `Variant` parameter, `Outline` removed.

## API changes
- **New `ButtonVariant` enum**: `Solid` (default), `Outline`, `Subtle`, `Text`, `Link` — exposed as `Variant` parameter on `HxButton` (+ `ButtonSettings`, `HxSmartPasteButton`, and the toggle-button render modes of `HxCheckbox`/`HxCheckboxList`/`HxRadioButtonList`).
- **`Outline` (bool) parameter removed** everywhere — migration: `Outline="true"` → `Variant="ButtonVariant.Outline"` (compile-time break).
- **`ButtonSize.ExtraSmall`** added (`btn-xs`, new in v6).
- `ThemeColorExtensions.ToButtonColorCss` removed; replaced by `ButtonVariantExtensions.ToButtonVariantAndColorCssClass`.

## Rendering rules
- `Variant` + `Color` → `btn-{variant} theme-{color}` (e.g. `btn-subtle theme-danger`).
- `Color="ThemeColor.Link"` still renders the `btn-link` variant (nav/menu toggle defaults rely on it).
- No `Color` → plain neutral `.btn` (v6 variant classes consume theme tokens, so a variant without a theme would be visually broken); explicit `Variant="Link"` works color-less.
- The `.btn`/`hx-button` base classes remain on every button (v6 keeps `.btn` as a valid neutral base; scoped CSS relies on it).

## Docs &amp; apps
- `HxButton_Demo_Variants` replaces `HxButton_Demo_Outline` (shows all five variants + colors incl. Accent/Inverse); ~86 `Outline` usages migrated across docs, BlazorAppTest, and TestApp.

## Verification
Solution builds clean locally (`-warnaserror` for the library); **464/464** unit tests and **351/351** documentation tests pass (net10.0; CI covers net8/net9).

Out of scope (per issue plan): `.btn-icon` square icon-buttons and `.btn-styled` depth modifier (can be follow-ups), v6 toggle-button nested-input markup (#1453), `HxCloseButton` (#1447).

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_