### PR TITLE
Theme-based variants: HxBadge, HxAlert, HxListGroup, HxToast

### DIFF
--- a/BlazorAppTest/Pages/HxBadgeTest.razor
+++ b/BlazorAppTest/Pages/HxBadgeTest.razor
@@ -4,7 +4,7 @@
 
 <HxBadge Color="ThemeColor.Secondary">New</HxBadge>
 <HxBadge Color="ThemeColor.Primary">New</HxBadge>
-<HxBadge Color="ThemeColor.Secondary" TextColor="ThemeColor.Inverse">Light</HxBadge>
+<HxBadge Color="ThemeColor.Secondary">Light</HxBadge>
 <HxBadge Color="ThemeColor.Danger" Type="BadgeType.RoundedPill">Rounded Pill</HxBadge>
 
 <HxButton Color="ThemeColor.Primary">Button <HxBadge Color="ThemeColor.Secondary">13</HxBadge></HxButton>

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAlertTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAlertTests.cs
@@ -12,18 +12,18 @@ public class HxAlertTests : BunitTestBase
 
 		// Assert
 		var div = cut.Find("div.alert");
-		Assert.True(div.ClassList.Contains("alert-primary"));
+		Assert.True(div.ClassList.Contains("theme-primary"));
 	}
 
 	[Theory]
