### PR TITLE
Bootstrap 6 checks/radios/switches markup + .form-select removal

### DIFF
--- a/BlazorAppTest/Pages/InputsWithoutEditContextTest.razor
+++ b/BlazorAppTest/Pages/InputsWithoutEditContextTest.razor
@@ -13,7 +13,7 @@
 <HxInputDateRange Label="DateRange" @bind-Value="@dateRangeValue" FromParsingErrorMessage="Enter correct date from." ToParsingErrorMessage="Enter correct date to." />
 
 <HxCheckbox Text="Checkbox" @bind-Value="@boolValue" />
-<HxCheckbox Text="Checkbox" CssClass="form-switch" @bind-Value="@boolValue" />
+<HxSwitch Text="Switch" @bind-Value="@boolValue" />
 
 <HxSubmit Icon="@BootstrapIcon.Check" Color="ThemeColor.Primary">Submit</HxSubmit>
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxCheckboxTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxCheckboxTests.cs
@@ -100,7 +100,7 @@ public class HxCheckboxTests : BunitTestBase
 		var cut = Render(componentRenderer);
 
 		// Assert
-		var label = cut.Find("label.form-check-label");
+		var label = cut.Find("div.form-field > label");
 		Assert.Equal(labelText, label.TextContent);
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxRadioButtonListTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxRadioButtonListTests.cs
@@ -1,4 +1,4 @@
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -111,20 +111,14 @@ public class HxRadioButtonListTests : BunitTestBase
 
 		var cut = Render(componentRenderer);
 
-		// Assert — inputs should have btn-check class instead of form-check-input
-		var inputs = cut.FindAll("input[type='radio']");
-		Assert.Equal(2, inputs.Count());
-		foreach (var input in inputs)
-		{
-			Assert.True(input.ClassList.Contains("btn-check"), "Radio input should have btn-check class in toggle button mode.");
-		}
-
-		// Assert — labels should have btn class with color
-		var labels = cut.FindAll("label");
+		// Assert — Bootstrap 6: btn-check moves to the label with the nested (unstyled) input, styled via :has()
+		var labels = cut.FindAll("label.btn-check");
 		Assert.Equal(2, labels.Count());
 		foreach (var label in labels)
 		{
-			Assert.True(label.ClassList.Contains("btn"), "Label should have btn class in toggle button mode.");
+			Assert.True(label.ClassList.Contains("btn-solid"), "Toggle button label should carry the button variant class.");
+			Assert.True(label.ClassList.Contains("theme-primary"), "Toggle button label should carry the theme color class.");
+			Assert.NotNull(label.QuerySelector("input[type='radio']"));
 		}
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor
@@ -17,13 +17,13 @@
 					  OnClick="HandlePreviousMonthClickAsync"
 					  tabindex="@tabindexValue" />
 			<div class="hx-calendar-month-year-select">
-				<select class="form-select form-select-sm" aria-label="Month" tabindex="@tabindexValue" value="@(DisplayMonth.Month - 1)" @onchange="HandleMonthChangeAsync" @onclick:stopPropagation>
+				<select class="form-control form-control-sm" aria-label="Month" tabindex="@tabindexValue" value="@(DisplayMonth.Month - 1)" @onchange="HandleMonthChangeAsync" @onclick:stopPropagation>
 					@foreach (var month in _renderData.Months)
 					{
 						<option @key="@month.Index" value="@month.Index" disabled="@(!month.Enabled)">@month.Name</option>
 					}
 				</select>
