### PR TITLE
HxAccordion: rebuild on native details/summary (Bootstrap 6)

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAccordionTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAccordionTests.cs
@@ -4,19 +4,22 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
 
 public class HxAccordionTests : BunitTestBase
 {
+	private static void AddItem(Bunit.ComponentParameterCollectionBuilder<HxAccordion> p, string id, string header, string body)
+	{
+		p.AddChildContent<HxAccordionItem>(item => item
+			.Add(i => i.Id, id)
+			.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, header)))
+			.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, body))));
+	}
+
 	[Fact]
 	public void HxAccordion_Render_HasAccordionStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.AddChildContent<HxAccordionItem>(item => item
-				.Add(i => i.Id, "item1")
-				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header 1")))
-				.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body 1")))));
+		var cut = RenderComponent<HxAccordion>(p => AddItem(p, "item1", "Header 1", "Body 1"));
 
 		// Assert
 		var accordion = cut.Find("div.accordion");
-		Assert.NotNull(accordion);
 		Assert.True(accordion.ClassList.Contains("hx-accordion"));
 	}
 
@@ -24,133 +27,153 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordion_MultipleItems_RendersAllItems()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.AddChildContent(builder =>
-			{
-				builder.OpenComponent<HxAccordionItem>(0);
-				builder.AddAttribute(1, nameof(HxAccordionItem.Id), "item1");
-				builder.AddAttribute(2, nameof(HxAccordionItem.HeaderTemplate), (RenderFragment)(b => b.AddContent(0, "Header 1")));
-				builder.AddAttribute(3, nameof(HxAccordionItem.BodyTemplate), (RenderFragment)(b => b.AddContent(0, "Body 1")));
-				builder.CloseComponent();
-
-				builder.OpenComponent<HxAccordionItem>(10);
-				builder.AddAttribute(11, nameof(HxAccordionItem.Id), "item2");
-				builder.AddAttribute(12, nameof(HxAccordionItem.HeaderTemplate), (RenderFragment)(b => b.AddContent(0, "Header 2")));
-				builder.AddAttribute(13, nameof(HxAccordionItem.BodyTemplate), (RenderFragment)(b => b.AddContent(0, "Body 2")));
-				builder.CloseComponent();
-
-				builder.OpenComponent<HxAccordionItem>(20);
-				builder.AddAttribute(21, nameof(HxAccordionItem.Id), "item3");
-				builder.AddAttribute(22, nameof(HxAccordionItem.HeaderTemplate), (RenderFragment)(b => b.AddContent(0, "Header 3")));
-				builder.AddAttribute(23, nameof(HxAccordionItem.BodyTemplate), (RenderFragment)(b => b.AddContent(0, "Body 3")));
-				builder.CloseComponent();
-			}));
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			AddItem(p, "item1", "Header 1", "Body 1");
+			AddItem(p, "item2", "Header 2", "Body 2");
+			AddItem(p, "item3", "Header 3", "Body 3");
+		});
 
 		// Assert
-		var items = cut.FindAll("div.accordion-item");
-		Assert.Equal(3, items.Count());
+		Assert.Equal(3, cut.FindAll("details.accordion-item").Count);
 	}
 
 	[Fact]
-	public void HxAccordionItem_Render_HasCorrectStructure()
+	public void HxAccordionItem_Render_HasNativeDetailsStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.AddChildContent<HxAccordionItem>(item => item
-				.Add(i => i.Id, "item1")
-				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header Text")))
-				.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body Text")))));
+		var cut = RenderComponent<HxAccordion>(p => AddItem(p, "item1", "Header Text", "Body Text"));
 
-		// Assert
-		var item = cut.Find("div.hx-accordion-item");
-		Assert.NotNull(item);
+		// Assert — Bootstrap 6 accordion is built on native <details>/<summary>
+		var item = cut.Find("details.hx-accordion-item");
 		Assert.True(item.ClassList.Contains("accordion-item"));
+		Assert.False(item.HasAttribute("open"));
 
-		var header = cut.Find("h2.accordion-header");
-		Assert.NotNull(header);
+		var summary = cut.Find("summary.accordion-header");
+		Assert.Contains("Header Text", summary.TextContent);
 
-		var button = cut.Find("button.accordion-button");
-		Assert.NotNull(button);
-		Assert.Equal("button", button.GetAttribute("type"));
-		Assert.Equal("collapse", button.GetAttribute("data-bs-toggle"));
-		Assert.Contains("Header Text", button.TextContent);
+		var icon = summary.QuerySelector("svg.accordion-icon");
+		Assert.NotNull(icon);
 
 		var body = cut.Find("div.accordion-body");
-		Assert.NotNull(body);
 		Assert.Contains("Body Text", body.TextContent);
 	}
 
 	[Fact]
