### PR TITLE
Navbar, navs &amp; tabs, tooltip/popover: Bootstrap 6 verification and leftovers

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/HxAutosuggest.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/HxAutosuggest.cs
@@ -109,7 +109,7 @@ public class HxAutosuggest<TItem, TValue> : HxInputBase<TValue>, IInputWithSize,
 
 	/// <summary>
 	/// The offset between the menu and the input.
-	/// <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+	/// <see href="https://floating-ui.com/docs/offset#options"/>
 	/// </summary>
 	protected virtual (int Skidding, int Distance) MenuOffset { get; set; } = (0, 4);
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInputInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInputInternal.razor.cs
@@ -26,7 +26,7 @@ public partial class HxAutosuggestInputInternal
 
 	/// <summary>
 	/// Offset between the menu and the input.
-	/// <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+	/// <see href="https://floating-ui.com/docs/offset#options"/>
 	/// </summary>
 	[Parameter] public (int Skidding, int Distance) MenuOffset { get; set; }
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInternal.razor.cs
@@ -72,7 +72,7 @@ public partial class HxAutosuggestInternal<TItem, TValue> : IAsyncDisposable
 
 	/// <summary>
 	/// Offset between the menu and the input.
-	/// <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+	/// <see href="https://floating-ui.com/docs/offset#options"/>
 	/// </summary>
 	[Parameter] public (int Skidding, int Distance) MenuOffset { get; set; } = (0, 4);
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/SearchBox/HxSearchBox.razor.cs
@@ -161,7 +161,7 @@ public partial class HxSearchBox<TItem> : IAsyncDisposable, IInputWithSize, IInp
 
 	/// <summary>
 	/// Offset between the menu and the input.
-	/// <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+	/// <see href="https://floating-ui.com/docs/offset#options"/>
 	/// </summary>
 	[Parameter] public (int Skidding, int Distance) MenuOffset { get; set; } = (0, 4);
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Menus/HxMenuToggleButton.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Menus/HxMenuToggleButton.cs
@@ -25,7 +25,7 @@ public class HxMenuToggleButton : HxButton, IAsyncDisposable, IHxMenuToggle
 	protected override ButtonSettings GetDefaults() => Defaults;
 
 	/// <summary>
-	/// Offset <c>(<see href="https://popper.js.org/docs/v2/modifiers/offset/#skidding-1">skidding</see>, <see href="https://popper.js.org/docs/v2/modifiers/offset/#distance-1">distance</see>)</c>
+	/// Offset <c>(<see href="https://floating-ui.com/docs/offset#options">skidding</see>, <see href="https://floating-ui.com/docs/offset#options">distance</see>)</c>
 	/// of the menu relative to its target.  Default is <c>(0, 2)</c>.
 	/// </summary>
 	[Parameter] public (int Skidding, int Distance)? MenuOffset { get; set; }
@@ -33,8 +33,7 @@ public class HxMenuToggleButton : HxButton, IAsyncDisposable, IHxMenuToggle
 	/// <summary>
 	/// Reference element of the menu menu. Accepts the values of <c>toggle</c> (default), <c>parent</c>,
 	/// an HTMLElement reference (e.g. <c>#id</c>) or an object providing <c>getBoundingClientRect</c>.
-	/// For more information, refer to Popper's <see href="https://popper.js.org/docs/v2/constructors/#createpopper">constructor docs</see>
-	/// and <see href="https://popper.js.org/docs/v2/virtual-elements/">virtual element docs</see>.
+	/// For more information, refer to the <see href="https://floating-ui.com/docs/computePosition">Floating UI documentation</see>.
 	/// </summary>
 	[Parameter] public string MenuReference { get; set; }
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Menus/HxMenuToggleElement.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Menus/HxMenuToggleElement.cs
@@ -16,13 +16,12 @@ public class HxMenuToggleElement : ComponentBase, IHxMenuToggle, IAsyncDisposabl
 	/// <summary>
 	/// Reference element of the menu menu. Accepts the values of <c>toggle</c> (default), <c>parent</c>,
 	/// an HTMLElement reference (e.g. <c>#id</c>) or an object providing <c>getBoundingClientRect</c>.