-				<select class="form-select form-select-sm" aria-label="Year" tabindex="@tabindexValue" value="@DisplayMonth.Year" @onchange="HandleYearChangeAsync" @onclick:stopPropagation>
+				<select class="form-control form-control-sm" aria-label="Year" tabindex="@tabindexValue" value="@DisplayMonth.Year" @onchange="HandleYearChangeAsync" @onclick:stopPropagation>
 					@foreach (int year in _renderData.Years)
 					{
 						/* not "N" - we do not want thousands separator */

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxBase.cs
@@ -60,10 +60,12 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 	/// <inheritdoc cref="HxInputBase{TValue}.CoreInputCssClass" />
 	private protected override string CoreInputCssClass => RenderModeEffective switch
 	{
-		CheckboxRenderMode.Checkbox => "form-check-input",
-		CheckboxRenderMode.Switch => "form-check-input",
-		CheckboxRenderMode.NativeSwitch => "form-check-input",
-		CheckboxRenderMode.ToggleButton => "btn-check",
+		// Bootstrap 6: all checkbox styling is applied with the .check class directly on the input (themed via theme-*);
+		// switch inputs are unstyled (the .switch wrapper carries the styling); toggle-button inputs are nested in label.btn-check.
+		CheckboxRenderMode.Checkbox => CssClassHelper.Combine("check", (ColorEffective != ThemeColor.None) ? ColorEffective.ToThemeCss() : null),
+		CheckboxRenderMode.Switch => null,
+		CheckboxRenderMode.NativeSwitch => null,
+		CheckboxRenderMode.ToggleButton => null,
 		_ => throw new InvalidOperationException($"Unknown {nameof(CheckboxRenderMode)}: {RenderModeEffective}.")
 	};
 
@@ -80,40 +82,31 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 
 			return CssClassHelper.Combine(
 				base.CoreCssClass,
-				NeedsInnerDiv ? null : AdditionalFormElementCssClass,
-				NeedsFormCheckOuter ? CssClassHelper.Combine("form-check", Inline ? "form-check-inline" : null) : null,
-				Reverse ? "form-check-reverse" : null);
+				NeedsFormFieldOuter ? GetFormFieldCssClass() : null);
 		}
 	}
 
-	private string AdditionalFormElementCssClass => RenderModeEffective switch
-	{
-		CheckboxRenderMode.Checkbox => null,
-		CheckboxRenderMode.Switch => "form-switch",
-		CheckboxRenderMode.NativeSwitch => "form-switch",
-		CheckboxRenderMode.ToggleButton => null,
-		_ => throw new InvalidOperationException($"Unknown {nameof(CheckboxRenderMode)}: {RenderModeEffective}.")
-	};
+	private string GetFormFieldCssClass() => CssClassHelper.Combine(
+		"form-field",
+		Inline ? "hx-form-field-inline" : null,
+		Reverse ? "hx-form-field-reverse" : null);
 
 	/// <summary>
-	/// For a naked checkbox without Label/LabelTemplate, we add form-check, form-check-inline to the parent div (allows combining with CssClass etc.).
-	/// It is expected that there is just the parent div, input, and label for Text/TextTemplate.
-	/// No label for Label/LabelTemplate, no HintTemplate, no validation message is expected.
-	/// For a checkbox with Label, there is a parent div followed by a label for Label/LabelTemplate.
-	/// Siblings label, input, label do not work well and there is nowhere to add form-check.
-	/// Therefore, we wrap the input and label in the additional div.
+	/// For a checkbox without Label/LabelTemplate, the form-field layout class goes to the parent div (allows combining with CssClass etc.).
+	/// For a checkbox with Label, there is a parent div followed by a label for Label/LabelTemplate,
+	/// so the input and text-label are wrapped in an additional div.form-field.
 	/// </summary>
 	private protected bool NeedsInnerDiv => !string.IsNullOrWhiteSpace(Label) || (LabelTemplate is not null);
 
 	/// <summary>
-	/// For checkbox without any Text/TextTemplate we do not add form-check class.
+	/// For a checkbox without any Text/TextTemplate, the form-field layout wrapper is not needed.
 	/// </summary>
-	private protected bool NeedsFormCheck => (!string.IsNullOrWhiteSpace(Text) || (TextTemplate is not null)) && (RenderModeEffective != CheckboxRenderMode.ToggleButton);
+	private protected bool NeedsFormField => (!string.IsNullOrWhiteSpace(Text) || (TextTemplate is not null)) && (RenderModeEffective != CheckboxRenderMode.ToggleButton);
 
 	/// <summary>
-	/// For checkbox without any Label/LabelTemplate and without Text/TextTemplate we do not add form-check to the parent div.
+	/// For a checkbox without any Label/LabelTemplate and without Text/TextTemplate, no form-field class goes to the parent div.
 	/// </summary>