-	[InlineData(ThemeColor.Primary, "alert-primary")]
-	[InlineData(ThemeColor.Secondary, "alert-secondary")]
-	[InlineData(ThemeColor.Success, "alert-success")]
-	[InlineData(ThemeColor.Danger, "alert-danger")]
-	[InlineData(ThemeColor.Warning, "alert-warning")]
-	[InlineData(ThemeColor.Info, "alert-info")]
-	[InlineData(ThemeColor.Accent, "alert-accent")]
-	[InlineData(ThemeColor.Inverse, "alert-inverse")]
+	[InlineData(ThemeColor.Primary, "theme-primary")]
+	[InlineData(ThemeColor.Secondary, "theme-secondary")]
+	[InlineData(ThemeColor.Success, "theme-success")]
+	[InlineData(ThemeColor.Danger, "theme-danger")]
+	[InlineData(ThemeColor.Warning, "theme-warning")]
+	[InlineData(ThemeColor.Info, "theme-info")]
+	[InlineData(ThemeColor.Accent, "theme-accent")]
+	[InlineData(ThemeColor.Inverse, "theme-inverse")]
 	public void HxAlert_Color_AllThemeColors(ThemeColor color, string expectedCss)
 	{
 		// Act

--- a/Havit.Blazor.Components.Web.Bootstrap/Alerts/HxAlert.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Alerts/HxAlert.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/alerts/">Bootstrap alert</see> component.<br />
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/">Bootstrap alert</see> component.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAlert">https://havit.blazor.eu/components/HxAlert</see>
 /// </summary>
 public partial class HxAlert
@@ -41,7 +41,7 @@ public partial class HxAlert
 		{
 			ThemeColor.None => null,
 			ThemeColor.Link => throw new NotSupportedException($"{nameof(ThemeColor)}.{nameof(ThemeColor.Link)} cannot be used as {nameof(HxAlert)} color."),
-			_ => "alert-" + Color.ToString("f").ToLower()
+			_ => Color.ToThemeCss()
 		};
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Badges/BadgeSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Badges/BadgeSettings.cs
@@ -11,9 +11,9 @@ public record BadgeSettings
 	public ThemeColor? Color { get; set; }
 
 	/// <summary>
-	/// Color of the badge text. Use <see cref="Color"/> for the background color.
+	/// Visual variant of the badge (solid, subtle, outline), composed with <see cref="Color"/>.
 	/// </summary>
-	public ThemeColor? TextColor { get; set; }
+	public BadgeVariant? Variant { get; set; }
 
 	/// <summary>
 	/// Badge type - Regular or rounded pills.

--- a/Havit.Blazor.Components.Web.Bootstrap/Badges/BadgeVariant.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Badges/BadgeVariant.cs
@@ -1,0 +1,23 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Visual variant of the <see cref="HxBadge"/> (composed with a theme color, see <see cref="HxBadge.Color"/>).
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap 6 badges</see>.
+/// </summary>
+public enum BadgeVariant
+{
+	/// <summary>
+	/// Solid (filled) badge. Default.
+	/// </summary>
+	Solid = 0,
+
+	/// <summary>
+	/// Badge with a subtle (light) background (<c>badge-subtle</c>).
+	/// </summary>
+	Subtle,
+
+	/// <summary>
+	/// Outlined badge (<c>badge-outline</c>).
+	/// </summary>
+	Outline
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Badges/HxBadge.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Badges/HxBadge.razor
@@ -1,2 +1,2 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
-<span class="@CssClassHelper.Combine("badge", GetBackgroundColorCss(), GetTypeCss(), TextColorEffective.ToTextColorCss(), CssClassEffective)" @attributes="AdditionalAttributes">@ChildContent</span>
+<span class="@CssClassHelper.Combine("badge", GetVariantCss(), ColorEffective.ToThemeCss(), GetTypeCss(), CssClassEffective)" @attributes="AdditionalAttributes">@ChildContent</span>

--- a/Havit.Blazor.Components.Web.Bootstrap/Badges/HxBadge.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Badges/HxBadge.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/badge/">Bootstrap Badge</see> component.<br />
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap Badge</see> component.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxBadge">https://havit.blazor.eu/components/HxBadge</see>
 /// </summary>
 public partial class HxBadge
@@ -16,7 +16,7 @@ public partial class HxBadge
 		Defaults = new BadgeSettings()
 		{
 			Color = null,
-			TextColor = ThemeColor.None,
+			Variant = BadgeVariant.Solid,
 			Type = BadgeType.Regular,
 			CssClass = null
 		};
@@ -50,11 +50,11 @@ public partial class HxBadge
 	protected ThemeColor ColorEffective => Color ?? GetSettings()?.Color ?? GetDefaults().Color ?? throw new InvalidOperationException(nameof(Color) + " for " + nameof(HxBadge) + " has to be set.");
 
 	/// <summary>
-	/// Color of badge text. Use <see cref="Color"/> for the background color.
-	/// The default is <see cref="ThemeColor.None"/> (color automatically selected to work with the chosen background color).
+	/// Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">variant</see> of the badge (solid, subtle, outline), composed with <see cref="Color"/>.
+	/// The default is <see cref="BadgeVariant.Solid"/>.
 	/// </summary>
-	[Parameter] public ThemeColor? TextColor { get; set; }
-	protected ThemeColor TextColorEffective => TextColor ?? GetSettings()?.TextColor ?? GetDefaults().TextColor ?? throw new InvalidOperationException(nameof(TextColor) + " default for " + nameof(HxBadge) + " has to be set.");
+	[Parameter] public BadgeVariant? Variant { get; set; }
+	protected BadgeVariant VariantEffective => Variant ?? GetSettings()?.Variant ?? GetDefaults().Variant ?? throw new InvalidOperationException(nameof(Variant) + " default for " + nameof(HxBadge) + " has to be set.");
 
 	/// <summary>
 	/// Badge type - Regular or rounded-pills. The default is <see cref="BadgeType.Regular"/>.
@@ -80,14 +80,15 @@ public partial class HxBadge
 		Contract.Requires<InvalidOperationException>(Color != ThemeColor.None, $"Parameter {nameof(Color)} of {nameof(HxBadge)} is required.");
 	}
 
-	private string GetBackgroundColorCss()
+	private string GetVariantCss()
 	{
-		// if TextColor is not set, we use the combined -text-bg-{color} class (Bootstrap 5.3.3)
-		if (TextColorEffective == ThemeColor.None)
+		return VariantEffective switch
 		{
-			return ColorEffective.ToTextBackgroundColorCss();
-		}
-		return ColorEffective.ToBackgroundColorCss();
+			BadgeVariant.Solid => null,
+			BadgeVariant.Subtle => "badge-subtle",
+			BadgeVariant.Outline => "badge-outline",
+			_ => throw new InvalidOperationException($"Unknown {nameof(BadgeVariant)} value: {VariantEffective}.")
+		};
 	}
 
 	protected string GetTypeCss()

