### PR TITLE
HxAvatar + HxAvatarStack: new components for Bootstrap 6 Avatar

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAvatarTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAvatarTests.cs
@@ -1,0 +1,164 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
+
+public class HxAvatarTests : BunitTestBase
+{
+	[Fact]
+	public void HxAvatar_Render_DisplaysInitials()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.AddChildContent("AB")
+		);
+
+		// Assert
+		Assert.Equal("AB", cut.Find("span.avatar").TextContent.Trim());
+	}
+
+	[Fact]
+	public void HxAvatar_ImageSrc_RendersAvatarImg()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.ImageSrc, "avatar.png")
+			.Add(p => p.ImageAlt, "John Doe")
+		);
+
+		// Assert
+		var image = cut.Find("span.avatar > img.avatar-img");
+		Assert.Equal("avatar.png", image.GetAttribute("src"));
+		Assert.Equal("John Doe", image.GetAttribute("alt"));
+	}
+
+	[Theory]
+	[InlineData(AvatarSize.ExtraSmall, "avatar-xs")]
+	[InlineData(AvatarSize.Small, "avatar-sm")]
+	[InlineData(AvatarSize.Large, "avatar-lg")]
+	[InlineData(AvatarSize.ExtraLarge, "avatar-xl")]
+	public void HxAvatar_Size_AppliesCorrectCssClass(AvatarSize size, string expectedCssClass)
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.Size, size)
+		);
+
+		// Assert
+		Assert.NotNull(cut.Find($"span.avatar.{expectedCssClass}"));
+	}
+
+	[Fact]
+	public void HxAvatar_RegularSize_DoesNotRenderSizeCssClass()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.Size, AvatarSize.Regular)
+		);
+
+		// Assert
+		Assert.Equal("avatar", cut.Find("span").GetAttribute("class"));
+	}
+
+	[Theory]
+	[InlineData(AvatarStatus.Online, "status-online", "Online")]
+	[InlineData(AvatarStatus.Offline, "status-offline", "Offline")]
+	[InlineData(AvatarStatus.Busy, "status-busy", "Busy")]
+	[InlineData(AvatarStatus.Away, "status-away", "Away")]
+	public void HxAvatar_Status_RendersStatusIndicator(AvatarStatus status, string expectedCssClass, string expectedLabel)
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.Status, status)
+		);
+
+		// Assert
+		var statusElement = cut.Find($"span.avatar > span.avatar-status.{expectedCssClass}");
+		Assert.Equal("img", statusElement.GetAttribute("role"));
+		Assert.Equal(expectedLabel, statusElement.GetAttribute("aria-label"));
+	}
+
+	[Fact]
+	public void HxAvatar_NoStatus_DoesNotRenderStatusIndicator()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>();
+
+		// Assert
+		Assert.Empty(cut.FindAll("span.avatar-status"));
+	}
+
+	[Fact]
+	public void HxAvatar_StatusLabel_OverridesAriaLabel()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.Status, AvatarStatus.Online)
+			.Add(p => p.StatusLabel, "Available")
+		);
+
+		// Assert
+		Assert.Equal("Available", cut.Find("span.avatar-status").GetAttribute("aria-label"));
+	}
+
+	[Fact]
+	public void HxAvatar_Color_AppliesThemeCssClass()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.Color, ThemeColor.Primary)
+		);
+
+		// Assert
+		Assert.NotNull(cut.Find("span.avatar.theme-primary"));
+	}
+
+	[Fact]
+	public void HxAvatar_Subtle_AppliesSubtleCssClass()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatar>(parameters => parameters
+			.Add(p => p.Color, ThemeColor.Danger)
+			.Add(p => p.Subtle, true)
+		);
+
+		// Assert
+		Assert.NotNull(cut.Find("span.avatar.avatar-subtle.theme-danger"));
+	}
+
+	[Fact]
+	public void HxAvatarStack_Render_RendersAvatars()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatarStack>(parameters => parameters
+			.AddChildContent<HxAvatar>(avatar => avatar.AddChildContent("AB"))
+			.AddChildContent<HxAvatar>(avatar => avatar.AddChildContent("+5"))
+		);
+
+		// Assert
+		Assert.Equal(2, cut.FindAll("div.avatar-stack > span.avatar").Count);
+	}
+
+	[Theory]
+	[InlineData(AvatarSize.ExtraSmall, "avatar-stack-xs")]
+	[InlineData(AvatarSize.Small, "avatar-stack-sm")]
+	[InlineData(AvatarSize.Large, "avatar-stack-lg")]
+	[InlineData(AvatarSize.ExtraLarge, "avatar-stack-xl")]
+	public void HxAvatarStack_Size_AppliesCorrectCssClass(AvatarSize size, string expectedCssClass)
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatarStack>(parameters => parameters
+			.Add(p => p.Size, size)
+		);
+
+		// Assert
+		Assert.NotNull(cut.Find($"div.avatar-stack.{expectedCssClass}"));
+	}
+
+	[Fact]
+	public void HxAvatarStack_RegularSize_DoesNotRenderSizeCssClass()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxAvatarStack>();
+
+		// Assert
+		Assert.Equal("avatar-stack", cut.Find("div").GetAttribute("class"));
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarSettings.cs
@@ -1,0 +1,27 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Settings for the <see cref="HxAvatar"/> and derived components.
+/// </summary>
+public record AvatarSettings
+{
+	/// <summary>
+	/// Size of the avatar.
+	/// </summary>
+	public AvatarSize? Size { get; set; }
+
+	/// <summary>
+	/// Theme color of the avatar (background and contrasting content color).
+	/// </summary>
+	public ThemeColor? Color { get; set; }
+
+	/// <summary>
+	/// When <c>true</c>, the avatar uses the subtle variant of the theme color.
+	/// </summary>
+	public bool? Subtle { get; set; }
+
+	/// <summary>
+	/// Any additional CSS class to apply.
+	/// </summary>
+	public string CssClass { get; set; }
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarSize.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarSize.cs
@@ -1,0 +1,32 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Size for <see cref="HxAvatar"/> and <see cref="HxAvatarStack"/>.
+/// </summary>
+public enum AvatarSize
+{
+	/// <summary>
+	/// Regular (default) size.
+	/// </summary>
+	Regular = 0,
+
+	/// <summary>
+	/// Extra small avatar (<c>avatar-xs</c>).
+	/// </summary>
+	ExtraSmall,
+
+	/// <summary>
+	/// Small avatar (<c>avatar-sm</c>).
+	/// </summary>
+	Small,
+
+	/// <summary>
+	/// Large avatar (<c>avatar-lg</c>).
+	/// </summary>
+	Large,
+
+	/// <summary>
+	/// Extra large avatar (<c>avatar-xl</c>).
+	/// </summary>
+	ExtraLarge
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarStackSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarStackSettings.cs
@@ -1,0 +1,17 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Settings for the <see cref="HxAvatarStack"/> and derived components.
+/// </summary>
+public record AvatarStackSettings
+{
+	/// <summary>
+	/// Size of the avatars in the stack.
+	/// </summary>
+	public AvatarSize? Size { get; set; }
+
+	/// <summary>
+	/// Any additional CSS class to apply.
+	/// </summary>
+	public string CssClass { get; set; }
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarStatus.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/AvatarStatus.cs
@@ -1,0 +1,32 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Status indicator for <see cref="HxAvatar"/>.
+/// </summary>
+public enum AvatarStatus
+{
+	/// <summary>
+	/// No status indicator (default).
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	/// Online status — green circle (<c>status-online</c>).
+	/// </summary>
+	Online,
+
+	/// <summary>
+	/// Offline status — gray rounded square (<c>status-offline</c>).
+	/// </summary>
+	Offline,
+
+	/// <summary>
+	/// Busy status — red rounded square (<c>status-busy</c>).
+	/// </summary>
+	Busy,
+
+	/// <summary>
+	/// Away status — yellow circle (<c>status-away</c>).
+	/// </summary>
+	Away
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatar.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatar.razor
@@ -1,0 +1,8 @@
+﻿@namespace Havit.Blazor.Components.Web.Bootstrap
+<span class="@GetCssClass()" @attributes="AdditionalAttributes">@if (!String.IsNullOrEmpty(ImageSrc))
+	{
+		<img class="avatar-img" src="@ImageSrc" alt="@ImageAlt" />
+	}@ChildContent@if (Status != AvatarStatus.None)
+	{
+		<span class="@CssClassHelper.Combine("avatar-status", GetStatusCssClass())" role="img" aria-label="@StatusLabelEffective"></span>
+	}</span>

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatar.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatar.razor.cs
@@ -1,0 +1,149 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/avatar/">Bootstrap Avatar</see> component.
+/// Represents a user or entity with an image or initials.<br />
+/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAvatar">https://havit.blazor.eu/components/HxAvatar</see>
+/// </summary>
+public partial class HxAvatar
+{
+	/// <summary>
+	/// Application-wide defaults for <see cref="HxAvatar"/> and derived components.
+	/// </summary>
+	public static AvatarSettings Defaults { get; set; }
+
+	static HxAvatar()
+	{
+		Defaults = new AvatarSettings()
+		{
+			Size = AvatarSize.Regular,
+			Color = ThemeColor.None,
+			Subtle = false,
+			CssClass = null
+		};
+	}
+
+	/// <summary>
+	/// Returns application-wide defaults for the component.
+	/// Enables overriding defaults in descendants (use a separate set of defaults).
+	/// </summary>
+	protected virtual AvatarSettings GetDefaults() => Defaults;
+
+	/// <summary>
+	/// Set of settings to be applied to the component instance (overrides <see cref="Defaults"/>, overridden by individual parameters).
+	/// </summary>
+	[Parameter] public AvatarSettings Settings { get; set; }
+
+	/// <summary>
+	/// Returns an optional set of component settings.
+	/// </summary>
+	/// <remarks>
+	/// Similar to <see cref="GetDefaults"/>, enables defining wider <see cref="Settings"/> in component descendants (by returning a derived settings class).
+	/// </remarks>
+	protected virtual AvatarSettings GetSettings() => Settings;
+
+	/// <summary>
+	/// URL of the avatar image. Renders an <c>img.avatar-img</c> element inside the avatar.
+	/// </summary>
+	[Parameter] public string ImageSrc { get; set; }
+
+	/// <summary>
+	/// Alternate text for the avatar image (<see cref="ImageSrc"/>).
+	/// </summary>
+	[Parameter] public string ImageAlt { get; set; }
+
+	/// <summary>
+	/// Content of the avatar, usually initials (e.g. <c>AB</c>). Can also be used for fully custom content.
+	/// </summary>
+	[Parameter] public RenderFragment ChildContent { get; set; }
+
+	/// <summary>
+	/// Size of the avatar. The default is <see cref="AvatarSize.Regular"/>.
+	/// </summary>
+	[Parameter] public AvatarSize? Size { get; set; }
+	protected AvatarSize SizeEffective => Size ?? GetSettings()?.Size ?? GetDefaults().Size ?? throw new InvalidOperationException(nameof(Size) + " default for " + nameof(HxAvatar) + " has to be set.");
+
+	/// <summary>
+	/// Theme color of the avatar (background and contrasting content color), usually combined with initials.
+	/// The default is <see cref="ThemeColor.None"/> (the default avatar background).
+	/// </summary>
+	[Parameter] public ThemeColor? Color { get; set; }
+	protected ThemeColor ColorEffective => Color ?? GetSettings()?.Color ?? GetDefaults().Color ?? throw new InvalidOperationException(nameof(Color) + " default for " + nameof(HxAvatar) + " has to be set.");
+
+	/// <summary>
+	/// When <c>true</c>, the avatar uses the subtle variant of the theme color (<c>avatar-subtle</c>), composed with <see cref="Color"/>.
+	/// The default is <c>false</c>.
+	/// </summary>
+	[Parameter] public bool? Subtle { get; set; }
+	protected bool SubtleEffective => Subtle ?? GetSettings()?.Subtle ?? GetDefaults().Subtle ?? throw new InvalidOperationException(nameof(Subtle) + " default for " + nameof(HxAvatar) + " has to be set.");
+
+	/// <summary>
+	/// Status indicator of the avatar. The default is <see cref="AvatarStatus.None"/> (no indicator rendered).
+	/// </summary>
+	[Parameter] public AvatarStatus Status { get; set; } = AvatarStatus.None;
+
+	/// <summary>
+	/// Accessible label of the status indicator (rendered as <c>aria-label</c>).
+	/// The default is the English name of the <see cref="Status"/> (e.g. <c>Online</c>).
+	/// </summary>
+	[Parameter] public string StatusLabel { get; set; }
+	protected string StatusLabelEffective => StatusLabel ?? GetStatusDefaultLabel();
+
+	/// <summary>
+	/// Any additional CSS class to apply.
+	/// </summary>
+	[Parameter] public string CssClass { get; set; }
+	protected string CssClassEffective => CssClass ?? GetSettings()?.CssClass ?? GetDefaults().CssClass;
+
+	/// <summary>
+	/// Additional attributes to be splatted onto an underlying HTML element.
+	/// </summary>
+	[Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+	protected virtual string GetCssClass()
+	{
+		return CssClassHelper.Combine(
+			"avatar",
+			GetSizeCssClass(),
+			SubtleEffective ? "avatar-subtle" : null,
+			ColorEffective.ToThemeCss(),
+			CssClassEffective);
+	}
+
+	private string GetSizeCssClass()
+	{
+		return SizeEffective switch
+		{
+			AvatarSize.Regular => null,
+			AvatarSize.ExtraSmall => "avatar-xs",
+			AvatarSize.Small => "avatar-sm",
+			AvatarSize.Large => "avatar-lg",
+			AvatarSize.ExtraLarge => "avatar-xl",
+			_ => throw new InvalidOperationException($"Unknown {nameof(AvatarSize)} value: {SizeEffective}.")
+		};
+	}
+
+	private string GetStatusCssClass()
+	{
+		return Status switch
+		{
+			AvatarStatus.Online => "status-online",
+			AvatarStatus.Offline => "status-offline",
+			AvatarStatus.Busy => "status-busy",
+			AvatarStatus.Away => "status-away",
+			_ => throw new InvalidOperationException($"Unknown {nameof(AvatarStatus)} value: {Status}.")
+		};
+	}
+
+	private string GetStatusDefaultLabel()
+	{
+		return Status switch
+		{
+			AvatarStatus.Online => "Online",
+			AvatarStatus.Offline => "Offline",
+			AvatarStatus.Busy => "Busy",
+			AvatarStatus.Away => "Away",
+			_ => throw new InvalidOperationException($"Unknown {nameof(AvatarStatus)} value: {Status}.")
+		};
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatarStack.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatarStack.razor
@@ -1,0 +1,5 @@
+﻿@namespace Havit.Blazor.Components.Web.Bootstrap
+
+<div class="@GetCssClass()" @attributes="AdditionalAttributes">
+	@ChildContent
+</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatarStack.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Avatars/HxAvatarStack.razor.cs
@@ -1,0 +1,88 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/avatar/#avatar-stack">Bootstrap Avatar stack</see> component.
+/// Groups multiple <see cref="HxAvatar"/> components with an overlapping effect.
+/// Avatars are rendered in reverse order, so the first avatar appears on top.
+/// To show a count of additional users, add an initials avatar (e.g. <c>&lt;HxAvatar Color="ThemeColor.Secondary"&gt;+5&lt;/HxAvatar&gt;</c>) as the last item.<br />
+/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAvatarStack">https://havit.blazor.eu/components/HxAvatarStack</see>
+/// </summary>
+public partial class HxAvatarStack
+{
+	/// <summary>
+	/// Application-wide defaults for <see cref="HxAvatarStack"/> and derived components.
+	/// </summary>
+	public static AvatarStackSettings Defaults { get; set; }
+
+	static HxAvatarStack()
+	{
+		Defaults = new AvatarStackSettings()
+		{
+			Size = AvatarSize.Regular,
+			CssClass = null
+		};
+	}
+
+	/// <summary>
+	/// Returns application-wide defaults for the component.
+	/// Enables overriding defaults in descendants (use a separate set of defaults).
+	/// </summary>
+	protected virtual AvatarStackSettings GetDefaults() => Defaults;
+
+	/// <summary>
+	/// Set of settings to be applied to the component instance (overrides <see cref="Defaults"/>, overridden by individual parameters).
+	/// </summary>
+	[Parameter] public AvatarStackSettings Settings { get; set; }
+
+	/// <summary>
+	/// Returns an optional set of component settings.
+	/// </summary>
+	/// <remarks>
+	/// Similar to <see cref="GetDefaults"/>, enables defining wider <see cref="Settings"/> in component descendants (by returning a derived settings class).
+	/// </remarks>
+	protected virtual AvatarStackSettings GetSettings() => Settings;
+
+	/// <summary>
+	/// Content of the avatar stack (put your <see cref="HxAvatar"/>s here).
+	/// </summary>
+	[Parameter] public RenderFragment ChildContent { get; set; }
+
+	/// <summary>
+	/// Size of the avatars in the stack (a shorthand for setting the size of all contained avatars).
+	/// The default is <see cref="AvatarSize.Regular"/>.
+	/// </summary>
+	[Parameter] public AvatarSize? Size { get; set; }
+	protected AvatarSize SizeEffective => Size ?? GetSettings()?.Size ?? GetDefaults().Size ?? throw new InvalidOperationException(nameof(Size) + " default for " + nameof(HxAvatarStack) + " has to be set.");
+
+	/// <summary>
+	/// Any additional CSS class to apply.
+	/// </summary>
+	[Parameter] public string CssClass { get; set; }
+	protected string CssClassEffective => CssClass ?? GetSettings()?.CssClass ?? GetDefaults().CssClass;
+
+	/// <summary>
+	/// Additional attributes to be splatted onto an underlying HTML element.
+	/// </summary>
+	[Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+	protected virtual string GetCssClass()
+	{
+		return CssClassHelper.Combine(
+			"avatar-stack",
+			GetSizeCssClass(),
+			CssClassEffective);
+	}
+
+	private string GetSizeCssClass()
+	{
+		return SizeEffective switch
+		{
+			AvatarSize.Regular => null,
+			AvatarSize.ExtraSmall => "avatar-stack-xs",
+			AvatarSize.Small => "avatar-stack-sm",
+			AvatarSize.Large => "avatar-stack-lg",
+			AvatarSize.ExtraLarge => "avatar-stack-xl",
+			_ => throw new InvalidOperationException($"Unknown {nameof(AvatarSize)} value: {SizeEffective}.")
+		};
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Image.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Image.razor
@@ -1,0 +1,1 @@
+﻿<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Initials.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Initials.razor
@@ -1,0 +1,9 @@
+﻿<HxAvatar>AB</HxAvatar>
+<HxAvatar Color="ThemeColor.Primary">CD</HxAvatar>
+<HxAvatar Color="ThemeColor.Accent">EF</HxAvatar>
+<HxAvatar Color="ThemeColor.Success">GG</HxAvatar>
+<HxAvatar Color="ThemeColor.Danger">GH</HxAvatar>
+<HxAvatar Color="ThemeColor.Warning">IJ</HxAvatar>
+<HxAvatar Color="ThemeColor.Info">KL</HxAvatar>
+<HxAvatar Color="ThemeColor.Inverse">MN</HxAvatar>
+<HxAvatar Color="ThemeColor.Secondary">OP</HxAvatar>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Sizes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Sizes.razor
@@ -1,0 +1,5 @@
+﻿<HxAvatar Size="AvatarSize.ExtraSmall" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+<HxAvatar Size="AvatarSize.Small" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+<HxAvatar Size="AvatarSize.Large" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+<HxAvatar Size="AvatarSize.ExtraLarge" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Stack.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Stack.razor
@@ -1,0 +1,7 @@
+﻿<HxAvatarStack>
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+</HxAvatarStack>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_StackCount.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_StackCount.razor
@@ -1,0 +1,6 @@
+﻿<HxAvatarStack>
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	<HxAvatar Color="ThemeColor.Secondary">+5</HxAvatar>
+</HxAvatarStack>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_StackSizes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_StackSizes.razor
@@ -1,0 +1,31 @@
+﻿<div class="vstack align-items-start gap-3">
+	<HxAvatarStack Size="AvatarSize.ExtraSmall">
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	</HxAvatarStack>
+
+	<HxAvatarStack Size="AvatarSize.Small">
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	</HxAvatarStack>
+
+	<HxAvatarStack>
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	</HxAvatarStack>
+
+	<HxAvatarStack Size="AvatarSize.Large">
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	</HxAvatarStack>
+
+	<HxAvatarStack Size="AvatarSize.ExtraLarge">
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+		<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" />
+	</HxAvatarStack>
+</div>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Status.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Status.razor
@@ -1,0 +1,4 @@
+﻿<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Online" />
+<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Offline" />
+<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Busy" />
+<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Away" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_StatusSizes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_StatusSizes.razor
@@ -1,0 +1,5 @@
+﻿<HxAvatar Size="AvatarSize.ExtraSmall" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Online" />
+<HxAvatar Size="AvatarSize.Small" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Online" />
+<HxAvatar ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Online" />
+<HxAvatar Size="AvatarSize.Large" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Online" />
+<HxAvatar Size="AvatarSize.ExtraLarge" ImageSrc="HAVIT-Icon_48x48_transparent.png" ImageAlt="HAVIT" Status="AvatarStatus.Online" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Subtle.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Demo_Subtle.razor
@@ -1,0 +1,9 @@
+﻿<HxAvatar>AB</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Primary">CD</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Accent">EF</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Success">GG</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Danger">GH</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Warning">IJ</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Info">KL</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Inverse">MN</HxAvatar>
+<HxAvatar Subtle="true" Color="ThemeColor.Secondary">OP</HxAvatar>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAvatarDoc/HxAvatar_Documentation.razor
@@ -1,0 +1,48 @@
+﻿@attribute [Route("/components/" + nameof(HxAvatar))]
+@attribute [Route("/components/" + nameof(HxAvatarStack))]
+
+<ApiDoc Type="typeof(HxAvatar)">
+    <p>Avatars are used to represent users or entities. They can display an image or initials as a fallback.</p>
+
+    <DocHeading Title="Image" />
+    <p>Use the <code>ImageSrc</code> parameter (with an optional <code>ImageAlt</code>) for image-based avatars.</p>
+    <Demo Type="typeof(HxAvatar_Demo_Image)" Tabs="false" />
+
+    <DocHeading Title="Initials" />
+    <p>Use the child content for initials-based avatars. Combine with the <code>Color</code> parameter to apply a theme color.</p>
+    <Demo Type="typeof(HxAvatar_Demo_Initials)" Tabs="false" />
+
+    <DocHeading Title="Subtle" Level="4" />
+    <p>Use <code>Subtle="true"</code> to create a subtle avatar.</p>
+    <Demo Type="typeof(HxAvatar_Demo_Subtle)" Tabs="false" />
+
+    <DocHeading Title="Sizes" />
+    <p>Avatars come in multiple sizes: extra small, small, default, large, and extra large.</p>
+    <Demo Type="typeof(HxAvatar_Demo_Sizes)" Tabs="false" />
+    <p>Use a custom size by modifying the <code>--bs-avatar-size</code> CSS variable (e.g. <code>style="--bs-avatar-size: 8rem;"</code>).</p>
+
+    <DocHeading Title="Status indicator" />
+    <p>
+        Use the <code>Status</code> parameter to show a status indicator. Each status has a distinct shape and color.
+        Because the status is conveyed purely through color and shape, the indicator renders with <code>role="img"</code>
+        and an <code>aria-label</code> (customizable with the <code>StatusLabel</code> parameter) so assistive technologies can announce it.
+    </p>
+    <Demo Type="typeof(HxAvatar_Demo_Status)" Tabs="false" />
+
+    <DocHeading Title="Status with sizes" Level="4" />
+    <p>The status indicator scales with the avatar size.</p>
+    <Demo Type="typeof(HxAvatar_Demo_StatusSizes)" Tabs="false" />
+</ApiDoc>
+
+<ApiDoc Type="typeof(HxAvatarStack)">
+    <p>Use <code>HxAvatarStack</code> to group multiple avatars together with an overlapping effect. Avatars are rendered in reverse order so the first avatar appears on top.</p>
+    <Demo Type="typeof(HxAvatar_Demo_Stack)" Tabs="false" />
+
+    <DocHeading Title="Stack with sizes" />
+    <p>As a shorthand, use the <code>Size</code> parameter to set the size of all avatars in the stack.</p>
+    <Demo Type="typeof(HxAvatar_Demo_StackSizes)" Tabs="false" />
+
+    <DocHeading Title="Stack with count" />
+    <p>Combine with initials to show a count of additional users.</p>
+    <Demo Type="typeof(HxAvatar_Demo_StackCount)" Tabs="false" />
+</ApiDoc>

--- a/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
+++ b/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
@@ -27,6 +27,8 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/components/HxAnchorFragmentNavigation", "HxAnchorFragmentNavigation", "id scroll"),
 		new("/components/HxApplicationInsights", "HxApplicationInsights", "telemetry monitoring azure logging exception tracking page view HxApplicationInsightsExceptionTracker appinsights application insights"),
 		new("/components/HxAutosuggest", "HxAutosuggest", "autocomplete search typeahead select combobox"),
+		new("/components/HxAvatar", "HxAvatar", "user profile picture image initials status"),
+		new("/components/HxAvatarStack", "HxAvatarStack", "avatars group overlap count"),
 		new("/components/HxBadge", "HxBadge", "chip tag"),
 		new("/components/HxBreadcrumb", "HxBreadcrumb", "navigation link"),
 		new("/components/HxButton", "HxButton", "click submit input tooltip"),
@@ -115,6 +117,8 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		// Defaults (settings)
 
 		new("/types/AutosuggestSettings", "Autosuggest Settings", "defaults", DefaultsLevel),
+		new("/types/AvatarSettings", "Avatar Settings", "defaults", DefaultsLevel),
+		new("/types/AvatarStackSettings", "AvatarStack Settings", "defaults", DefaultsLevel),
 		new("/types/BadgeSettings", "Badge Settings", "defaults", DefaultsLevel),
 		new("/types/ButtonSettings", "Button Settings", "defaults", DefaultsLevel),
 		new("/types/CalendarSettings", "Calendar Settings", "defaults", DefaultsLevel),
@@ -152,6 +156,8 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 
 		// Enums
 
+		new("/types/AvatarSize", "AvatarSize", "enum", EnumsLevel),
+		new("/types/AvatarStatus", "AvatarStatus", "enum online offline busy away", EnumsLevel),
 		new("/types/BadgeType", "BadgeType", "enum shape", EnumsLevel),
 		new("/types/BootstrapFlavor", "BootstrapFlavor", "enum", EnumsLevel),
 		new("/types/ButtonGroupOrientation", "ButtonGroupOrientation", "enum", EnumsLevel),

--- a/Havit.Blazor.Documentation/Shared/Sidebar.razor
+++ b/Havit.Blazor.Documentation/Shared/Sidebar.razor
@@ -56,6 +56,7 @@
             <HxSidebarItem Href="@($"/components/{nameof(HxButtonToolbar)}#{nameof(HxButtonToolbar)}")" Text="@nameof(HxButtonToolbar)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxCloseButton)}")" Text="@nameof(HxCloseButton)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxSubmit)}#{nameof(HxSubmit)}")" Text="@nameof(HxSubmit)" />
+            <HxSidebarItem Href="@($"/components/{nameof(HxAvatar)}")" Text="@nameof(HxAvatar)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxBadge)}")" Text="@nameof(HxBadge)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxChipList)}")" Text="@(nameof(HxChipList))" />
             <HxSidebarItem Href="@($"/components/{nameof(HxSpinner)}")" Text="@nameof(HxSpinner)" />
@@ -153,6 +154,8 @@
             <HxSidebarItem Href="@($"/components/{nameof(HxAccordion)}")" Text="@nameof(HxAccordion)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxAlert)}")" Text="@nameof(HxAlert)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxAutosuggest)}")" Text="@nameof(HxAutosuggest)" />
+            <HxSidebarItem Href="@($"/components/{nameof(HxAvatar)}")" Text="@nameof(HxAvatar)" />
+            <HxSidebarItem Href="@($"/components/{nameof(HxAvatarStack)}")" Text="@nameof(HxAvatarStack)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxBadge)}")" Text="@nameof(HxBadge)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxBreadcrumb)}")" Text="@nameof(HxBreadcrumb)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxButton)}")" Text="@nameof(HxButton)" />

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -154,6 +154,244 @@
             Additional attributes to be splatted onto an underlying HTML element.
             </summary>
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.AvatarSettings">
+            <summary>
+            Settings for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar"/> and derived components.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.AvatarSettings.Size">
+            <summary>
+            Size of the avatar.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.AvatarSettings.Color">
+            <summary>
+            Theme color of the avatar (background and contrasting content color).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.AvatarSettings.Subtle">
+            <summary>
+            When <c>true</c>, the avatar uses the subtle variant of the theme color.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.AvatarSettings.CssClass">
+            <summary>
+            Any additional CSS class to apply.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.AvatarSize">
+            <summary>
+            Size for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar"/> and <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack"/>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.Regular">
+            <summary>
+            Regular (default) size.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.ExtraSmall">
+            <summary>
+            Extra small avatar (<c>avatar-xs</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.Small">
+            <summary>
+            Small avatar (<c>avatar-sm</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.Large">
+            <summary>
+            Large avatar (<c>avatar-lg</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.ExtraLarge">
+            <summary>
+            Extra large avatar (<c>avatar-xl</c>).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.AvatarStackSettings">
+            <summary>
+            Settings for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack"/> and derived components.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.AvatarStackSettings.Size">
+            <summary>
+            Size of the avatars in the stack.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.AvatarStackSettings.CssClass">
+            <summary>
+            Any additional CSS class to apply.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus">
+            <summary>
+            Status indicator for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar"/>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus.None">
+            <summary>
+            No status indicator (default).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus.Online">
+            <summary>
+            Online status — green circle (<c>status-online</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus.Offline">
+            <summary>
+            Offline status — gray rounded square (<c>status-offline</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus.Busy">
+            <summary>
+            Busy status — red rounded square (<c>status-busy</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus.Away">
+            <summary>
+            Away status — yellow circle (<c>status-away</c>).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar">
+            <summary>
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/avatar/">Bootstrap Avatar</see> component.
+            Represents a user or entity with an image or initials.<br />
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAvatar">https://havit.blazor.eu/components/HxAvatar</see>
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Defaults">
+            <summary>
+            Application-wide defaults for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar"/> and derived components.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.GetDefaults">
+            <summary>
+            Returns application-wide defaults for the component.
+            Enables overriding defaults in descendants (use a separate set of defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Settings">
+            <summary>
+            Set of settings to be applied to the component instance (overrides <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Defaults"/>, overridden by individual parameters).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.GetSettings">
+            <summary>
+            Returns an optional set of component settings.
+            </summary>
+            <remarks>
+            Similar to <see cref="M:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.GetDefaults"/>, enables defining wider <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Settings"/> in component descendants (by returning a derived settings class).
+            </remarks>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.ImageSrc">
+            <summary>
+            URL of the avatar image. Renders an <c>img.avatar-img</c> element inside the avatar.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.ImageAlt">
+            <summary>
+            Alternate text for the avatar image (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.ImageSrc"/>).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.ChildContent">
+            <summary>
+            Content of the avatar, usually initials (e.g. <c>AB</c>). Can also be used for fully custom content.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Size">
+            <summary>
+            Size of the avatar. The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.Regular"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Color">
+            <summary>
+            Theme color of the avatar (background and contrasting content color), usually combined with initials.
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ThemeColor.None"/> (the default avatar background).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Subtle">
+            <summary>
+            When <c>true</c>, the avatar uses the subtle variant of the theme color (<c>avatar-subtle</c>), composed with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Color"/>.
+            The default is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Status">
+            <summary>
+            Status indicator of the avatar. The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.AvatarStatus.None"/> (no indicator rendered).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.StatusLabel">
+            <summary>
+            Accessible label of the status indicator (rendered as <c>aria-label</c>).
+            The default is the English name of the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.Status"/> (e.g. <c>Online</c>).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.CssClass">
+            <summary>
+            Any additional CSS class to apply.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatar.AdditionalAttributes">
+            <summary>
+            Additional attributes to be splatted onto an underlying HTML element.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack">
+            <summary>
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/avatar/#avatar-stack">Bootstrap Avatar stack</see> component.
+            Groups multiple <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar"/> components with an overlapping effect.
+            Avatars are rendered in reverse order, so the first avatar appears on top.
+            To show a count of additional users, add an initials avatar (e.g. <c>&lt;HxAvatar Color="ThemeColor.Secondary"&gt;+5&lt;/HxAvatar&gt;</c>) as the last item.<br />
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAvatarStack">https://havit.blazor.eu/components/HxAvatarStack</see>
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.Defaults">
+            <summary>
+            Application-wide defaults for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack"/> and derived components.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.GetDefaults">
+            <summary>
+            Returns application-wide defaults for the component.
+            Enables overriding defaults in descendants (use a separate set of defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.Settings">
+            <summary>
+            Set of settings to be applied to the component instance (overrides <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.Defaults"/>, overridden by individual parameters).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.GetSettings">
+            <summary>
+            Returns an optional set of component settings.
+            </summary>
+            <remarks>
+            Similar to <see cref="M:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.GetDefaults"/>, enables defining wider <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.Settings"/> in component descendants (by returning a derived settings class).
+            </remarks>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.ChildContent">
+            <summary>
+            Content of the avatar stack (put your <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxAvatar"/>s here).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.Size">
+            <summary>
+            Size of the avatars in the stack (a shorthand for setting the size of all contained avatars).
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.AvatarSize.Regular"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.CssClass">
+            <summary>
+            Any additional CSS class to apply.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxAvatarStack.AdditionalAttributes">
+            <summary>
+            Additional attributes to be splatted onto an underlying HTML element.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.BadgeSettings">
             <summary>
             Settings for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxBadge"/> and derived components.


### PR DESCRIPTION
Fixes #1459

New `HxAvatar` and `HxAvatarStack` components wrapping Bootstrap 6's CSS-only **Avatar** (22 files, +894 lines, purely additive — no existing component touched).

## HxAvatar
- `span.avatar` with image (`ImageSrc`/`ImageAlt` → `img.avatar-img`) or arbitrary child content (initials)
- `Size` (`AvatarSize`: ExtraSmall–ExtraLarge → `avatar-{xs,sm,lg,xl}`), `Color` (`ThemeColor?` → `theme-*`), `Subtle`
- `Status` (`AvatarStatus`: Online/Offline/Busy/Away → `span.avatar-status.status-*`) with `role="img"` + `aria-label` per the upstream a11y guidance; `StatusLabel` for localizing the label
- Standard repo patterns throughout: `Settings`/static `Defaults` with `*Effective` resolution, `AdditionalAttributes`, full XML docs

## HxAvatarStack
- `div.avatar-stack` (+ `avatar-stack-*` size shorthand). No dedicated "+N count" parameter — upstream's count item is just an initials avatar as the last child; the docs demo shows the pattern. Kept the API lean per the mdx contract.

## Docs & tests
- New documentation page (`/components/HxAvatar`, also routed from `/components/HxAvatarStack`) with 9 live demos (image, initials/colors, subtle, sizes, statuses, status+size, stack, stack sizes, stack count), registered in the sidebar and catalog service
- 18 new bUnit test cases

## Verification
Library builds with `-warnaserror`; **490/490** unit tests and **361/361** documentation tests (the new demos are smoke-tested) pass locally on net10.0; CI covers net8/net9.

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_