-	private protected bool NeedsFormCheckOuter => !NeedsInnerDiv && NeedsFormCheck;
+	private protected bool NeedsFormFieldOuter => !NeedsInnerDiv && NeedsFormField;
 
 	/// <summary>
 	/// The input ElementReference.
@@ -124,13 +117,27 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 	/// <inheritdoc />
 	protected override void BuildRenderInput(RenderTreeBuilder builder)
 	{
+		if (RenderModeEffective == CheckboxRenderMode.ToggleButton)
+		{
+			BuildRenderInput_ToggleButton(builder);
+			return;
+		}
+
 		if (NeedsInnerDiv)
 		{
 			builder.OpenElement(-2, "div");
-			builder.AddAttribute(-1, "class", CssClassHelper.Combine(NeedsFormCheck ? "form-check" : null, AdditionalFormElementCssClass));
+			builder.AddAttribute(-1, "class", GetFormFieldCssClass());
 		}
 
 		EnsureInputId(); // must be called before the input is rendered
+
+		bool isSwitch = (RenderModeEffective == CheckboxRenderMode.Switch) || (RenderModeEffective == CheckboxRenderMode.NativeSwitch);
+		if (isSwitch)
+		{
+			// Bootstrap 6 switch: an unstyled checkbox layered over the styled .switch wrapper element
+			builder.OpenElement(-100, "div");
+			builder.AddAttribute(-99, "class", CssClassHelper.Combine("switch", (ColorEffective != ThemeColor.None) ? ColorEffective.ToThemeCss() : null));
+		}
 
 		builder.OpenElement(0, "input");
 		BuildRenderInput_AddCommonAttributes(builder, "checkbox");
@@ -144,7 +151,7 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 		builder.AddAttribute(1002, "onchange", value: EventCallback.Factory.CreateBinder<bool>(this, value => CurrentValue = value, CurrentValue));
 		builder.SetUpdatesAttributeName("checked");
 
-		if ((RenderModeEffective == CheckboxRenderMode.Switch) || (RenderModeEffective == CheckboxRenderMode.NativeSwitch))
+		if (isSwitch)
 		{
 			builder.AddAttribute(1003, "role", "switch");
 		}
@@ -152,33 +159,70 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 		{
 			builder.AddAttribute(1004, "switch", true); // does not render ="true", we need only "switch" attribute to be present
 		}
-		if (RenderModeEffective == CheckboxRenderMode.ToggleButton)
-		{
-			builder.AddAttribute(1005, "autocomplete", "off");
-		}
 
 		builder.AddEventStopPropagationAttribute(1006, "onclick", true);
 		builder.AddElementReferenceCapture(1007, elementReference => InputElement = elementReference);
 		builder.CloseElement(); // input
 
-		builder.OpenElement(2000, "label");
-		builder.AddAttribute(2001, "class", CssClassHelper.Combine(
-			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? "btn" : "form-check-label",
-			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective) : null,
-			(RenderModeEffective == CheckboxRenderMode.ToggleButton) ? ButtonSizeEffective.ToButtonSizeCssClass() : null,
+		if (isSwitch)
+		{
+			builder.CloseElement(); // div.switch
+		}
+
+		if (!String.IsNullOrWhiteSpace(Text) || (TextTemplate is not null))
+		{
+			builder.OpenElement(2000, "label");
+			if (TextCssClass is not null)
+			{
+				builder.AddAttribute(2001, "class", TextCssClass);
+			}
+			builder.AddAttribute(2002, "for", InputId);
+			if (TextTemplate == null)
+			{
+				builder.AddContent(2003, Text);
+			}
+			builder.AddContent(2004, TextTemplate);
+			builder.CloseElement(); // label
+		}
+
+		if (NeedsInnerDiv)
+		{
+			builder.CloseElement(); // div
+		}
+	}
+
+	/// <summary>
+	/// Bootstrap 6 toggle button: the <c>btn-check</c> class moves to the <c>label</c> with a nested unstyled input
+	/// (no <c>id</c>/<c>for</c> pairing, the styling uses <c>:has()</c>).
+	/// </summary>
+	private void BuildRenderInput_ToggleButton(RenderTreeBuilder builder)
+	{
+		EnsureInputId(); // must be called before the input is rendered
+
+		builder.OpenElement(0, "label");
+		builder.AddAttribute(1, "class", CssClassHelper.Combine(
+			"btn-check",
+			VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective),
+			ButtonSizeEffective.ToButtonSizeCssClass(),
 			TextCssClass));
-		builder.AddAttribute(2002, "for", InputId);
+
+		builder.OpenElement(100, "input");
+		BuildRenderInput_AddCommonAttributes(builder, "checkbox");
+		builder.AddAttribute(1000, "checked", BindConverter.FormatValue(CurrentValue));
+		builder.AddAttribute(1001, "value", bool.TrueString);
+		builder.AddAttribute(1002, "onchange", value: EventCallback.Factory.CreateBinder<bool>(this, value => CurrentValue = value, CurrentValue));
+		builder.SetUpdatesAttributeName("checked");
+		builder.AddAttribute(1005, "autocomplete", "off");
+		builder.AddEventStopPropagationAttribute(1006, "onclick", true);
+		builder.AddElementReferenceCapture(1007, elementReference => InputElement = elementReference);
+		builder.CloseElement(); // input
+
 		if (TextTemplate == null)
 		{
 			builder.AddContent(2003, Text);
 		}
 		builder.AddContent(2004, TextTemplate);
 		builder.CloseElement(); // label
-
-		if (NeedsInnerDiv)
-		{
-			builder.CloseElement(); // div
-		}
 	}
 
 	/// <inheritdoc />

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
@@ -38,7 +38,7 @@ public class HxMultiSelect<TValue, TItem> : HxInputBase<List<TValue>>, IInputWit
 	InputSize IInputWithSize.InputSizeEffective => InputSizeEffective;
 	string IInputWithSize.GetInputSizeCssClass() => InputSizeEffective.AsFormSelectCssClass();
 