-	/// For more information, refer to Popper's <see href="https://popper.js.org/docs/v2/constructors/#createpopper">constructor docs</see>
-	/// and <see href="https://popper.js.org/docs/v2/virtual-elements/">virtual element docs</see>.
+	/// For more information, refer to the <see href="https://floating-ui.com/docs/computePosition">Floating UI documentation</see>.
 	/// </summary>
 	[Parameter] public string MenuReference { get; set; }
 
 	/// <summary>
-	/// Offset <c>(<see href="https://popper.js.org/docs/v2/modifiers/offset/#skidding-1">skidding</see>, <see href="https://popper.js.org/docs/v2/modifiers/offset/#distance-1">distance</see>)</c>
+	/// Offset <c>(<see href="https://floating-ui.com/docs/offset#options">skidding</see>, <see href="https://floating-ui.com/docs/offset#options">distance</see>)</c>
 	/// of the menu relative to its target. Default is <c>(0, 2)</c>.
 	/// </summary>
 	[Parameter] public (int Skidding, int Distance)? MenuOffset { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNavbarToggler.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNavbarToggler.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Bootstrap 5 <see href="https://getbootstrap.com/docs/5.3/components/navbar/#toggler">navbar-toggler</see> component.
+/// Bootstrap <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/navbar/#toggler">navbar-toggler</see> component. The toggler icon is rendered via a CSS <c>mask-image</c> tinted with <c>currentcolor</c> (no separate light/dark icons needed in Bootstrap 6).
 /// Derived from <see cref="HxCollapseToggleButton"/>.
 /// </summary>
 public class HxNavbarToggler : HxCollapseToggleButton

--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor.cs
@@ -212,15 +212,12 @@ public partial class HxTabPanel : ComponentBase
 			return null;
 		}
 
-		if (NavVariant == NavVariant.Pills)
-		{
-			return "card-header-pills";
-		}
-		else if (NavVariant == NavVariant.Tabs)
+		if (NavVariant == NavVariant.Tabs)
 		{
 			return "card-header-tabs";
 		}
 
+		// Bootstrap 6 has no card-header-pills class (only card-header-tabs remains).
 		return null;
 	}
 }

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -3334,7 +3334,7 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAutosuggest`2.MenuOffset">
             <summary>
             The offset between the menu and the input.
-            <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+            <see href="https://floating-ui.com/docs/offset#options"/>
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAutosuggest`2.ItemFromValueResolver">
@@ -3392,7 +3392,7 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxAutosuggestInputInternal.MenuOffset">
             <summary>
             Offset between the menu and the input.
-            <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+            <see href="https://floating-ui.com/docs/offset#options"/>
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxAutosuggestInputInternal.AdditionalAttributes">
@@ -3445,7 +3445,7 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxAutosuggestInternal`2.MenuOffset">
             <summary>
             Offset between the menu and the input.
-            <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+            <see href="https://floating-ui.com/docs/offset#options"/>
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxAutosuggestInternal`2.InputGroupCssClass">
@@ -7310,7 +7310,7 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSearchBox`1.MenuOffset">
             <summary>
             Offset between the menu and the input.
-            <see href="https://popper.js.org/docs/v2/modifiers/offset/#options"/>
+            <see href="https://floating-ui.com/docs/offset#options"/>
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSearchBox`1.Label">
@@ -9836,7 +9836,7 @@
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMenuToggleButton.MenuOffset">
             <summary>
-            Offset <c>(<see href="https://popper.js.org/docs/v2/modifiers/offset/#skidding-1">skidding</see>, <see href="https://popper.js.org/docs/v2/modifiers/offset/#distance-1">distance</see>)</c>
+            Offset <c>(<see href="https://floating-ui.com/docs/offset#options">skidding</see>, <see href="https://floating-ui.com/docs/offset#options">distance</see>)</c>
             of the menu relative to its target.  Default is <c>(0, 2)</c>.
             </summary>
         </member>
