### PR TITLE
HxInputBase: Bootstrap 6 form-field layout + validation/input-group adoption

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInputInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInputInternal.razor.css
@@ -1,8 +1,3 @@
 ﻿.hx-autosuggest-input {
     position: relative;
 }
-
-.form-control.is-invalid {
-    background-position: center right 2.5rem;
-    padding-right: 4.125rem;
-}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBase.cs
@@ -108,7 +108,7 @@ public abstract class HxInputBase<TValue> : InputBase<TValue>, ICascadeEnabledCo
 	/// <summary>
 	/// The CSS class to be rendered with the wrapping div.
 	/// </summary>
-	private protected virtual string CoreCssClass => "hx-form-group position-relative";
+	private protected virtual string CoreCssClass => "hx-form-group form-field position-relative";
 
 	/// <summary>
 	/// The CSS class to be rendered with the input element.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateInternal.razor.css
@@ -28,10 +28,6 @@
     margin-left: auto;
 }
 
-.hx-input-date-has-calendar-icon ::deep .is-invalid {
-	background-position: right calc(0.375em + 2rem) center;
-}
-
 .hx-input-date-has-calendar-icon ::deep .form-control {
 	padding-right: 4.25rem;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateRangeInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxInputDateRangeInternal.razor.css
@@ -40,11 +40,6 @@
     padding-right: 2.5rem;
 }
 
-.hx-input-date-has-calendar-icon ::deep .is-invalid {
-	background-position: right calc(0.375em + 2rem) center;
-    padding-right: 4.25rem;
-}
-
 .hx-input-date-range:has(input:not(:disabled)) .hx-input-date-icon {
 	cursor: pointer;
 }


### PR DESCRIPTION
Fixes #1455, fixes #1456, fixes #1457

The forms-core batch. The investigation showed our rendering architecture was already largely v6-shaped, so the change is surgical:

## `.form-field` layout (#1455)
- **`HxInputBase.CoreCssClass` now includes `form-field`** — since every Hx input renders through the central `HxFormValueComponentRenderer` (outer div → label → control/input-group → help text → validation feedback), this single change adopts the v6 CSS-grid field layout uniformly across all form components. Spacing inside the field is now grid-gap-based (matching v6's removal of `form-text` margins); `form-label` and the naked-input fast path are unchanged.
- Checks/radios/switches (#1484) compose naturally: with a `Label` the outer `form-field` stacks the label above the inner control+text `form-field` row.

## Validation overhaul (#1456)
- Blazor's `EditForm` integration uses the server-side-style `.is-invalid` classes — **unchanged in v6** (as are `invalid-feedback` and `form-label`). `data-bs-validate` exists for native browser validation, which Blazor doesn't use, so no API is needed.
- Removed the validation-icon compensation CSS in the autosuggest/date inputs (`$enable-validation-icons` and the built-in icons no longer exist; the rules were dead).

## Input groups (#1457)
- Verified: validation feedback was already rendered **outside** the input group in the parent wrapper (the new v6 placement); we never emitted `has-validation`; nothing relies on the removed `flex-wrap`. `.input-group-ignore` becomes relevant with the form-adorn work (#1458).

## Verification
Library builds with `-warnaserror`; Documentation, BlazorAppTest, TestApp, E2ETests build clean. **466/466** unit tests and **352/352** documentation tests pass locally (net10.0; CI covers net8/net9).

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_