-	public void HxAccordionItem_DataBsTarget_MatchesCollapseId()
+	public void HxAccordion_StayOpenFalse_RendersSharedNameAttribute()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.AddChildContent<HxAccordionItem>(item => item
-				.Add(i => i.Id, "testitem")
-				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header")))
-				.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body")))));
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.StayOpen, false);
+			AddItem(p, "item1", "Header 1", "Body 1");
+			AddItem(p, "item2", "Header 2", "Body 2");
+		});
 
-		// Assert - button data-bs-target should match collapse id
-		var button = cut.Find("button.accordion-button");
-		var dataBsTarget = button.GetAttribute("data-bs-target");
-		Assert.NotNull(dataBsTarget);
-		Assert.StartsWith("#collapse-", dataBsTarget);
-
-		// The aria-controls should match the collapse id (without #)
-		var ariaControls = button.GetAttribute("aria-controls");
-		Assert.Equal(dataBsTarget.TrimStart('#'), ariaControls);
+		// Assert — exclusive accordions share the name attribute (replaces v5 data-bs-parent)
+		var accordionId = cut.Find("div.accordion").Id;
+		var items = cut.FindAll("details.accordion-item");
+		Assert.All(items, item => Assert.Equal(accordionId, item.GetAttribute("name")));
 	}
 
 	[Fact]