-	private protected override string CoreInputCssClass => "hx-multi-select-input form-select user-select-none";
+	private protected override string CoreInputCssClass => "hx-multi-select-input form-control user-select-none";
 
 	/// <summary>
 	/// Items to display. 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonListBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonListBase.cs
@@ -206,55 +206,84 @@ public abstract class HxRadioButtonListBase<TValue, TItem> : HxInputBase<TValue>
 
 			bool isToggleButton = (RenderMode == RadioButtonListRenderMode.ToggleButtons) || (RenderMode == RadioButtonListRenderMode.ButtonGroup);
 
-			if (!isToggleButton)
-			{
-				builder.OpenElement(100, "div");
-
-				// TODO CoreCssClass
-				builder.AddAttribute(101, "class", CssClassHelper.Combine("form-check", Inline ? "form-check-inline" : null, ItemCssClassImpl, ItemCssClassSelectorImpl?.Invoke(item)));
-			}
-
-			builder.OpenElement(200, "input");
-			builder.AddAttribute(201, "class", CssClassHelper.Combine(
-				isToggleButton ? "btn-check" : "form-check-input",
-				(RenderMode == RadioButtonListRenderMode.ButtonGroup) ? ItemInputCssClassSelectorImpl?.Invoke(item) : CssClassHelper.Combine(ItemInputCssClassImpl, ItemInputCssClassSelectorImpl?.Invoke(item))));
-			builder.AddAttribute(202, "type", "radio");
-			builder.AddAttribute(203, "name", GroupName);
-			builder.AddAttribute(204, "id", inputId);
-			builder.AddAttribute(205, "value", index.ToString());
-			builder.AddAttribute(206, "checked", selected);
-			builder.AddAttribute(207, "disabled", !CascadeEnabledComponent.EnabledEffective(this));
-			int j = index;
-			builder.AddAttribute(208, "onclick", EventCallback.Factory.Create(this, () => HandleInputClick(j)));
-			builder.SetUpdatesAttributeName("checked");
-			builder.AddEventStopPropagationAttribute(209, "onclick", true);
 			if (isToggleButton)
 			{
-				builder.AddAttribute(210, "autocomplete", "off");
-			}
-			builder.AddMultipleAttributes(250, AdditionalAttributes);
-			builder.CloseElement(); // input
+				// Bootstrap 6 toggle button: btn-check moves to the label with a nested unstyled input (no id/for pairing, uses :has())
+				builder.OpenElement(100, "label");
+				builder.AddAttribute(101, "class", CssClassHelper.Combine(
+					"btn-check",
+					VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective),
+					ButtonSizeEffective.ToButtonSizeCssClass(),
+					ItemTextCssClassImpl,
+					ItemTextCssClassSelectorImpl?.Invoke(item)));
 
