### PR TITLE
HxStepper: new component for Bootstrap 6 Stepper

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxStepperTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxStepperTests.cs
@@ -1,0 +1,223 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
+
+public class HxStepperTests : BunitTestBase
+{
+	[Fact]
+	public void HxStepper_Render_RendersOrderedListWithAllItems()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Create account"))
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Confirm email"))
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Finish"))
+		);
+
+		// Assert
+		var stepper = cut.Find("ol.stepper");
+		var items = cut.FindAll("ol.stepper > li.stepper-item");
+		Assert.Equal(3, items.Count);
+		Assert.Equal("Create account", items[0].TextContent.Trim());
+		Assert.Equal("Confirm email", items[1].TextContent.Trim());
+		Assert.Equal("Finish", items[2].TextContent.Trim());
+	}
+
+	[Fact]
+	public void HxStepper_ActiveItem_HasActiveClass()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Active, true)
+				.Add(i => i.Text, "Active item"))
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Inactive item"))
+		);
+
+		// Assert
+		var items = cut.FindAll(".stepper-item");
+		Assert.True(items[0].ClassList.Contains("active"), "First item should have the 'active' class.");
+		Assert.False(items[1].ClassList.Contains("active"), "Second item should not have the 'active' class.");
+	}
+
+	[Fact]
+	public void HxStepper_HorizontalAlways_HasHorizontalClassAndNoWrapper()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.Add(p => p.Horizontal, StepperHorizontal.Always)
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Step"))
+		);
+
+		// Assert
+		var stepper = cut.Find("ol");
+		Assert.True(stepper.ClassList.Contains("stepper-horizontal"));
+		Assert.Empty(cut.FindAll(".contains-inline"));
+		Assert.Empty(cut.FindAll(".stepper-overflow"));
+	}
+
+	[Theory]
+	[InlineData(StepperHorizontal.SmallUp, "sm:stepper-horizontal")]
+	[InlineData(StepperHorizontal.MediumUp, "md:stepper-horizontal")]
+	[InlineData(StepperHorizontal.LargeUp, "lg:stepper-horizontal")]
+	[InlineData(StepperHorizontal.ExtraLargeUp, "xl:stepper-horizontal")]
+	[InlineData(StepperHorizontal.XxlUp, "2xl:stepper-horizontal")]
+	public void HxStepper_ResponsiveHorizontal_HasResponsiveClassAndContainsInlineWrapper(StepperHorizontal horizontal, string expectedCssClass)
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.Add(p => p.Horizontal, horizontal)
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Step"))
+		);
+
+		// Assert
+		var wrapper = cut.Find("div.contains-inline");
+		var stepper = cut.Find("ol");
+		Assert.Equal(wrapper, stepper.ParentElement);
+		Assert.True(stepper.ClassList.Contains(expectedCssClass), $"Stepper should have the '{expectedCssClass}' class.");
+	}
+
+	[Fact]
+	public void HxStepper_Overflow_RendersStepperOverflowWrapper()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.Add(p => p.Horizontal, StepperHorizontal.Always)
+			.Add(p => p.Overflow, true)
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Step"))
+		);
+
+		// Assert
+		var wrapper = cut.Find("div.stepper-overflow");
+		var stepper = cut.Find("ol.stepper");
+		Assert.Equal(wrapper, stepper.ParentElement);
+	}
+
+	[Fact]
+	public void HxStepper_OverflowWithResponsiveHorizontal_DoesNotRenderContainsInlineWrapper()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.Add(p => p.Horizontal, StepperHorizontal.MediumUp)
+			.Add(p => p.Overflow, true)
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Step"))
+		);
+
+		// Assert
+		Assert.NotNull(cut.Find("div.stepper-overflow"));
+		Assert.Empty(cut.FindAll(".contains-inline"));
+	}
+
+	[Fact]
+	public void HxStepper_Color_RendersThemeClass()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.Add(p => p.Color, ThemeColor.Success)
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Step"))
+		);
+
+		// Assert
+		Assert.True(cut.Find("ol.stepper").ClassList.Contains("theme-success"));
+	}
+
+	[Fact]
+	public void HxStepperItem_Color_RendersThemeClass()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Color, ThemeColor.Danger)
+				.Add(i => i.Text, "Step"))
+		);
+
+		// Assert
+		Assert.True(cut.Find(".stepper-item").ClassList.Contains("theme-danger"));
+	}
+
+	[Fact]
+	public void HxStepperItem_Href_RendersAnchorItemsAndDivStepper()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Href, "/step-1")
+				.Add(i => i.Active, true)
+				.Add(i => i.Text, "Create account"))
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Href, "/step-2")
+				.Add(i => i.Text, "Confirm email"))
+		);
+
+		// Assert
+		var stepper = cut.Find("div.stepper");
+		Assert.Empty(cut.FindAll("ol"));
+		Assert.Empty(cut.FindAll("li"));
+		var items = cut.FindAll("a.stepper-item");
+		Assert.Equal(2, items.Count);
+		Assert.Equal("/step-1", items[0].GetAttribute("href"));
+		Assert.True(items[0].ClassList.Contains("active"));
+		Assert.Equal("/step-2", items[1].GetAttribute("href"));
+	}
+
+	[Fact]
+	public void HxStepperItem_MixedAnchorAndPlainItems_RendersPlainItemsAsDivs()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Href, "/step-1")
+				.Add(i => i.Text, "Create account"))
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Confirm email"))
+		);
+
+		// Assert
+		Assert.Empty(cut.FindAll("ol"));
+		Assert.Empty(cut.FindAll("li"));
+		Assert.NotNull(cut.Find("div.stepper > a.stepper-item"));
+		Assert.NotNull(cut.Find("div.stepper > div.stepper-item"));
+	}
+
+	[Fact]
+	public void HxStepper_CssClassAndAdditionalAttributes_AreRendered()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.Add(p => p.CssClass, "w-100")
+			.AddUnmatched("style", "--bs-stepper-gap: 3rem")
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Step")
+				.Add(i => i.CssClass, "align-items-start"))
+		);
+
+		// Assert
+		var stepper = cut.Find("ol.stepper");
+		Assert.True(stepper.ClassList.Contains("w-100"));
+		Assert.Equal("--bs-stepper-gap: 3rem", stepper.GetAttribute("style"));
+		Assert.True(cut.Find(".stepper-item").ClassList.Contains("align-items-start"));
+	}
+
+	[Fact]
+	public void HxStepperItem_TextAndChildContent_RendersBoth()
+	{
+		// Act
+		var cut = RenderComponent<HxStepper>(parameters => parameters
+			.AddChildContent<HxStepperItem>(item => item
+				.Add(i => i.Text, "Create account")
+				.AddChildContent("<span class=\"badge\">Complete</span>"))
+		);
+
+		// Assert
+		var item = cut.Find(".stepper-item");
+		Assert.Contains("Create account", item.TextContent);
+		Assert.NotNull(cut.Find(".stepper-item > span.badge"));
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepper.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepper.razor
@@ -1,0 +1,41 @@
+﻿@namespace Havit.Blazor.Components.Web.Bootstrap
+
+@{
+	RenderFragment stepperTemplate;
+	if (_hasAnchorItems)
+	{
+		// Anchor items cannot be nested in an ordered list (invalid HTML), the stepper renders as a plain div element (follows the Bootstrap "With anchors" markup).
+		stepperTemplate =
+			@<div class="@GetClasses()" @attributes="AdditionalAttributes">
+				<CascadingValue Value="this" IsFixed="true">
+					@ChildContent
+				</CascadingValue>
+			</div>;
+	}
+	else
+	{
+		stepperTemplate =
+			@<ol class="@GetClasses()" @attributes="AdditionalAttributes">
+				<CascadingValue Value="this" IsFixed="true">
+					@ChildContent
+				</CascadingValue>
+			</ol>;
+	}
+}
+
+@if (OverflowEffective)
+{
+	<div class="stepper-overflow">
+		@stepperTemplate
+	</div>
+}
+else if (RenderContainsInlineWrapper)
+{
+	<div class="contains-inline">
+		@stepperTemplate
+	</div>
+}
+else
+{
+	@stepperTemplate
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepper.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepper.razor.cs
@@ -1,0 +1,139 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/stepper/">Bootstrap Stepper</see> component (new in Bootstrap 6).<br />
+/// Displays progress through a multi-step workflow (wizards, timelines, step-by-step progress bars) as a sequence of numbered steps (<see cref="HxStepperItem"/>s).
+/// The component is CSS-only, there is no step-switching logic (wire up your own state).<br />
+/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxStepper">https://havit.blazor.eu/components/HxStepper</see>
+/// </summary>
+public partial class HxStepper
+{
+	/// <summary>
+	/// Application-wide defaults for <see cref="HxStepper"/> and derived components.
+	/// </summary>
+	public static StepperSettings Defaults { get; set; }
+
+	static HxStepper()
+	{
+		Defaults = new StepperSettings();
+	}
+
+	/// <summary>
+	/// Returns application-wide defaults for the component.
+	/// Enables overriding defaults in descendants (use a separate set of defaults).
+	/// </summary>
+	protected virtual StepperSettings GetDefaults() => Defaults;
+
+	/// <summary>
+	/// Set of settings to be applied to the component instance (overrides <see cref="Defaults"/>, overridden by individual parameters).
+	/// </summary>
+	[Parameter] public StepperSettings Settings { get; set; }
+
+	/// <summary>
+	/// Returns an optional set of component settings.
+	/// </summary>
+	/// <remarks>
+	/// Similar to <see cref="GetDefaults"/>, enables defining wider <see cref="Settings"/> in component descendants (by returning a derived settings class).
+	/// </remarks>
+	protected virtual StepperSettings GetSettings() => Settings;
+
+	/// <summary>
+	/// Content of the stepper (<see cref="HxStepperItem"/>s).
+	/// </summary>
+	[Parameter] public RenderFragment ChildContent { get; set; }
+
+	/// <summary>
+	/// Changes the layout of the stepper items from vertical to horizontal, including the responsive breakpoint
+	/// (Bootstrap 6 responsive <c>{breakpoint}:stepper-horizontal</c> classes are container query based,
+	/// the component renders the required <c>contains-inline</c> wrapper automatically).
+	/// The default is <see cref="StepperHorizontal.Never"/> (vertical stepper).
+	/// </summary>
+	[Parameter] public StepperHorizontal? Horizontal { get; set; }
+	protected StepperHorizontal HorizontalEffective => Horizontal ?? GetSettings()?.Horizontal ?? GetDefaults().Horizontal ?? StepperHorizontal.Never;
+
+	/// <summary>
+	/// Theme color of the stepper (renders the <c>theme-*</c> class), applies to all active items.
+	/// To color individual steps, use <see cref="HxStepperItem.Color"/>.
+	/// </summary>
+	[Parameter] public ThemeColor? Color { get; set; }
+	protected ThemeColor? ColorEffective => Color ?? GetSettings()?.Color ?? GetDefaults().Color;
+
+	/// <summary>
+	/// When <c>true</c>, the stepper is wrapped in a <c>stepper-overflow</c> container which enables horizontal scrolling
+	/// when the (horizontal) stepper overflows its parent. The default is <c>false</c>.
+	/// </summary>
+	[Parameter] public bool? Overflow { get; set; }
+	protected bool OverflowEffective => Overflow ?? GetSettings()?.Overflow ?? GetDefaults().Overflow ?? false;
+
+	/// <summary>
+	/// Additional CSS class(es) for the stepper.
+	/// </summary>
+	[Parameter] public string CssClass { get; set; }
+	protected string CssClassEffective => CssClass ?? GetSettings()?.CssClass ?? GetDefaults().CssClass;
+
+	/// <summary>
+	/// Additional attributes to be splatted onto an underlying HTML element
+	/// (e.g. use the <c>style</c> attribute to customize the gap by overriding the <c>--bs-stepper-gap</c> CSS variable).
+	/// </summary>
+	[Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+	/// <summary>
+	/// Indicates whether any of the items is rendered as an anchor (has <see cref="HxStepperItem.Href"/> set).
+	/// </summary>
+	internal bool HasAnchorItems => _hasAnchorItems;
+	private bool _hasAnchorItems;
+
+	/// <summary>
+	/// Called by <see cref="HxStepperItem"/> with <see cref="HxStepperItem.Href"/> set.
+	/// Anchor items cannot be nested in an ordered list, so the stepper re-renders as a <c>div</c> element.
+	/// </summary>
+	internal void RegisterAnchorItem()
+	{
+		if (!_hasAnchorItems)
+		{
+			_hasAnchorItems = true;
+			StateHasChanged();
+		}
+	}
+
+	/// <summary>
+	/// Responsive horizontal steppers use container queries, which require a <c>contains-inline</c> parent element
+	/// (when the <c>stepper-overflow</c> wrapper is rendered, it establishes the query container itself).
+	/// </summary>
+	private bool RenderContainsInlineWrapper => !OverflowEffective
+		&& (HorizontalEffective is not (StepperHorizontal.Never or StepperHorizontal.Always));
+
+	protected virtual string GetClasses()
+	{
+		return CssClassHelper.Combine(
+			"stepper",
+			GetHorizontalCssClass(),
+			GetColorCssClass(),
+			CssClassEffective);
+	}
+
+	protected virtual string GetHorizontalCssClass()
+	{
+		return HorizontalEffective switch
+		{
+			StepperHorizontal.Never => null,
+			StepperHorizontal.Always => "stepper-horizontal",
+			StepperHorizontal.SmallUp => "sm:stepper-horizontal",
+			StepperHorizontal.MediumUp => "md:stepper-horizontal",
+			StepperHorizontal.LargeUp => "lg:stepper-horizontal",
+			StepperHorizontal.ExtraLargeUp => "xl:stepper-horizontal",
+			StepperHorizontal.XxlUp => "2xl:stepper-horizontal",
+			_ => throw new InvalidOperationException($"Unknown {nameof(StepperHorizontal)} value {HorizontalEffective}.")
+		};
+	}
+
+	private string GetColorCssClass()
+	{
+		return ColorEffective switch
+		{
+			null => null,
+			ThemeColor.None => null,
+			_ => ColorEffective.Value.ToThemeCss()
+		};
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepperItem.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepperItem.razor
@@ -1,0 +1,24 @@
+﻿@namespace Havit.Blazor.Components.Web.Bootstrap
+
+@if (Href is not null)
+{
+	<a class="@GetClasses()" href="@Href">
+		@Text
+		@ChildContent
+	</a>
+}
+else if (StepperContainer?.HasAnchorItems ?? false)
+{
+	@* Sibling items are anchors, the parent stepper renders as a div element where a li element would be invalid. *@
+	<div class="@GetClasses()">
+		@Text
+		@ChildContent
+	</div>
+}
+else
+{
+	<li class="@GetClasses()">
+		@Text
+		@ChildContent
+	</li>
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepperItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Steppers/HxStepperItem.razor.cs
@@ -1,0 +1,74 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// A single step for <see cref="HxStepper"/>.
+/// The step number is rendered automatically by Bootstrap (CSS counter).<br />
+/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxStepper">https://havit.blazor.eu/components/HxStepper</see>
+/// </summary>
+public partial class HxStepperItem
+{
+	/// <summary>
+	/// Step label.
+	/// </summary>
+	[Parameter] public string Text { get; set; }
+
+	/// <summary>
+	/// Content of the step (an alternative to <see cref="Text"/> which allows complex content,
+	/// such as descriptions, helper messages, status indicators, badges, or other decorative elements).
+	/// </summary>
+	[Parameter] public RenderFragment ChildContent { get; set; }
+
+	/// <summary>
+	/// Link of the step. When set, the item renders as an anchor element
+	/// (and the whole stepper renders as a <c>div</c> instead of an ordered list).
+	/// </summary>
+	[Parameter] public string Href { get; set; }
+
+	/// <summary>
+	/// Set to <c>true</c> for completed steps and the current step (highlights the step number and the connecting line).
+	/// Bootstrap automatically renders the connecting line following the last active step in the inactive color.
+	/// </summary>
+	[Parameter] public bool Active { get; set; }
+
+	/// <summary>
+	/// Theme color of the step (renders the <c>theme-*</c> class).
+	/// </summary>
+	[Parameter] public ThemeColor? Color { get; set; }
+
+	/// <summary>
+	/// Additional CSS class(es) for the step
+	/// (e.g. use <c>align-items-start</c> to align multi-line content with the step number).
+	/// </summary>
+	[Parameter] public string CssClass { get; set; }
+
+	[CascadingParameter] protected HxStepper StepperContainer { get; set; }
+
+	protected override void OnParametersSet()
+	{
+		base.OnParametersSet();
+
+		if (Href is not null)
+		{
+			StepperContainer?.RegisterAnchorItem();
+		}
+	}
+
+	private string GetClasses()
+	{
+		return CssClassHelper.Combine(
+			"stepper-item",
+			Active ? "active" : null,
+			GetColorCssClass(),
+			CssClass);
+	}
+
+	private string GetColorCssClass()
+	{
+		return Color switch
+		{
+			null => null,
+			ThemeColor.None => null,
+			_ => Color.Value.ToThemeCss()
+		};
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Steppers/StepperHorizontal.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Steppers/StepperHorizontal.cs
@@ -1,0 +1,44 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Responsive horizontal setting (breakpoint) for <see cref="HxStepper"/>.
+/// The responsive breakpoints are container query based (they react to the width of the containing element, not the viewport).
+/// Default is <see cref="StepperHorizontal.Never"/>.
+/// </summary>
+public enum StepperHorizontal
+{
+	/// <summary>
+	/// Never horizontal, always vertical.
+	/// </summary>
+	Never = 0,
+
+	/// <summary>
+	/// Horizontal for containers above the "small" breakpoint (<c>576px</c>).
+	/// </summary>
+	SmallUp,
+
+	/// <summary>
+	/// Horizontal for containers above the "medium" breakpoint (<c>768px</c>).
+	/// </summary>
+	MediumUp,
+
+	/// <summary>
+	/// Horizontal for containers above the "large" breakpoint (<c>1024px</c>).
+	/// </summary>
+	LargeUp,
+
+	/// <summary>
+	/// Horizontal for containers above the "extra-large" breakpoint (<c>1280px</c>).
+	/// </summary>
+	ExtraLargeUp,
+
+	/// <summary>
+	/// Horizontal for containers above the "2xl" breakpoint (<c>1536px</c>).
+	/// </summary>
+	XxlUp,
+
+	/// <summary>
+	/// Always horizontal, never vertical.
+	/// </summary>
+	Always
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Steppers/StepperSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Steppers/StepperSettings.cs
@@ -1,0 +1,27 @@
+﻿namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Settings for <see cref="HxStepper"/>.
+/// </summary>
+public record StepperSettings
+{
+	/// <summary>
+	/// Layout of the stepper items (vertical/horizontal, including the responsive breakpoint).
+	/// </summary>
+	public StepperHorizontal? Horizontal { get; set; }
+
+	/// <summary>
+	/// Theme color of the stepper (renders the <c>theme-*</c> class).
+	/// </summary>
+	public ThemeColor? Color { get; set; }
+
+	/// <summary>
+	/// When <c>true</c>, the stepper is wrapped in a scrollable <c>stepper-overflow</c> container.
+	/// </summary>
+	public bool? Overflow { get; set; }
+
+	/// <summary>
+	/// Additional CSS class(es) for the stepper.
+	/// </summary>
+	public string CssClass { get; set; }
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo.razor
@@ -1,0 +1,6 @@
+﻿<HxStepper>
+	<HxStepperItem Active="true" Text="Create account" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Alignment.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Alignment.razor
@@ -1,0 +1,31 @@
+﻿<HxStepper Horizontal="StepperHorizontal.Always" CssClass="mb-4">
+	<HxStepperItem Active="true" Text="Default stepper" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>
+
+<div class="text-center mb-4">
+	<HxStepper Horizontal="StepperHorizontal.Always">
+		<HxStepperItem Active="true" Text="Center stepper" />
+		<HxStepperItem Active="true" Text="Confirm email" />
+		<HxStepperItem Text="Update profile" />
+		<HxStepperItem Text="Finish" />
+	</HxStepper>
+</div>
+
+<div class="text-end mb-4">
+	<HxStepper Horizontal="StepperHorizontal.Always">
+		<HxStepperItem Active="true" Text="End stepper" />
+		<HxStepperItem Active="true" Text="Confirm email" />
+		<HxStepperItem Text="Update profile" />
+		<HxStepperItem Text="Finish" />
+	</HxStepper>
+</div>
+
+<HxStepper Horizontal="StepperHorizontal.Always" CssClass="w-100">
+	<HxStepperItem Active="true" Text="Full-width stepper" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Anchors.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Anchors.razor
@@ -1,0 +1,6 @@
+﻿<HxStepper>
+	<HxStepperItem Href="#" Active="true" Text="Create account" />
+	<HxStepperItem Href="#" Active="true" Text="Confirm email" />
+	<HxStepperItem Href="#" Color="ThemeColor.Secondary" Text="Update profile" />
+	<HxStepperItem Href="#" Color="ThemeColor.Secondary" Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Badges.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Badges.razor
@@ -1,0 +1,26 @@
+﻿<HxStepper Horizontal="StepperHorizontal.Always" CssClass="w-100">
+	<HxStepperItem Active="true" Color="ThemeColor.Success">
+		<div>
+			<div>Create account</div>
+			<HxBadge Color="ThemeColor.Success" Variant="BadgeVariant.Subtle">Complete</HxBadge>
+		</div>
+	</HxStepperItem>
+	<HxStepperItem Active="true" Color="ThemeColor.Success">
+		<div>
+			<div>Confirm email</div>
+			<HxBadge Color="ThemeColor.Success" Variant="BadgeVariant.Subtle">Complete</HxBadge>
+		</div>
+	</HxStepperItem>
+	<HxStepperItem Active="true" Color="ThemeColor.Primary">
+		<div>
+			<div>Update profile</div>
+			<HxBadge Color="ThemeColor.Primary" Variant="BadgeVariant.Subtle">In-progress</HxBadge>
+		</div>
+	</HxStepperItem>
+	<HxStepperItem Color="ThemeColor.Secondary">
+		<div>
+			<div>Finish</div>
+			<HxBadge Color="ThemeColor.Secondary" Variant="BadgeVariant.Subtle">Pending</HxBadge>
+		</div>
+	</HxStepperItem>
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Colors.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Colors.razor
@@ -1,0 +1,13 @@
+﻿<HxStepper Horizontal="StepperHorizontal.Always" CssClass="mb-4">
+	<HxStepperItem Active="true" Color="ThemeColor.Accent" Text="Create account" />
+	<HxStepperItem Text="Confirm email" />
+	<HxStepperItem Active="true" Color="ThemeColor.Success" Text="Update profile" />
+	<HxStepperItem Active="true" Color="ThemeColor.Danger" Text="Finish" />
+</HxStepper>
+
+<HxStepper Horizontal="StepperHorizontal.Always" Color="ThemeColor.Success">
+	<HxStepperItem Active="true" Text="Create account" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_ComplexContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_ComplexContent.razor
@@ -1,0 +1,26 @@
+﻿<HxStepper>
+	<HxStepperItem Active="true" CssClass="align-items-start">
+		<div class="pt-1">
+			<div class="fw-semibold">Create</div>
+			<small class="fg-3">Create an account.</small>
+		</div>
+	</HxStepperItem>
+	<HxStepperItem Active="true" CssClass="align-items-start">
+		<div class="pt-1">
+			<div class="fw-semibold">Confirm</div>
+			<small class="fg-3">Confirm your email.</small>
+		</div>
+	</HxStepperItem>
+	<HxStepperItem CssClass="align-items-start">
+		<div class="pt-1">
+			<div class="fw-semibold">Set-up</div>
+			<small class="fg-3">Configure your profile.</small>
+		</div>
+	</HxStepperItem>
+	<HxStepperItem CssClass="align-items-start">
+		<div class="pt-1">
+			<div class="fw-semibold">Finish</div>
+			<small class="fg-3">Welcome aboard!</small>
+		</div>
+	</HxStepperItem>
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Gap.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Gap.razor
@@ -1,0 +1,6 @@
+﻿<HxStepper style="--bs-stepper-gap: 3rem">
+	<HxStepperItem Active="true" Text="Create account" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Horizontal.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Horizontal.razor
@@ -1,0 +1,6 @@
+﻿<HxStepper Horizontal="StepperHorizontal.Always">
+	<HxStepperItem Active="true" Text="Create account" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Overflow.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Overflow.razor
@@ -1,0 +1,8 @@
+﻿<HxStepper Horizontal="StepperHorizontal.Always" Overflow="true">
+	<HxStepperItem Active="true" Text="Create account" />
+	<HxStepperItem Active="true" Text="Verify email address" />
+	<HxStepperItem Text="Complete profile setup" />
+	<HxStepperItem Text="Add payment method" />
+	<HxStepperItem Text="Review and confirm" />
+	<HxStepperItem Text="Finish onboarding" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Responsive.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_Responsive.razor
@@ -1,0 +1,6 @@
+﻿<HxStepper Horizontal="StepperHorizontal.MediumUp">
+	<HxStepperItem Active="true" Text="Create account" />
+	<HxStepperItem Active="true" Text="Confirm email" />
+	<HxStepperItem Text="Update profile" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_States.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Demo_States.razor
@@ -1,0 +1,6 @@
+﻿<HxStepper Horizontal="StepperHorizontal.Always">
+	<HxStepperItem Active="true" Text="Completed step" />
+	<HxStepperItem Active="true" Text="Current step" />
+	<HxStepperItem Text="Step to be done" />
+	<HxStepperItem Text="Finish" />
+</HxStepper>

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Documentation.razor
@@ -1,0 +1,74 @@
+﻿@attribute [Route("/components/" + nameof(HxStepper))]
+
+<ApiDoc Type="typeof(HxStepper)">
+	<DocHeading Title="Basic usage" />
+	<p>
+		The stepper is built with CSS only, there is no step-switching logic included (wire up your own state).
+		By default, the steps are displayed vertically. The step numbers are rendered automatically (CSS counter).
+	</p>
+	<Demo Type="typeof(HxStepper_Demo)" Tabs="false" />
+
+	<DocHeading Title="Step states" />
+	<p>
+		Set <code>Active="true"</code> on completed steps and the current step (highlights the step number and the connecting line).
+		Bootstrap automatically renders the connecting line following the last active step (i.e. after the current step) in the inactive color.
+		Steps to be done are left in the default state.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_States)" />
+
+	<DocHeading Title="Horizontal" />
+	<p>Use <code>Horizontal="StepperHorizontal.Always"</code> to lay out the steps horizontally.</p>
+	<Demo Type="typeof(HxStepper_Demo_Horizontal)" />
+
+	<DocHeading Title="Responsive" Level="3" />
+	<p>
+		The stepper can be made horizontal at a specific breakpoint, e.g. <code>Horizontal="StepperHorizontal.MediumUp"</code>.
+		The responsive classes are container query based (they react to the width of the containing element, not the viewport);
+		the required <code>contains-inline</code> parent element is rendered by the component automatically.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_Responsive)" />
+
+	<DocHeading Title="Gap" />
+	<p>Customize the gap between the steps by overriding the <code>--bs-stepper-gap</code> CSS variable.</p>
+	<Demo Type="typeof(HxStepper_Demo_Gap)" />
+
+	<DocHeading Title="Colors" />
+	<p>
+		Use the <code>Color</code> parameter on individual items to set the theme color of the active steps.
+		Setting <code>Color</code> on the whole <code>HxStepper</code> applies the theme to all active steps.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_Colors)" />
+
+	<DocHeading Title="Overflow" />
+	<p>
+		Set <code>Overflow="true"</code> to wrap the stepper in a <code>stepper-overflow</code> container
+		which enables horizontal scrolling when the stepper overflows its parent.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_Overflow)" />
+
+	<DocHeading Title="Complex content" />
+	<p>
+		Use the item content to provide more context within each step, such as descriptions, helper messages, or status indicators.
+		Add the <code>align-items-start</code> CSS class to align multi-line content with the step number.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_ComplexContent)" />
+	<p>Mix with other components, like badges, and theme colors to create a more unique stepper.</p>
+	<Demo Type="typeof(HxStepper_Demo_Badges)" />
+
+	<DocHeading Title="Alignment" />
+	<p>
+		Use text alignment utilities on a wrapping element to align a horizontal stepper (the stepper uses <code>display: inline-grid</code>).
+		Apply <code>CssClass="w-100"</code> to make the stepper full width&mdash;the steps are stretched to fill the available space.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_Alignment)" />
+
+	<DocHeading Title="With anchors" />
+	<p>
+		Set <code>Href</code> on the items to build a stepper which links across multiple pages.
+		The items render as anchor elements (and the stepper renders as a <code>div</code> instead of an ordered list).
+		Use <code>Color="ThemeColor.Secondary"</code> for quick link color control of the steps to be done.
+	</p>
+	<Demo Type="typeof(HxStepper_Demo_Anchors)" />
+</ApiDoc>
+
+<ApiDoc Type="typeof(HxStepperItem)" />

--- a/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
+++ b/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
@@ -96,6 +96,7 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/components/HxSmartTextArea", "HxSmartTextArea", "autocompletions suggest intellisense typeahead ai gpt artificial intelligence"),
 		new("/components/HxSmartComboBox", "HxSmartComboBox", "autocomplete search typeahead select suggest ai artificial intelligence autosuggest"),
 		new("/components/HxSpinner", "HxSpinner", "loading progress placeholder skeleton"),
+		new("/components/HxStepper", "HxStepper", "wizard steps progress timeline workflow"),
 		new("/components/HxSubmit#HxSubmit", "HxSubmit", "send form button"),
 		new("/components/HxSwitch", "HxSwitch", "hxinputswitch hxradiobutton checkbox"),
 		new("/components/HxTabPanel", "HxTabPanel", "page tabs"),
@@ -149,6 +150,7 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/types/RadioButtonListSettings", "RadioButtonList Settings", "defaults", DefaultsLevel),
 		new("/types/SelectSettings", "Select Settings", "defaults", DefaultsLevel),
 		new("/types/SearchBoxSettings", "SearchBox Settings", "defaults", DefaultsLevel),
+		new("/types/StepperSettings", "Stepper Settings", "defaults", DefaultsLevel),
 
 		// Enums
 
@@ -187,6 +189,7 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/types/PlaceholderSize", "PlaceholderSize", "enum", EnumsLevel),
 		new("/types/SpinnerSize", "SpinnerSize", "enum", EnumsLevel),
 		new("/types/SpinnerType", "SpinnerType", "enum", EnumsLevel),
+		new("/types/StepperHorizontal", "StepperHorizontal", "enum", EnumsLevel),
 		new("/types/ThemeColor", "ThemeColor", "enum", EnumsLevel),
 		new("/types/ToastContainerPosition", "ToastContainerPosition", "enum", EnumsLevel),
 		new("/types/PopoverPlacement", "PopoverPlacement", "enum", EnumsLevel),

--- a/Havit.Blazor.Documentation/Shared/Sidebar.razor
+++ b/Havit.Blazor.Documentation/Shared/Sidebar.razor
@@ -61,6 +61,7 @@
             <HxSidebarItem Href="@($"/components/{nameof(HxSpinner)}")" Text="@nameof(HxSpinner)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxProgress)}")" Text="@nameof(HxProgress)" />
             <HxSidebarItem Href="@($"/components/{nameof(HxProgressIndicator)}")" Text="@nameof(HxProgressIndicator)" />
+            <HxSidebarItem Href="@($"/components/{nameof(HxStepper)}")" Text="@nameof(HxStepper)" />
         </HxSidebarItem>
 
         <HxSidebarItem Text="Data & Grid" Icon="BootstrapIcon.Table">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -11343,6 +11343,199 @@
             Represents a growing spinner. For more information, see: <see href="https://getbootstrap.com/docs/5.3/components/spinners/#growing-spinner">https://getbootstrap.com/docs/5.3/components/spinners/#growing-spinner</see>
             </summary>
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxStepper">
+            <summary>
+            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/stepper/">Bootstrap Stepper</see> component (new in Bootstrap 6).<br />
+            Displays progress through a multi-step workflow (wizards, timelines, step-by-step progress bars) as a sequence of numbered steps (<see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem"/>s).
+            The component is CSS-only, there is no step-switching logic (wire up your own state).<br />
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxStepper">https://havit.blazor.eu/components/HxStepper</see>
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Defaults">
+            <summary>
+            Application-wide defaults for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepper"/> and derived components.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxStepper.GetDefaults">
+            <summary>
+            Returns application-wide defaults for the component.
+            Enables overriding defaults in descendants (use a separate set of defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Settings">
+            <summary>
+            Set of settings to be applied to the component instance (overrides <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Defaults"/>, overridden by individual parameters).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxStepper.GetSettings">
+            <summary>
+            Returns an optional set of component settings.
+            </summary>
+            <remarks>
+            Similar to <see cref="M:Havit.Blazor.Components.Web.Bootstrap.HxStepper.GetDefaults"/>, enables defining wider <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Settings"/> in component descendants (by returning a derived settings class).
+            </remarks>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.ChildContent">
+            <summary>
+            Content of the stepper (<see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem"/>s).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Horizontal">
+            <summary>
+            Changes the layout of the stepper items from vertical to horizontal, including the responsive breakpoint
+            (Bootstrap 6 responsive <c>{breakpoint}:stepper-horizontal</c> classes are container query based,
+            the component renders the required <c>contains-inline</c> wrapper automatically).
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.Never"/> (vertical stepper).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Color">
+            <summary>
+            Theme color of the stepper (renders the <c>theme-*</c> class), applies to all active items.
+            To color individual steps, use <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Color"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.Overflow">
+            <summary>
+            When <c>true</c>, the stepper is wrapped in a <c>stepper-overflow</c> container which enables horizontal scrolling
+            when the (horizontal) stepper overflows its parent. The default is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.CssClass">
+            <summary>
+            Additional CSS class(es) for the stepper.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.AdditionalAttributes">
+            <summary>
+            Additional attributes to be splatted onto an underlying HTML element
+            (e.g. use the <c>style</c> attribute to customize the gap by overriding the <c>--bs-stepper-gap</c> CSS variable).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.HasAnchorItems">
+            <summary>
+            Indicates whether any of the items is rendered as an anchor (has <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Href"/> set).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxStepper.RegisterAnchorItem">
+            <summary>
+            Called by <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem"/> with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Href"/> set.
+            Anchor items cannot be nested in an ordered list, so the stepper re-renders as a <c>div</c> element.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepper.RenderContainsInlineWrapper">
+            <summary>
+            Responsive horizontal steppers use container queries, which require a <c>contains-inline</c> parent element
+            (when the <c>stepper-overflow</c> wrapper is rendered, it establishes the query container itself).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem">
+            <summary>
+            A single step for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepper"/>.
+            The step number is rendered automatically by Bootstrap (CSS counter).<br />
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxStepper">https://havit.blazor.eu/components/HxStepper</see>
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Text">
+            <summary>
+            Step label.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.ChildContent">
+            <summary>
+            Content of the step (an alternative to <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Text"/> which allows complex content,
+            such as descriptions, helper messages, status indicators, badges, or other decorative elements).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Href">
+            <summary>
+            Link of the step. When set, the item renders as an anchor element
+            (and the whole stepper renders as a <c>div</c> instead of an ordered list).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Active">
+            <summary>
+            Set to <c>true</c> for completed steps and the current step (highlights the step number and the connecting line).
+            Bootstrap automatically renders the connecting line following the last active step in the inactive color.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.Color">
+            <summary>
+            Theme color of the step (renders the <c>theme-*</c> class).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxStepperItem.CssClass">
+            <summary>
+            Additional CSS class(es) for the step
+            (e.g. use <c>align-items-start</c> to align multi-line content with the step number).
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal">
+            <summary>
+            Responsive horizontal setting (breakpoint) for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepper"/>.
+            The responsive breakpoints are container query based (they react to the width of the containing element, not the viewport).
+            Default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.Never"/>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.Never">
+            <summary>
+            Never horizontal, always vertical.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.SmallUp">
+            <summary>
+            Horizontal for containers above the "small" breakpoint (<c>576px</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.MediumUp">
+            <summary>
+            Horizontal for containers above the "medium" breakpoint (<c>768px</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.LargeUp">
+            <summary>
+            Horizontal for containers above the "large" breakpoint (<c>1024px</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.ExtraLargeUp">
+            <summary>
+            Horizontal for containers above the "extra-large" breakpoint (<c>1280px</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.XxlUp">
+            <summary>
+            Horizontal for containers above the "2xl" breakpoint (<c>1536px</c>).
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.StepperHorizontal.Always">
+            <summary>
+            Always horizontal, never vertical.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.StepperSettings">
+            <summary>
+            Settings for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxStepper"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.StepperSettings.Horizontal">
+            <summary>
+            Layout of the stepper items (vertical/horizontal, including the responsive breakpoint).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.StepperSettings.Color">
+            <summary>
+            Theme color of the stepper (renders the <c>theme-*</c> class).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.StepperSettings.Overflow">
+            <summary>
+            When <c>true</c>, the stepper is wrapped in a scrollable <c>stepper-overflow</c> container.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.StepperSettings.CssClass">
+            <summary>
+            Additional CSS class(es) for the stepper.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxTab">
             <summary>
             Single tab for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxTabPanel"/>.


### PR DESCRIPTION
Fixes #1460

New `HxStepper` + `HxStepperItem` components wrapping Bootstrap 6's CSS-only **Stepper** (22 files, +983 lines, purely additive). No JS, no step-switching logic — users wire their own state, per the upstream contract.

## API
- **HxStepper**: `Horizontal` (`StepperHorizontal`: Never/SmallUp/…/Always — mirrors `ListGroupHorizontal`, vertical default per upstream), `Color` (`ThemeColor?` → `theme-*`), `Overflow` (wraps in `.stepper-overflow`), `CssClass`, `AdditionalAttributes`, full `Settings`/`Defaults` pattern. Responsive breakpoints automatically render the `contains-inline` wrapper Bootstrap's container queries require (skipped when the overflow wrapper already establishes the container).
- **HxStepperItem**: `Text`/`ChildContent`, `Href`, `Active`, `Color`, `CssClass`.
- Semantic-markup handling: the stepper renders `<ol>`/`<li>` normally, but when any item has `Href` it renders `<div>`/`<a>` instead (anchor-in-list is invalid HTML) — items register with the cascading parent à la `HxBreadcrumb`.

## Upstream deviations (deliberate, documented in the agent-of-record notes)
- No `disabled`/`completed` item states — the upstream SCSS only defines `.active` (completed = active via the `:has()` connector rule; the docs demo explains this).
- Upstream's `.stepper-vertical` class doesn't exist in the compiled CSS (vertical is default) — omitted.

## Docs & tests
- Documentation page with 11 live demos (basic, states, horizontal, responsive, gap, colors, overflow, complex content, badges, alignment, anchors), registered in sidebar + catalog.
- 12 bUnit tests / 16 cases.

## Verification
Library builds with `-warnaserror`; **485/485** unit tests and **363/363** documentation tests pass locally (net10.0; CI covers net8/net9).

Note: this PR and #1489 both append to the docs sidebar/catalog registration lists — whichever merges second may need a trivial conflict resolution, which I'll handle.

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_