-	public void HxAccordion_StayOpenFalse_SetsDataBsParent()
+	public void HxAccordion_StayOpenTrue_NoNameAttribute()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.Add(a => a.StayOpen, false)
-			.AddChildContent<HxAccordionItem>(item => item
-				.Add(i => i.Id, "item1")
-				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header")))
-				.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body")))));
-
-		// Assert - the collapse element should have data-bs-parent pointing to accordion
-		var accordionDiv = cut.Find("div.accordion");
-		var accordionId = accordionDiv.Id;
-
-		var collapseDiv = cut.Find("div.accordion-collapse");
-		var dataBsParent = collapseDiv.GetAttribute("data-bs-parent");
-		Assert.Equal($"#{accordionId}", dataBsParent);
-	}
-
-	[Fact]
-	public void HxAccordion_StayOpenTrue_NoDataBsParent()
-	{
-		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.Add(a => a.StayOpen, true)
-			.AddChildContent<HxAccordionItem>(item => item
-				.Add(i => i.Id, "item1")
-				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header")))
-				.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body")))));
-
-		// Assert - the collapse element should NOT have data-bs-parent
-		var collapseDiv = cut.Find("div.accordion-collapse");
-		var dataBsParent = collapseDiv.GetAttribute("data-bs-parent");
-		Assert.True(string.IsNullOrEmpty(dataBsParent), "data-bs-parent should not be set when StayOpen is true.");
-	}
-
-	[Fact]
-	public void HxAccordion_CssClass_IsApplied()
-	{
-		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
-			.Add(a => a.CssClass, "custom-accordion")
-			.AddChildContent<HxAccordionItem>(item => item
-				.Add(i => i.Id, "item1")
-				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header")))
-				.Add(i => i.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body")))));
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.StayOpen, true);
+			AddItem(p, "item1", "Header 1", "Body 1");
+		});
 
 		// Assert
-		var accordion = cut.Find("div.accordion");
-		Assert.True(accordion.ClassList.Contains("custom-accordion"));
+		var item = cut.Find("details.accordion-item");
+		Assert.False(item.HasAttribute("name"));
+	}
+
+	[Fact]
+	public void HxAccordion_InitialExpandedItemId_RendersOpenAttribute()
+	{
+		// Act
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.InitialExpandedItemId, "item2");
+			AddItem(p, "item1", "Header 1", "Body 1");
+			AddItem(p, "item2", "Header 2", "Body 2");
+		});
+
+		// Assert
+		var items = cut.FindAll("details.accordion-item");
+		Assert.False(items[0].HasAttribute("open"));
+		Assert.True(items[1].HasAttribute("open"));
+	}
+
+	[Fact]
+	public void HxAccordion_HeaderClick_ExpandsItemAndRaisesExpandedItemIdChanged()
+	{
+		string expandedItemId = null;
+
+		// Act
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.ExpandedItemIdChanged, (string id) => expandedItemId = id);
+			AddItem(p, "item1", "Header 1", "Body 1");
+		});
+		cut.Find("summary.accordion-header").Click();
+
+		// Assert
+		Assert.Equal("item1", expandedItemId);
+		Assert.True(cut.Find("details.accordion-item").HasAttribute("open"));
+	}
+
+	[Fact]
+	public void HxAccordion_ExclusiveMode_ExpandingOneItemCollapsesTheOther()
+	{
+		// Act
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.InitialExpandedItemId, "item1");
+			AddItem(p, "item1", "Header 1", "Body 1");
+			AddItem(p, "item2", "Header 2", "Body 2");
+		});
+		cut.FindAll("summary.accordion-header")[1].Click();
+
+		// Assert — exclusivity is replicated Blazor-side (state is Blazor-managed)
+		var items = cut.FindAll("details.accordion-item");
+		Assert.False(items[0].HasAttribute("open"));
+		Assert.True(items[1].HasAttribute("open"));
+	}
+
+	[Fact]
+	public void HxAccordion_StayOpen_ExpandingOneItemKeepsTheOtherOpen()
+	{
+		// Act
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.StayOpen, true);
+			p.Add(a => a.InitialExpandedItemIds, new List<string> { "item1" });
+			AddItem(p, "item1", "Header 1", "Body 1");
+			AddItem(p, "item2", "Header 2", "Body 2");
+		});
+		cut.FindAll("summary.accordion-header")[1].Click();
+
+		// Assert
+		var items = cut.FindAll("details.accordion-item");
+		Assert.True(items[0].HasAttribute("open"));
+		Assert.True(items[1].HasAttribute("open"));
+	}
+
+	[Fact]
+	public void HxAccordion_Color_RendersThemeCssClass()
+	{
+		// Act
+		var cut = RenderComponent<HxAccordion>(p =>
+		{
+			p.Add(a => a.Color, ThemeColor.Primary);
+			AddItem(p, "item1", "Header 1", "Body 1");
+		});
+
+		// Assert
+		Assert.True(cut.Find("div.accordion").ClassList.Contains("theme-primary"));
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordion.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordion.razor
@@ -1,5 +1,5 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
-<div id="@Id" class="@CssClassHelper.Combine("hx-accordion","accordion", CssClass)">
+<div id="@Id" class="@CssClassHelper.Combine("hx-accordion", "accordion", Color?.ToThemeCss(), CssClass)">
 	<CascadingValue Value="this" IsFixed="true">
 		@ChildContent
 	</CascadingValue>

--- a/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordion.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordion.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/accordion/">Bootstrap accordion</see> component.<br />
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/accordion/">Bootstrap accordion</see> component (built on the native <c>&lt;details&gt;</c>/<c>&lt;summary&gt;</c> disclosure elements, no JavaScript needed).<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAccordion">https://havit.blazor.eu/components/HxAccordion</see>
 /// </summary>
 public partial class HxAccordion
@@ -10,6 +10,11 @@ public partial class HxAccordion
 	/// Additional CSS classes for the accordion container.
 	/// </summary>
 	[Parameter] public string CssClass { get; set; }
+
+	/// <summary>
+	/// Theme color of the accordion (renders the <c>theme-*</c> class applied to open items).
+	/// </summary>
+	[Parameter] public ThemeColor? Color { get; set; }
 
 	/// <summary>
 	/// IDs of the expanded items (if <see cref="StayOpen"/> is <code>true</code>, several items can be expanded).
@@ -81,6 +86,27 @@ public partial class HxAccordion
 		}
 	}
 