-			builder.OpenElement(300, "label");
-			builder.AddAttribute(301, "class", CssClassHelper.Combine(
-				isToggleButton ? "btn" : "form-check-label",
-				isToggleButton ? VariantEffective.ToButtonVariantAndColorCssClass(ColorEffective) : null,
-				isToggleButton ? ButtonSizeEffective.ToButtonSizeCssClass() : null,
-				ItemTextCssClassImpl,
-				ItemTextCssClassSelectorImpl?.Invoke(item)));
-			builder.AddAttribute(302, "for", inputId);
-			if (ItemTemplateImpl != null)
-			{
-				builder.AddContent(303, ItemTemplateImpl(item));
+				builder.OpenElement(200, "input");
+				builder.AddAttribute(201, "class", (RenderMode == RadioButtonListRenderMode.ButtonGroup) ? ItemInputCssClassSelectorImpl?.Invoke(item) : CssClassHelper.Combine(ItemInputCssClassImpl, ItemInputCssClassSelectorImpl?.Invoke(item)));
+				builder.AddAttribute(202, "type", "radio");
+				builder.AddAttribute(203, "name", GroupName);
+				builder.AddAttribute(204, "id", inputId);
+				builder.AddAttribute(205, "value", index.ToString());
+				builder.AddAttribute(206, "checked", selected);
+				builder.AddAttribute(207, "disabled", !CascadeEnabledComponent.EnabledEffective(this));
+				int j = index;
+				builder.AddAttribute(208, "onclick", EventCallback.Factory.Create(this, () => HandleInputClick(j)));
+				builder.SetUpdatesAttributeName("checked");
+				builder.AddEventStopPropagationAttribute(209, "onclick", true);
+				builder.AddAttribute(210, "autocomplete", "off");
+				builder.AddMultipleAttributes(250, AdditionalAttributes);
+				builder.CloseElement(); // input
+
+				if (ItemTemplateImpl != null)
+				{
+					builder.AddContent(303, ItemTemplateImpl(item));
+				}
+				else
+				{
+					builder.AddContent(304, SelectorHelpers.GetText(ItemTextSelectorImpl, item));
+				}
+				builder.CloseElement(); // label
 			}
 			else
 			{
-				builder.AddContent(304, SelectorHelpers.GetText(ItemTextSelectorImpl, item));
-			}
-			builder.CloseElement(); // label
+				builder.OpenElement(100, "div");
+				builder.AddAttribute(101, "class", CssClassHelper.Combine("form-field", Inline ? "hx-form-field-inline" : null, ItemCssClassImpl, ItemCssClassSelectorImpl?.Invoke(item)));
 