--- a/Havit.Blazor.Components.Web.Bootstrap/ListGroups/HxListGroupItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/ListGroups/HxListGroupItem.razor.cs
@@ -59,7 +59,7 @@ public partial class HxListGroupItem
 		{
 			null => null,
 			ThemeColor.None => null,
-			_ => "list-group-item-" + Color.Value.ToString("f").ToLower()
+			_ => Color.Value.ToThemeCss()
 		};
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToast.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToast.cs
@@ -25,6 +25,12 @@ public partial class HxToast : ComponentBase, IAsyncDisposable
 	[Parameter] public string CssClass { get; set; }
 
 	/// <summary>
+	/// When <c>true</c>, enhances the toast translucency with a backdrop blur and saturation filter (<c>toast-translucent</c>, new in Bootstrap 6).
+	/// Default is <c>false</c>.
+	/// </summary>
+	[Parameter] public bool Translucent { get; set; }
+
+	/// <summary>
 	/// Header icon.
 	/// </summary>
 	[Parameter] public IconBase HeaderIcon { get; set; }
@@ -95,6 +101,7 @@ public partial class HxToast : ComponentBase, IAsyncDisposable
 		var ssrInit = true; // TODO .NET9 - disable ssrInit for pre-rendering (keep for pure static SSR)
 		builder.AddAttribute(104, "class", CssClassHelper.Combine(
 			"hx-toast toast",
+			Translucent ? "toast-translucent" : null,
 			ssrInit ? "hx-toast-init" : null,
 			Color?.ToTextBackgroundColorCss(),
 			CssClass));

--- a/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Demo_Colors.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Demo_Colors.razor
@@ -2,7 +2,7 @@
 <HxBadge Color="ThemeColor.Secondary">Secondary</HxBadge>
 <HxBadge Color="ThemeColor.Success">Success</HxBadge>
 <HxBadge Color="ThemeColor.Danger">Danger</HxBadge>
-<HxBadge Color="ThemeColor.Warning" TextColor="ThemeColor.Inverse">Warning</HxBadge>
+<HxBadge Color="ThemeColor.Warning">Warning</HxBadge>
 <HxBadge Color="ThemeColor.Info">Info</HxBadge>
-<HxBadge Color="ThemeColor.Secondary" TextColor="ThemeColor.Inverse">Light</HxBadge>
+<HxBadge Color="ThemeColor.Secondary">Light</HxBadge>
 <HxBadge Color="ThemeColor.Inverse">Dark</HxBadge>

--- a/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Demo_Pills.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Demo_Pills.razor
@@ -2,7 +2,7 @@
 <HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Secondary">Secondary</HxBadge>
 <HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Success">Success</HxBadge>
 <HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Danger">Danger</HxBadge>
-<HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Warning" TextColor="ThemeColor.Inverse">Warning</HxBadge>
+<HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Warning">Warning</HxBadge>
 <HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Info">Info</HxBadge>
-<HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Secondary" TextColor="ThemeColor.Inverse">Light</HxBadge>
+<HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Secondary">Light</HxBadge>
 <HxBadge Type="BadgeType.RoundedPill" Color="ThemeColor.Inverse">Dark</HxBadge>

--- a/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Demo_Variants.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Demo_Variants.razor
@@ -1,0 +1,5 @@
+﻿<HxBadge Color="ThemeColor.Primary">Solid</HxBadge>
+<HxBadge Variant="BadgeVariant.Subtle" Color="ThemeColor.Primary">Subtle</HxBadge>
+<HxBadge Variant="BadgeVariant.Outline" Color="ThemeColor.Primary">Outline</HxBadge>
+<HxBadge Variant="BadgeVariant.Subtle" Color="ThemeColor.Danger">Subtle danger</HxBadge>
+<HxBadge Variant="BadgeVariant.Outline" Color="ThemeColor.Success">Outline success</HxBadge>

--- a/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxBadgeDoc/HxBadge_Documentation.razor
@@ -1,4 +1,4 @@
-@attribute [Route("/components/" + nameof(HxBadge))]
+﻿@attribute [Route("/components/" + nameof(HxBadge))]
 
 <ApiDoc Type="typeof(HxBadge)">
     <p>Badges scale to match the size of the immediate parent element by using relative font sizing and <code>em</code> units. As of Bootstrap v5, badges no longer have focus or hover styles for links.</p>