+	private readonly List<HxAccordionItem> _items = new();
+
+	internal void RegisterItem(HxAccordionItem item) => _items.Add(item);
+
+	/// <summary>
+	/// Called by an expanding <see cref="HxAccordionItem"/>. For exclusive accordions (<see cref="StayOpen"/> is <c>false</c>),
+	/// collapses all other expanded items first (replicates the native <c>name</c>-attribute exclusivity Blazor-side,
+	/// as the open state is managed by Blazor).
+	/// </summary>
+	internal async Task NotifyItemExpandedAsync(HxAccordionItem expandedItem)
+	{
+		if (!StayOpen)
+		{
+			foreach (HxAccordionItem otherItem in _items.Where(i => !ReferenceEquals(i, expandedItem) && i.IsExpanded).ToList())
+			{
+				await otherItem.CollapseCoreAsync(invokeExpandedItemIdChanged: false);
+			}
+		}
+		await SetItemExpandedAsync(expandedItem.Id);
+	}
+
 	internal async Task SetItemExpandedAsync(string itemId)
 	{
 		if (!ExpandedItemIds.Contains(itemId))
@@ -94,12 +120,12 @@ public partial class HxAccordion
 		}
 	}
 
-	internal async Task SetItemCollapsedAsync(string itemId)
+	internal async Task SetItemCollapsedAsync(string itemId, bool invokeExpandedItemIdChanged = true)
 	{
 		if (ExpandedItemIds.Contains(itemId))
 		{
 			ExpandedItemIds.Remove(itemId);
-			if (!StayOpen)
+			if (!StayOpen && invokeExpandedItemIdChanged)
 			{
 				await InvokeExpandedItemIdChangedAsync(null);
 			}

--- a/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordionItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordionItem.razor
@@ -1,25 +1,16 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
-<div class="@CssClassHelper.Combine("hx-accordion-item accordion-item", CssClass)">
-    <h2 class="@CssClassHelper.Combine("accordion-header", HeaderCssClass)" id="header-@_idEffective">
-        <button type="button"
-                class="@CssClassHelper.Combine("accordion-button", _lastKnownStateIsExpanded ? null : "collapsed")"
-                data-bs-toggle="collapse"
-                data-bs-target="#collapse-@_idEffective"
-                aria-expanded="@_lastKnownStateIsExpanded"
-                aria-controls="collapse-@_idEffective">
-            @HeaderTemplate
-        </button>
-    </h2>
-    <HxCollapse @ref="_collapseComponent"
-                Id="@("collapse-" + _idEffective)"
-                Parent="@(!ParentAccordion.StayOpen ? $"#{ParentAccordion.Id}" : null)"
-                CssClass="accordion-collapse"
-                InitiallyExpanded="IsSetToBeExpanded()"
-                OnShown="HandleCollapseShown"
-                OnHidden="HandleCollapseHidden"
-                aria-labelledby="@("header-" + _idEffective)">
-        <div class="@CssClassHelper.Combine("accordion-body", BodyCssClass)">
-            @BodyTemplate
-        </div>
-    </HxCollapse>
-</div>
+<details class="@CssClassHelper.Combine("hx-accordion-item accordion-item", CssClass)"
+         id="@_idEffective"
+         name="@(ParentAccordion.StayOpen ? null : ParentAccordion.Id)"
+         open="@_lastKnownStateIsExpanded">
+	<summary class="@CssClassHelper.Combine("accordion-header", HeaderCssClass)"
+	         id="header-@_idEffective"
+	         @onclick="HandleHeaderClick"
+	         @onclick:preventDefault>
+		@HeaderTemplate
+		<svg class="accordion-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m2 5 6 6 6-6"/></svg>
+	</summary>
+	<div class="@CssClassHelper.Combine("accordion-body", BodyCssClass)">
+		@BodyTemplate
+	</div>
+</details>

--- a/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordionItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Accordions/HxAccordionItem.razor.cs
@@ -23,8 +23,8 @@ public partial class HxAccordionItem : ComponentBase
 	[Parameter] public string Id { get; set; } = Guid.NewGuid().ToString("N");
 
 	/// <summary>
-	/// Raised after the transition to this item (the animation is finished).
-	/// Is not raised for the initial rendering even if the item is not collapsed (no transition happened).
+	/// Raised when the item is expanded.
+	/// Is not raised for the initial rendering even if the item is expanded.
 	/// </summary>
 	[Parameter] public EventCallback<string> OnExpanded { get; set; }
 	/// <summary>
@@ -33,8 +33,8 @@ public partial class HxAccordionItem : ComponentBase
 	protected virtual Task InvokeOnExpandedAsync(string expandedItemId) => OnExpanded.InvokeAsync(expandedItemId);
 
 	/// <summary>
-	/// Raised after the transition from this item (the animation is finished).
-	/// Is not raised for the initial rendering even if the item is collapsed (no transition happened).
+	/// Raised when the item is collapsed.
+	/// Is not raised for the initial rendering even if the item is collapsed.
 	/// </summary>
 	[Parameter] public EventCallback<string> OnCollapsed { get; set; }
 	/// <summary>
@@ -57,11 +57,18 @@ public partial class HxAccordionItem : ComponentBase
 	/// </summary>
 	[Parameter] public string BodyCssClass { get; set; }
 
+	internal bool IsExpanded => _lastKnownStateIsExpanded;
+
 	private string _currentId;
 	private string _idEffective;
 	private bool _lastKnownStateIsExpanded;
 	private bool _isInitialized;
-	private HxCollapse _collapseComponent;
+
+	protected override void OnInitialized()
+	{
+		base.OnInitialized();
+		ParentAccordion?.RegisterItem(this);
+	}
 
 	protected override async Task OnParametersSetAsync()
 	{
@@ -117,35 +124,42 @@ public partial class HxAccordionItem : ComponentBase
 	/// </summary>
 	public async Task ExpandAsync()
 	{
-		await _collapseComponent.ShowAsync();
+		if (_lastKnownStateIsExpanded)
+		{
+			return;
+		}
 		_lastKnownStateIsExpanded = true;
+
+		await ParentAccordion.NotifyItemExpandedAsync(this);
+		await InvokeOnExpandedAsync(Id);
+
+		StateHasChanged();
 	}
 
 	/// <summary>
 	/// Collapses the item.
 	/// </summary>
-	public async Task CollapseAsync()
+	public Task CollapseAsync() => CollapseCoreAsync(invokeExpandedItemIdChanged: true);
+
+	internal async Task CollapseCoreAsync(bool invokeExpandedItemIdChanged)
 	{
-		await _collapseComponent.HideAsync();
-		_lastKnownStateIsExpanded = false;
-	}
-
-	private async Task HandleCollapseShown()
-	{
-		_lastKnownStateIsExpanded = true;
-
-		await ParentAccordion.SetItemExpandedAsync(Id);
-
-		await InvokeOnExpandedAsync(Id);
-	}
-
-	private async Task HandleCollapseHidden()
-	{
+		if (!_lastKnownStateIsExpanded)
+		{
+			return;
+		}
 		_lastKnownStateIsExpanded = false;
 
-		await ParentAccordion.SetItemCollapsedAsync(Id);
-
+		await ParentAccordion.SetItemCollapsedAsync(Id, invokeExpandedItemIdChanged);
 		await InvokeOnCollapsedAsync(Id);
+
+		StateHasChanged();
+	}
+
+	private Task HandleHeaderClick()
+	{
+		// The native <details> toggle is prevented (@onclick:preventDefault on the <summary>) - Blazor state is the source of truth
+		// (a re-render must not revert a browser-toggled open attribute, and exclusivity has to update the bound parameters).
+		return _lastKnownStateIsExpanded ? CollapseAsync() : ExpandAsync();
 	}
 
 	private bool IsSetToBeExpanded() => ParentAccordion.ExpandedItemIds.Contains(Id);

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -6,13 +6,18 @@
     <members>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAccordion">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/accordion/">Bootstrap accordion</see> component.<br />
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/accordion/">Bootstrap accordion</see> component (built on the native <c>&lt;details&gt;</c>/<c>&lt;summary&gt;</c> disclosure elements, no JavaScript needed).<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAccordion">https://havit.blazor.eu/components/HxAccordion</see>
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordion.CssClass">
             <summary>
             Additional CSS classes for the accordion container.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordion.Color">
+            <summary>
+            Theme color of the accordion (renders the <c>theme-*</c> class applied to open items).
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordion.ExpandedItemIds">
@@ -46,6 +51,13 @@
             IDs of the items you want to expand at the very beginning (overwrites <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordion.ExpandedItemIds"/> if set).
             </summary>
         </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAccordion.NotifyItemExpandedAsync(Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem)">
+            <summary>
+            Called by an expanding <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem"/>. For exclusive accordions (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordion.StayOpen"/> is <c>false</c>),
+            collapses all other expanded items first (replicates the native <c>name</c>-attribute exclusivity Blazor-side,
+            as the open state is managed by Blazor).
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem">
             <summary>
             Single item for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAccordion"/>.
@@ -68,8 +80,8 @@
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem.OnExpanded">
             <summary>
-            Raised after the transition to this item (the animation is finished).
-            Is not raised for the initial rendering even if the item is not collapsed (no transition happened).
+            Raised when the item is expanded.
+            Is not raised for the initial rendering even if the item is expanded.
             </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem.InvokeOnExpandedAsync(System.String)">
@@ -79,8 +91,8 @@
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem.OnCollapsed">
             <summary>
-            Raised after the transition from this item (the animation is finished).
-            Is not raised for the initial rendering even if the item is collapsed (no transition happened).
+            Raised when the item is collapsed.
+            Is not raised for the initial rendering even if the item is collapsed.
             </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAccordionItem.InvokeOnCollapsedAsync(System.String)">

--- a/Havit.Blazor.E2ETests/HxAccordionTests/HxAccordionTests.cs
+++ b/Havit.Blazor.E2ETests/HxAccordionTests/HxAccordionTests.cs
@@ -1,4 +1,4 @@
-namespace Havit.Blazor.E2ETests.HxAccordionTests;
+﻿namespace Havit.Blazor.E2ETests.HxAccordionTests;
 
 public class HxAccordionTests : TestAppTestBase
 {
@@ -43,7 +43,7 @@ public class HxAccordionTests : TestAppTestBase
 		// Arrange - Navigate to the HxAccordion test page
 		await NavigateToTestAppAsync("/HxAccordion");
 
-		var header1Toggle = Page.Locator("button.accordion-button:has([data-testid='header-1'])");
+		var header1Toggle = Page.Locator("summary.accordion-header:has([data-testid='header-1'])");
 		var body1 = Page.Locator("[data-testid='body-1']");
 		var expandedItemId = Page.Locator("[data-testid='expanded-item-id']");
 


### PR DESCRIPTION
Fixes #1441

Bootstrap 6 rebuilds the **Accordion** on the native `<details>`/`<summary>` disclosure widget — no Collapse plugin, no JavaScript for open/close.

## Rendering
- `HxAccordionItem` now renders `<details class="accordion-item">` → `<summary class="accordion-header">` (with the v6 `accordion-icon` SVG) → `div.accordion-body`. The v5 `accordion-button`/`accordion-collapse` classes and the `HxCollapse`/Collapse-JS dependency are gone.
- New **`Color`** parameter on `HxAccordion` → `theme-*` class (v6 accordion variants).

## State management
- The `open` state is **Blazor-managed**: the native toggle is prevented (`@onclick:preventDefault` on the summary) so that re-renders can't revert browser-toggled state and the two-way `ExpandedItemId(s)` binding stays the single source of truth.
- Exclusivity for non-`StayOpen` accordions is replicated Blazor-side via item registration with the parent (deterministic event order: others collapse first, then the new item's `ExpandedItemIdChanged` fires). The shared `name` attribute is still rendered for semantic fidelity.
- **Public API is unchanged**: `ExpandedItemId`/`ExpandedItemIds` two-way binding, `StayOpen`, `InitialExpandedItemId(s)`, `ExpandAsync`/`CollapseAsync`, `OnExpanded`/`OnCollapsed`. One behavioral note: the events now fire on state change rather than after the CSS transition (there's no JS to await transitions; v6 animates via CSS).

## Verification
Library builds with `-warnaserror`; all apps build clean. **466/466** unit tests — the accordion suite was rewritten for native semantics and now covers click-to-expand, exclusive-mode collapse, `StayOpen`, initial expansion, the shared `name` attribute, and theme color. **352/352** documentation tests pass (the docs demos use the unchanged component API, so they work as-is). E2E selector updated (`summary.accordion-header`).

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_