-			if (!isToggleButton)
-			{
+				builder.OpenElement(200, "input");
+				builder.AddAttribute(201, "class", CssClassHelper.Combine(
+					"radio",
+					(ColorEffective != ThemeColor.None) ? ColorEffective.ToThemeCss() : null,
+					ItemInputCssClassImpl,
+					ItemInputCssClassSelectorImpl?.Invoke(item)));
+				builder.AddAttribute(202, "type", "radio");
+				builder.AddAttribute(203, "name", GroupName);
+				builder.AddAttribute(204, "id", inputId);
+				builder.AddAttribute(205, "value", index.ToString());
+				builder.AddAttribute(206, "checked", selected);
+				builder.AddAttribute(207, "disabled", !CascadeEnabledComponent.EnabledEffective(this));
+				int j = index;
+				builder.AddAttribute(208, "onclick", EventCallback.Factory.Create(this, () => HandleInputClick(j)));
+				builder.SetUpdatesAttributeName("checked");
+				builder.AddEventStopPropagationAttribute(209, "onclick", true);
+				builder.AddMultipleAttributes(250, AdditionalAttributes);
+				builder.CloseElement(); // input
+
+				builder.OpenElement(300, "label");
+				string labelCssClass = CssClassHelper.Combine(ItemTextCssClassImpl, ItemTextCssClassSelectorImpl?.Invoke(item));
+				if (!String.IsNullOrEmpty(labelCssClass))
+				{
+					builder.AddAttribute(301, "class", labelCssClass);
+				}
+				builder.AddAttribute(302, "for", inputId);
+				if (ItemTemplateImpl != null)
+				{
+					builder.AddContent(303, ItemTemplateImpl(item));
+				}
+				else
+				{
+					builder.AddContent(304, SelectorHelpers.GetText(ItemTextSelectorImpl, item));
+				}
+				builder.CloseElement(); // label
+
 				builder.CloseElement(); // div
 			}
 		}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelectBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelectBase.cs
@@ -143,7 +143,7 @@ public abstract class HxSelectBase<TValue, TItem> : HxInputBaseWithInputGroups<T
 	/// </summary>
 	protected ElementReference InputElement { get; set; }
 
-	private protected override string CoreInputCssClass => "form-select";
+	private protected override string CoreInputCssClass => "form-control";
 
 	private IEqualityComparer<TValue> _comparer = EqualityComparer<TValue>.Default;
 	private List<TItem> _itemsToRender;

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSwitch.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSwitch.cs
@@ -45,7 +45,11 @@ public class HxSwitch : HxCheckboxBase
 
 	protected override CheckboxRenderMode RenderModeEffective => NativeEffective ? CheckboxRenderMode.NativeSwitch : CheckboxRenderMode.Switch;
 
-	protected override ThemeColor ColorEffective => throw new NotSupportedException();
+	/// <summary>
+	/// Theme color of the switch (renders the <c>theme-*</c> class on the <c>.switch</c> wrapper, new in Bootstrap 6).
+	/// </summary>
+	[Parameter] public ThemeColor? Color { get; set; }
+	protected override ThemeColor ColorEffective => Color ?? GetSettings()?.Color ?? GetDefaults().Color ?? ThemeColor.None;
 
 	protected override ButtonVariant VariantEffective => throw new NotSupportedException();
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/InputSizeExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/InputSizeExtensions.cs
@@ -31,15 +31,15 @@ public static class InputSizeExtensions
 	}
 
 	/// <summary>