@@ -17,6 +17,10 @@
     <DocHeading Title="Rounded circle" Level="4" />
     <p>You can add the <code>rounded-circle</code> class and leave the content empty for a more generic indicator.</p>
     <Demo Type="typeof(HxBadge_Demo_Positioned_RoundedCircle)" />
+
+    <DocHeading Title="Variants" />
+    <p>Bootstrap 6 badges compose a visual variant (<code>BadgeVariant.Solid</code>, <code>Subtle</code>, <code>Outline</code>) with a theme color:</p>
+    <Demo Type="typeof(HxBadge_Demo_Variants)" />
 
     <DocHeading Title="Background colors" />
     <p>Use our background utility classes to quickly change the appearance of a badge. Please note that when using Bootstrap’s default <code>.bg-light</code>, you’ll likely need a text color utility like <code>.text-dark</code> for proper styling. This is because background utilities do not set anything but <code>background-color</code>.</p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxInputTagsDoc/HxInputTags_Demo_Colors.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxInputTagsDoc/HxInputTags_Demo_Colors.razor
@@ -11,7 +11,7 @@
 <HxInputTags Label="Tags"
 			 @bind-Value="values"
 			 DataProvider="GetNewItemSuggestions"
-			 TagBadgeSettings="@(new BadgeSettings() { Color=ThemeColor.Warning, TextColor=ThemeColor.Inverse })" />
+			 TagBadgeSettings="@(new BadgeSettings() { Color=ThemeColor.Warning })" />
 
 @code
 {

--- a/Havit.Blazor.Documentation/Pages/Components/HxInputTagsDoc/HxInputTags_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxInputTagsDoc/HxInputTags_Documentation.razor
@@ -1,4 +1,4 @@
-@attribute [Route("/components/" + nameof(HxInputTags))]
+﻿@attribute [Route("/components/" + nameof(HxInputTags))]
 
 <ApiDoc Type="typeof(HxInputTags)">
     <MainContent>
@@ -31,7 +31,7 @@
         <Demo Type="typeof(HxInputTags_Demo_AllowCustomTags)" />
 
         <DocHeading Title="Colors" />
-        <p>Use <code>TagBackgroundColor</code> and <code>TagTextColor</code> via <code>TagBadgeSettings</code> to adjust the colors.</p>
+        <p>Use <code>Color</code> and <code>Variant</code> via <code>TagBadgeSettings</code> to adjust the tag appearance.</p>
         <Demo Type="typeof(HxInputTags_Demo_Colors)" />
 
         <DocHeading Title="Naked" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Demo_NumberedCustomContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Demo_NumberedCustomContent.razor
@@ -4,20 +4,20 @@
             <div class="fw-bold">Subheading</div>
             Cras justo odio
         </div>
-        <HxBadge Color="ThemeColor.Primary" Variant="BadgeVariant.RoundedPill">14</HxBadge>
+        <HxBadge Color="ThemeColor.Primary" Type="BadgeType.RoundedPill">14</HxBadge>
     </HxListGroupItem>
     <HxListGroupItem CssClass="d-flex justify-content-between align-items-start">
         <div class="ms-2 me-auto">
             <div class="fw-bold">Subheading</div>
             Cras justo odio
         </div>
-        <HxBadge Color="ThemeColor.Primary" Variant="BadgeVariant.RoundedPill">14</HxBadge>
+        <HxBadge Color="ThemeColor.Primary" Type="BadgeType.RoundedPill">14</HxBadge>
     </HxListGroupItem>
     <HxListGroupItem CssClass="d-flex justify-content-between align-items-start">
         <div class="ms-2 me-auto">
             <div class="fw-bold">Subheading</div>
             Cras justo odio
         </div>
-        <HxBadge Color="ThemeColor.Primary" Variant="BadgeVariant.RoundedPill">14</HxBadge>
+        <HxBadge Color="ThemeColor.Primary" Type="BadgeType.RoundedPill">14</HxBadge>
     </HxListGroupItem>
 </HxListGroup>

--- a/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Demo_TitleTemplate.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Demo_TitleTemplate.razor
@@ -2,7 +2,7 @@
 
 <HxListLayout TFilterModel="HxListLayout.NoFilter">
 	<TitleTemplate>
-		Employees <HxBadge Color="ThemeColor.Secondary" TextColor="ThemeColor.Inverse" CssClass="ms-1 fs-6">NEW</HxBadge>
+		Employees <HxBadge Color="ThemeColor.Secondary" CssClass="ms-1 fs-6">NEW</HxBadge>
 	</TitleTemplate>
 	<DataTemplate>
 		<HxGrid TItem="EmployeeDto"

--- a/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Demo.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Demo.razor
@@ -19,6 +19,8 @@
 
 	<HxToast ShowCloseButton="false" CssClass="mb-2" ContentText="Always visible. No close button here." />
 
+	<HxToast Translucent="true" HeaderText="Translucent" ContentText="Translucent toast with backdrop blur (new in Bootstrap 6)." CssClass="mb-2" />
+
 </HxToastContainer>
 
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxTreeViewDoc/HxTreeView_Demo_CustomContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTreeViewDoc/HxTreeView_Demo_CustomContent.razor
@@ -1,4 +1,4 @@
-<div class="row">
+﻿<div class="row">
     <div class="col-lg-4" style="height: 400px">
         <HxTreeView TItem="Directory"
                     @bind-SelectedItem="selectedDirectory"
@@ -15,7 +15,7 @@
                     </div>
                     @if (context.Subdirectories?.Any() ?? false)
                     {
-                        <HxBadge CssClass="mx-2" TextColor="ThemeColor.Inverse" Color="ThemeColor.Secondary">@context.Subdirectories?.Length</HxBadge>
+                        <HxBadge CssClass="mx-2" Color="ThemeColor.Secondary">@context.Subdirectories?.Length</HxBadge>
                     }
                     <div role="button" @onclick:stopPropagation class="btn-plus ms-auto"><HxIcon Icon="BootstrapIcon.PlusLg" /></div>
             </ItemTemplate>

--- a/Havit.Blazor.Documentation/Pages/Concepts/SettingsAndDefaults_Program.CodeSnippet.cs
+++ b/Havit.Blazor.Documentation/Pages/Concepts/SettingsAndDefaults_Program.CodeSnippet.cs
@@ -23,7 +23,7 @@
 		HxDrawer.Defaults.FooterCssClass = "border-top";
 		
 		HxChipList.Defaults.ChipBadgeSettings.Color = ThemeColor.Secondary;
-		HxChipList.Defaults.ChipBadgeSettings.TextColor = ThemeColor.Inverse;
+		HxChipList.Defaults.ChipBadgeSettings. ;
 		HxChipList.Defaults.ChipBadgeSettings.CssClass = "p-2 rounded-pill";
 	}
 }