@@ -9844,8 +9844,7 @@
             <summary>
             Reference element of the menu menu. Accepts the values of <c>toggle</c> (default), <c>parent</c>,
             an HTMLElement reference (e.g. <c>#id</c>) or an object providing <c>getBoundingClientRect</c>.
-            For more information, refer to Popper's <see href="https://popper.js.org/docs/v2/constructors/#createpopper">constructor docs</see>
-            and <see href="https://popper.js.org/docs/v2/virtual-elements/">virtual element docs</see>.
+            For more information, refer to the <see href="https://floating-ui.com/docs/computePosition">Floating UI documentation</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMenuToggleButton.OnShown">
@@ -9952,13 +9951,12 @@
             <summary>
             Reference element of the menu menu. Accepts the values of <c>toggle</c> (default), <c>parent</c>,
             an HTMLElement reference (e.g. <c>#id</c>) or an object providing <c>getBoundingClientRect</c>.
-            For more information, refer to Popper's <see href="https://popper.js.org/docs/v2/constructors/#createpopper">constructor docs</see>
-            and <see href="https://popper.js.org/docs/v2/virtual-elements/">virtual element docs</see>.
+            For more information, refer to the <see href="https://floating-ui.com/docs/computePosition">Floating UI documentation</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxMenuToggleElement.MenuOffset">
             <summary>
-            Offset <c>(<see href="https://popper.js.org/docs/v2/modifiers/offset/#skidding-1">skidding</see>, <see href="https://popper.js.org/docs/v2/modifiers/offset/#distance-1">distance</see>)</c>
+            Offset <c>(<see href="https://floating-ui.com/docs/offset#options">skidding</see>, <see href="https://floating-ui.com/docs/offset#options">distance</see>)</c>
             of the menu relative to its target. Default is <c>(0, 2)</c>.
             </summary>
         </member>
@@ -10355,7 +10353,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxNavbarToggler">
             <summary>
-            Bootstrap 5 <see href="https://getbootstrap.com/docs/5.3/components/navbar/#toggler">navbar-toggler</see> component.
+            Bootstrap <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/navbar/#toggler">navbar-toggler</see> component. The toggler icon is rendered via a CSS <c>mask-image</c> tinted with <c>currentcolor</c> (no separate light/dark icons needed in Bootstrap 6).
             Derived from <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxCollapseToggleButton"/>.
             </summary>
         </member>


### PR DESCRIPTION
Fixes #1448, fixes #1451, fixes #1452

Third Phase 3 batch. Most of these three issues was already delivered by earlier PRs — this PR adds the remaining pieces and records the verification.

## Changes
- **HxTabPanel**: `card-header-pills` no longer exists in Bootstrap 6 (only `card-header-tabs` remains) — the Pills nav variant in card mode now renders without the dead class.
- **HxNavbarToggler**: doc note for the v6 mask-based `currentcolor` toggler icon (markup unchanged — the same `span.navbar-toggler-icon` works; no separate light/dark icons anymore).
- XML doc links updated from Popper.js to **Floating UI** (menu toggle offsets/reference, autosuggest, search box).

## Verification of already-delivered pieces (per issue checklists)
- **#1448 navbar**: prefix expand classes (`md:navbar-expand`, `2xl:navbar-expand`) shipped in #1475; Menu in navbar demos in #1476; Drawer in #1479.
- **#1451 tooltip/popover**: Floating UI replaces Popper inside the v6 bundle shipped in #1473; `HxTooltip`/`HxPopover` never exposed `popperConfig` (they're data-attribute driven), so no API change is needed — `bootstrap.Tooltip`/`bootstrap.Popover` interop is unchanged; the `floatingConfig` option is already used where we pass positioning config (`HxContextMenu`, `HxSidebarItem` via `data-bs-floating-config`, #1476).
- **#1452 navs &amp; tabs**: nav-menu integration shipped in #1476 (`HxNav_Demo_Menus`); `HxTab`/`HxTabPanel` manage tab state Blazor-side (no `data-bs-toggle="tab"` dependency) and the emitted markup (`nav-tabs`/`nav-pills`/`nav-underline`, `tab-content`/`tab-pane active`) is all present in the v6 CSS.

## Verification
Library builds with `-warnaserror`; **463/463** unit tests and **352/352** documentation tests pass locally (net10.0; CI covers net8/net9).

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_