-	/// Returns CSS class to render select (form-select) with the desired size.
+	/// Returns CSS class to render select with the desired size (Bootstrap 6 consolidated .form-select into .form-control).
 	/// </summary>
 	public static string AsFormSelectCssClass(this InputSize inputSize)
 	{
 		return inputSize switch
 		{
 			InputSize.Regular => null,
-			InputSize.Small => "form-select-sm",
-			InputSize.Large => "form-select-lg",
+			InputSize.Small => "form-control-sm",
+			InputSize.Large => "form-control-lg",
 			_ => throw new InvalidOperationException($"Unknown {nameof(InputSize)} value {inputSize}.")
 		};
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
@@ -91,9 +91,9 @@
 					{
 						<li>
 							<button type="button" class="menu-item" @onclick="HandleSelectAllClickedAsync">
-								<div class="form-check">
-									<input class="form-check-input" type="checkbox" id="@($"{InputId}_selectall")" checked="@_selectAllChecked" tabindex="-1" />
-									<label class="form-check-label" for="@($"{InputId}_selectall")" @onclick:preventDefault>
+								<div class="form-field">
+									<input class="check" type="checkbox" id="@($"{InputId}_selectall")" checked="@_selectAllChecked" tabindex="-1" />
+									<label for="@($"{InputId}_selectall")" @onclick:preventDefault>
 										@(GetSelectAllText())
 									</label>
 								</div>
@@ -112,9 +112,9 @@
 
 						<li>
 							<button type="button" class="menu-item" @onclick="async () => await HandleItemSelectionChangedAsync(!itemSelected, item)">
-								<div class="form-check">
-									<input class="form-check-input" type="checkbox" id="@checkboxElementId" checked="@itemSelected" tabindex="-1" />
-									<label class="form-check-label" for="@checkboxElementId" @onclick:preventDefault>
+								<div class="form-field">
+									<input class="check" type="checkbox" id="@checkboxElementId" checked="@itemSelected" tabindex="-1" />
+									<label for="@checkboxElementId" @onclick:preventDefault>
 										@SelectorHelpers.GetText(TextSelector, item)
 									</label>
 								</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/SwitchSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/SwitchSettings.cs
@@ -9,4 +9,9 @@ public record SwitchSettings : InputSettings
 	/// To render switch as a native switch.
 	/// </summary>
 	public bool? Native { get; set; }
+
+	/// <summary>
+	/// Theme color of the switch (renders the <c>theme-*</c> class on the <c>.switch</c> wrapper).
+	/// </summary>
+	public ThemeColor? Color { get; set; }
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/Internal/HxMultiSelectGridColumnInternal.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/Internal/HxMultiSelectGridColumnInternal.cs
@@ -35,7 +35,7 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 
 					builder.OpenElement(103, "input");
 					builder.AddAttribute(104, "type", "checkbox");
-					builder.AddAttribute(105, "class", "form-check-input");
+					builder.AddAttribute(105, "class", "check");
 
 					builder.AddAttribute(106, "checked", AllDataItemsSelected);
 					builder.AddAttribute(107, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleSelectAllOrNoneClick));
@@ -76,7 +76,7 @@ public class HxMultiSelectGridColumnInternal<TItem> : HxGridColumnBase<TItem>
 
 				builder.OpenElement(103, "input");
 				builder.AddAttribute(104, "type", "checkbox");
-				builder.AddAttribute(105, "class", "form-check-input");
+				builder.AddAttribute(105, "class", "check");
 
 				bool selected = SelectedDataItems?.Contains(item) ?? false;
 				builder.AddAttribute(106, "checked", selected);

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
@@ -225,3 +225,24 @@ form > .hx-button {
 .hx-tab-panel .nav-link {
 	cursor: pointer;
 }
+
+/* HxCheckbox/HxSwitch/HxRadioButtonList layout modifiers
+   (Bootstrap 6 has no equivalents of the former form-check-inline/form-check-reverse) */
+.form-field.hx-form-field-inline {
+	display: inline-grid;
+	margin-right: 1rem;
+}
+
+.form-field.hx-form-field-reverse:has(> .check, > .radio, > .switch) {
+	grid-template-columns: 1fr auto;
+}
+
+.form-field.hx-form-field-reverse > .check,
+.form-field.hx-form-field-reverse > .radio,
+.form-field.hx-form-field-reverse > .switch {
+	grid-column: 2;
+}
+
+.form-field.hx-form-field-reverse > :not(.check, .radio, .switch) {
+	grid-column: 1;
+}

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -4624,22 +4624,19 @@
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.NeedsInnerDiv">
             <summary>
-            For a naked checkbox without Label/LabelTemplate, we add form-check, form-check-inline to the parent div (allows combining with CssClass etc.).
-            It is expected that there is just the parent div, input, and label for Text/TextTemplate.
-            No label for Label/LabelTemplate, no HintTemplate, no validation message is expected.
-            For a checkbox with Label, there is a parent div followed by a label for Label/LabelTemplate.
-            Siblings label, input, label do not work well and there is nowhere to add form-check.
-            Therefore, we wrap the input and label in the additional div.
+            For a checkbox without Label/LabelTemplate, the form-field layout class goes to the parent div (allows combining with CssClass etc.).
+            For a checkbox with Label, there is a parent div followed by a label for Label/LabelTemplate,
+            so the input and text-label are wrapped in an additional div.form-field.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.NeedsFormCheck">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.NeedsFormField">
             <summary>
-            For checkbox without any Text/TextTemplate we do not add form-check class.
+            For a checkbox without any Text/TextTemplate, the form-field layout wrapper is not needed.
             </summary>
         </member>
-        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.NeedsFormCheckOuter">
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.NeedsFormFieldOuter">
             <summary>
-            For checkbox without any Label/LabelTemplate and without Text/TextTemplate we do not add form-check to the parent div.
+            For a checkbox without any Label/LabelTemplate and without Text/TextTemplate, no form-field class goes to the parent div.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.InputElement">
@@ -4650,6 +4647,12 @@
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.BuildRenderInput(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
             <inheritdoc />
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.BuildRenderInput_ToggleButton(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
+            <summary>
+            Bootstrap 6 toggle button: the <c>btn-check</c> class moves to the <c>label</c> with a nested unstyled input
+            (no <c>id</c>/<c>for</c> pairing, the styling uses <c>:has()</c>).
+            </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxCheckboxBase.TryParseValueFromString(System.String,System.Boolean@,System.String@)">
             <inheritdoc />
@@ -6434,6 +6437,11 @@
             To render switch as a native switch.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSwitch.Color">
+            <summary>
+            Theme color of the switch (renders the <c>theme-*</c> class on the <c>.switch</c> wrapper, new in Bootstrap 6).
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxValidationMessage`1">
             <summary>
             Displays a list of validation messages for a specified field within a cascaded <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxValidationMessage`1.EditContext"/>.<br />
@@ -6770,7 +6778,7 @@
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.InputSizeExtensions.AsFormSelectCssClass(Havit.Blazor.Components.Web.Bootstrap.InputSize)">
             <summary>
-            Returns CSS class to render select (form-select) with the desired size.
+            Returns CSS class to render select with the desired size (Bootstrap 6 consolidated .form-select into .form-control).
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.InputTextSettings">
@@ -7555,6 +7563,11 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.SwitchSettings.Native">
             <summary>
             To render switch as a native switch.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SwitchSettings.Color">
+            <summary>
+            Theme color of the switch (renders the <c>theme-*</c> class on the <c>.switch</c> wrapper).
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.ValidationMessageMode">


### PR DESCRIPTION
Fixes #1453, fixes #1454

First forms-track batch.

## Checks, radios, switches (#1453)
- **`HxCheckbox`**: the input renders `class="check"` (+ `theme-*` via the existing `Color` parameter — v6 themed checks) with **no `form-check` wrapper**; the text label is a plain `<label>`; the v6 **`.form-field`** grid wrapper replaces `form-check` for the side-by-side layout.
- **`Inline`/`Reverse`** keep working via two small library CSS rules (`hx-form-field-inline`, `hx-form-field-reverse` in `defaults.lib.css`) — Bootstrap 6 has no `form-check-inline`/`form-check-reverse` equivalents.
- **`HxSwitch`**: the unstyled checkbox is nested in the styled `div.switch` wrapper; new **`Color`** parameter themes it (`theme-*` on the wrapper); `role="switch"` always, the `switch` haptics attribute with `Native="true"`.
- **Toggle buttons** (HxCheckbox/HxCheckboxList/HxRadioButtonList): `btn-check` moves to the `<label>` with the nested unstyled input — no `id`/`for` pairing, styling via `:has()`, label carries the `btn-{variant} theme-{color}` composition from #1442.
- **`HxRadioButtonList`**: items render `input.radio` inside `.form-field` wrappers.
- `HxMultiSelect` dropdown items and the `HxGrid` multiselect column updated to `input.check`.

## `.form-select` removal (#1454)
- `HxSelect`/`HxSelectBase` and `HxMultiSelect` render `form-control` (v6 consolidated `.form-select` into `.form-control`); sizes map to `form-control-sm/-lg`; `HxCalendar`'s month/year selects updated.

## Notes
- The broader `.form-field` adoption for text inputs (label/help/validation layout) is #1455 and intentionally not part of this PR; check/radio/switch usage of `.form-field` here matches the dedicated v6 docs pages for those controls.
- Per the earlier decision, `form-ghost` applies to the composite inputs and is tracked in #1458/#1463.

## Verification
Library builds with `-warnaserror`; all apps build clean. **466/466** unit tests (check/radio/switch suites updated to v6 markup expectations) and **352/352** documentation tests pass locally (net10.0; CI covers net8/net9).

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_