--- a/Havit.Blazor.Documentation/Shared/Components/ApiDoc.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/ApiDoc.razor
@@ -69,7 +69,7 @@
 						<td>
 							@if (property.IsStatic)
 							{
-								<HxBadge Color="ThemeColor.Secondary" TextColor="ThemeColor.Inverse">static</HxBadge>
+								<HxBadge Color="ThemeColor.Secondary">static</HxBadge>
 							}
 
 							<strong>@property.PropertyInfo.Name</strong>

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -118,7 +118,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAlert">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/alerts/">Bootstrap alert</see> component.<br />
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/">Bootstrap alert</see> component.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAlert">https://havit.blazor.eu/components/HxAlert</see>
             </summary>
         </member>
@@ -152,9 +152,9 @@
             Badge color (background).
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.BadgeSettings.TextColor">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.BadgeSettings.Variant">
             <summary>
-            Color of the badge text. Use <see cref="P:Havit.Blazor.Components.Web.Bootstrap.BadgeSettings.Color"/> for the background color.
+            Visual variant of the badge (solid, subtle, outline), composed with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.BadgeSettings.Color"/>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.BadgeSettings.Type">
@@ -178,9 +178,30 @@
             For more information, see <see href="https://getbootstrap.com/docs/5.3/components/badge/#pill-badges">https://getbootstrap.com/docs/5.3/components/badge/#pill-badges</see>.
             </summary>
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.BadgeVariant">
+            <summary>
+            Visual variant of the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxBadge"/> (composed with a theme color, see <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxBadge.Color"/>).
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap 6 badges</see>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.BadgeVariant.Solid">
+            <summary>
+            Solid (filled) badge. Default.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.BadgeVariant.Subtle">
+            <summary>
+            Badge with a subtle (light) background (<c>badge-subtle</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.BadgeVariant.Outline">
+            <summary>
+            Outlined badge (<c>badge-outline</c>).
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxBadge">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/badge/">Bootstrap Badge</see> component.<br />
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap Badge</see> component.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxBadge">https://havit.blazor.eu/components/HxBadge</see>
             </summary>
         </member>
@@ -213,10 +234,10 @@
             Badge color (background).
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxBadge.TextColor">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxBadge.Variant">
             <summary>
-            Color of badge text. Use <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxBadge.Color"/> for the background color.
-            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ThemeColor.None"/> (color automatically selected to work with the chosen background color).
+            Visual <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">variant</see> of the badge (solid, subtle, outline), composed with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxBadge.Color"/>.
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.BadgeVariant.Solid"/>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxBadge.Type">
@@ -11764,6 +11785,12 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxToast.CssClass">
             <summary>
             CSS class to render with the toast.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxToast.Translucent">
+            <summary>
+            When <c>true</c>, enhances the toast translucency with a backdrop blur and saturation filter (<c>toast-translucent</c>, new in Bootstrap 6).
+            Default is <c>false</c>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxToast.HeaderIcon">

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxTreeViewTests/HxTreeView_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxTreeViewTests/HxTreeView_Test.razor
@@ -19,7 +19,7 @@
 				</div>
 				@if (context.Subdirectories?.Any() ?? false)
 				{
-					<HxBadge CssClass="mx-2" TextColor="ThemeColor.Inverse" Color="ThemeColor.Secondary">@context.Subdirectories?.Length</HxBadge>
+					<HxBadge CssClass="mx-2" Color="ThemeColor.Secondary">@context.Subdirectories?.Length</HxBadge>
 				}
 				<div role="button" @onclick:stopPropagation class="btn-plus ms-auto"><HxIcon Icon="BootstrapIcon.PlusLg" /></div>
 			</ItemTemplate>


### PR DESCRIPTION
Fixes #1443, fixes #1444, fixes #1449, fixes #1450

First Phase 3 batch — the four components whose v6 change is the same pattern: per-color CSS classes replaced by the composable **theme token system** (#1468).

## HxBadge (#1443)
- New **`BadgeVariant`** (`Solid` default, `Subtle`, `Outline`) composed with `Color`: `badge theme-primary`, `badge badge-subtle theme-primary`, `badge badge-outline theme-primary`.
- **`TextColor` removed** — theme tokens provide the contrast color automatically.
- Fixed a latent docs bug the new parameter surfaced: `Variant="BadgeVariant.RoundedPill"` in a list-group demo had been silently splatted as a string attribute (no `Variant` parameter existed in v5) — corrected to `Type="BadgeType.RoundedPill"`.

## HxAlert (#1444)
- `alert-{color}` → `theme-{color}` (`alert-dismissible`/`fade`/`show` are unchanged in v6).

## HxListGroup (#1449)
- Item variants: `list-group-item-{color}` → `theme-{color}`. (The prefix-based horizontal classes were already delivered in #1475.)

## HxToast / HxMessenger (#1450)
- New **`Translucent`** parameter → `toast-translucent` (backdrop blur + saturation filter, new in v6).
- Header colors already use theme classes since #1474; dark mode is available via `data-bs-theme="dark"` attribute splatting; close-button rework belongs to #1447.

## Docs &amp; verification
Badge **Variants** demo added, translucent toast example, `TextColor` usages removed across docs/test apps. Library builds with `-warnaserror`; **464/464** unit tests and **353/353** documentation tests pass locally (net10.0; CI covers net8/net9).

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_