### PR TITLE
Checks/radios/switches: Inline/Reverse via Bootstrap utilities

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxCheckboxBase.cs
@@ -86,10 +86,13 @@ public abstract class HxCheckboxBase : HxInputBase<bool>
 		}
 	}
 
+	// Bootstrap 6 has no form-check-inline/form-check-reverse equivalents; both are expressed with plain utilities:
+	// Inline keeps the form-field grid, just displayed inline (d-inline-grid) with the v5-like spacing (me-3);
+	// Reverse switches the form-field to a reversed flex row (control packs to the end, label adjacent), matching the v5 visual.
 	private string GetFormFieldCssClass() => CssClassHelper.Combine(
 		"form-field",
-		Inline ? "hx-form-field-inline" : null,
-		Reverse ? "hx-form-field-reverse" : null);
+		Inline ? "d-inline-grid me-3" : null,
+		Reverse ? "d-flex flex-row-reverse gap-2" : null);
 
 	/// <summary>
 	/// For a checkbox without Label/LabelTemplate, the form-field layout class goes to the parent div (allows combining with CssClass etc.).

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonListBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxRadioButtonListBase.cs
@@ -246,7 +246,7 @@ public abstract class HxRadioButtonListBase<TValue, TItem> : HxInputBase<TValue>
 			else
 			{
 				builder.OpenElement(100, "div");
-				builder.AddAttribute(101, "class", CssClassHelper.Combine("form-field", Inline ? "hx-form-field-inline" : null, ItemCssClassImpl, ItemCssClassSelectorImpl?.Invoke(item)));
+				builder.AddAttribute(101, "class", CssClassHelper.Combine("form-field", Inline ? "d-inline-grid me-3" : null, ItemCssClassImpl, ItemCssClassSelectorImpl?.Invoke(item)));
 
 				builder.OpenElement(200, "input");
 				builder.AddAttribute(201, "class", CssClassHelper.Combine(

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
@@ -226,23 +226,3 @@ form > .hx-button {
 	cursor: pointer;
 }
 
-/* HxCheckbox/HxSwitch/HxRadioButtonList layout modifiers
-   (Bootstrap 6 has no equivalents of the former form-check-inline/form-check-reverse) */
-.form-field.hx-form-field-inline {
-	display: inline-grid;
-	margin-right: 1rem;
-}
-
-.form-field.hx-form-field-reverse:has(> .check, > .radio, > .switch) {
-	grid-template-columns: 1fr auto;
-}
-
-.form-field.hx-form-field-reverse > .check,
-.form-field.hx-form-field-reverse > .radio,
-.form-field.hx-form-field-reverse > .switch {
-	grid-column: 2;
-}
-
-.form-field.hx-form-field-reverse > :not(.check, .radio, .switch) {
-	grid-column: 1;
-}


### PR DESCRIPTION
Follow-up to #1484 (per review feedback): the `Inline`/`Reverse` modifiers for checks/radios/switches are now expressed with **plain Bootstrap utilities** instead of the custom `hx-form-field-*` classes:

- **`Inline`** → `d-inline-grid me-3` — keeps the `.form-field` grid behavior, just displayed inline with v5-like spacing.
- **`Reverse`** → `d-flex flex-row-reverse gap-2` — the reversed flex row packs the control to the end with the label adjacent, matching the v5 `form-check-reverse` visual.

The custom rules are removed from `defaults.lib.css`. Besides being less code to maintain, this fixes the modifiers for consumers who don't load the Havit defaults stylesheet (PlainBootstrap flavor) — utilities always ship in `bootstrap.css`.

Verified: library builds with `-warnaserror`, 466/466 unit tests pass.

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_