### PR TITLE
HxSelect: opt-in client-side filtering rendering the Bootstrap 6 Combobox markup

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSelectFilteringTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSelectFilteringTests.cs
@@ -1,0 +1,196 @@
+﻿using System.Linq.Expressions;
+
+namespace Havit.Blazor.Components.Web.Bootstrap.Tests.Forms;
+
+public class HxSelectFilteringTests : BunitTestBase
+{
+	private IRenderedComponent<HxSelect<string, string>> RenderSelect(List<string> items, Action<string> valueChanged = null, string value = null, Func<string, string, bool> filterPredicate = null, string nullText = null, bool? nullable = null)
+	{
+		Expression<Func<string>> valueExpression = () => value;
+
+		return RenderComponent<HxSelect<string, string>>(parameters =>
+		{
+			parameters
+				.Add(p => p.Data, items)
+				.Add(p => p.Value, value)
+				.Add(p => p.ValueChanged, v => valueChanged?.Invoke(v))
+				.Add(p => p.ValueExpression, valueExpression)
+				.Add(p => p.AllowFiltering, true)
+				.Add(p => p.AutoSort, false);
+
+			if (filterPredicate is not null)
+			{
+				parameters.Add(p => p.FilterPredicate, filterPredicate);
+			}
+			if (nullText is not null)
+			{
+				parameters.Add(p => p.NullText, nullText);
+			}
+			if (nullable is not null)
+			{
+				parameters.Add(p => p.Nullable, nullable);
+			}
+		});
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_RendersComboboxMarkup()
+	{
+		// Arrange + Act
+		var cut = RenderSelect(new List<string> { "Apple", "Banana", "Cherry" });
+
+		// Assert — no native select is rendered
+		Assert.Empty(cut.FindAll("select"));
+
+		// Assert — combobox toggle (button) with the value and the caret
+		var toggle = cut.Find("button.combobox-toggle");
+		Assert.Contains("form-control", toggle.ClassList);
+		Assert.Equal("listbox", toggle.GetAttribute("aria-haspopup"));
+		Assert.Equal("false", toggle.GetAttribute("aria-expanded"));
+		Assert.Equal("menu", toggle.GetAttribute("data-bs-toggle"));
+		cut.Find("button.combobox-toggle .combobox-value");
+		cut.Find("button.combobox-toggle svg.combobox-caret");
+
+		// Assert — menu with the filter input and the items
+		cut.Find(".menu .combobox-search input.combobox-search-input");
+		var options = cut.FindAll(".menu .menu-item[role='option']");
+		Assert.Equal(4, options.Count); // null item + 3 items
+		Assert.Contains(options, o => o.TextContent.Contains("Apple"));
+		Assert.Contains(options, o => o.TextContent.Contains("Banana"));
+		Assert.Contains(options, o => o.TextContent.Contains("Cherry"));
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_FilterNarrowsItems()
+	{
+		// Arrange
+		var cut = RenderSelect(new List<string> { "Apple", "Banana", "Cherry" });
+
+		// Act
+		cut.Find(".combobox-search-input").Input("ban");
+
+		// Assert — only "Banana" remains (+ the null item which is not filtered)
+		var options = cut.FindAll(".menu .menu-item[role='option']");
+		Assert.Equal(2, options.Count);
+		Assert.Contains(options, o => o.TextContent.Contains("Banana"));
+		Assert.DoesNotContain(options, o => o.TextContent.Contains("Apple"));
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_NoFilterResults_RendersEmptyResultText()
+	{
+		// Arrange
+		var cut = RenderSelect(new List<string> { "Apple", "Banana", "Cherry" });
+
+		// Act
+		cut.Find(".combobox-search-input").Input("xyz");
+
+		// Assert
+		cut.Find(".menu .combobox-no-results");
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_SelectionSetsValueAndClosesMenu()
+	{
+		// Arrange
+		string selectedValue = null;
+		var cut = RenderSelect(new List<string> { "Apple", "Banana", "Cherry" }, v => selectedValue = v);
+
+		// Act — click the "Banana" item
+		var bananaItem = cut.FindAll(".menu .menu-item[role='option']").Single(o => o.TextContent.Contains("Banana"));
+		bananaItem.Click();
+
+		// Assert
+		Assert.Equal("Banana", selectedValue);
+		Assert.Equal("false", cut.Find("button.combobox-toggle").GetAttribute("aria-expanded"));
+		Assert.DoesNotContain("show", cut.Find(".menu").ClassList);
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_SelectedItem_RendersSelectedStateAndToggleText()
+	{
+		// Arrange + Act
+		var cut = RenderSelect(new List<string> { "Apple", "Banana", "Cherry" }, value: "Banana");
+
+		// Assert — the toggle displays the selected item text (not the placeholder styling)
+		var toggleValue = cut.Find("button.combobox-toggle .combobox-value");
+		Assert.Equal("Banana", toggleValue.TextContent.Trim());
+		Assert.DoesNotContain("combobox-placeholder", toggleValue.ClassList);
+
+		// Assert — the selected item is marked
+		var selectedItems = cut.FindAll(".menu .menu-item.selected[aria-selected='true']");
+		var selectedItem = Assert.Single(selectedItems);
+		Assert.Contains("Banana", selectedItem.TextContent);
+		Assert.NotNull(selectedItem.QuerySelector("svg.menu-item-check"));
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_NullItem_RenderedFirstAndSelectsNull()
+	{
+		// Arrange
+		string selectedValue = "Banana";
+		var cut = RenderSelect(new List<string> { "Apple", "Banana", "Cherry" }, v => selectedValue = v, value: "Banana", nullable: true, nullText: "-select fruit-");
+
+		// Assert — the null item is rendered first
+		var options = cut.FindAll(".menu .menu-item[role='option']");
+		Assert.Equal(4, options.Count);
+		Assert.Equal("-select fruit-", options[0].TextContent.Trim());
+
+		// Act — select the null item
+		options[0].Click();
+
+		// Assert
+		Assert.Null(selectedValue);
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_NoSelection_RendersNullTextAsPlaceholder()
+	{
+		// Arrange + Act
+		var cut = RenderSelect(new List<string> { "Apple", "Banana" }, nullable: true, nullText: "-select fruit-");
+
+		// Assert
+		var toggleValue = cut.Find("button.combobox-toggle .combobox-value");
+		Assert.Equal("-select fruit-", toggleValue.TextContent.Trim());
+		Assert.Contains("combobox-placeholder", toggleValue.ClassList);
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_FilterPredicateOverride_IsApplied()
+	{
+		// Arrange — custom predicate filtering by the last character
+		var cut = RenderSelect(
+			new List<string> { "Apple", "Banana", "Cherry" },
+			filterPredicate: (item, filter) => item.EndsWith(filter, StringComparison.OrdinalIgnoreCase));
+
+		// Act
+		cut.Find(".combobox-search-input").Input("y");
+
+		// Assert — only "Cherry" matches the custom predicate
+		var options = cut.FindAll(".menu .menu-item[role='option']");
+		Assert.Equal(2, options.Count); // null item + Cherry
+		Assert.Contains(options, o => o.TextContent.Contains("Cherry"));
+		Assert.DoesNotContain(options, o => o.TextContent.Contains("Banana"));
+	}
+
+	[Fact]
+	public void HxSelect_AllowFilteringNotSet_RendersNativeSelect()
+	{
+		// Arrange
+		string selectedValue = null;
+		Expression<Func<string>> valueExpression = () => selectedValue;
+
+		// Act
+		var cut = RenderComponent<HxSelect<string, string>>(parameters => parameters
+			.Add(p => p.Data, new List<string> { "Apple", "Banana" })
+			.Add(p => p.Value, selectedValue)
+			.Add(p => p.ValueChanged, value => selectedValue = value)
+			.Add(p => p.ValueExpression, valueExpression)
+			.Add(p => p.Nullable, true)
+		);
+
+		// Assert — the native select is rendered, no combobox markup
+		cut.Find("select");
+		Assert.Empty(cut.FindAll(".combobox-toggle"));
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelect.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelect.cs
@@ -102,4 +102,78 @@ public class HxSelect<TValue, TItem> : HxSelectBase<TValue, TItem>
 		get => ItemDisabledSelectorImpl;
 		set => ItemDisabledSelectorImpl = value;
 	}
+
+	/// <summary>
+	/// Enables filtering capabilities.
+	/// When enabled, the component renders the Bootstrap Combobox (a toggle with a menu containing a filter input) instead of the native <c>select</c> element.
+	/// The default is <c>false</c>.
+	/// </summary>
+	[Parameter]
+	public bool? AllowFiltering
+	{
+		get => AllowFilteringImpl;
+		set => AllowFilteringImpl = value;
+	}
+
+	/// <summary>
+	/// Defines a custom filtering predicate to apply to the list of items.
+	/// If not specified, the default behavior filters items based on whether the item text (obtained via <see cref="TextSelector"/>) contains the filter query string.
+	/// </summary>
+	[Parameter]
+	public Func<TItem, string, bool> FilterPredicate
+	{
+		get => FilterPredicateImpl;
+		set => FilterPredicateImpl = value;
+	}
+
+	/// <summary>
+	/// When enabled, the filter will be cleared when the menu is closed.
+	/// The default is <c>true</c>.
+	/// </summary>
+	[Parameter]
+	public bool? ClearFilterOnHide
+	{
+		get => ClearFilterOnHideImpl;
+		set => ClearFilterOnHideImpl = value;
+	}
+
+	/// <summary>
+	/// Template that defines what should be rendered in case of empty filtered items.
+	/// </summary>
+	[Parameter]
+	public RenderFragment FilterEmptyResultTemplate
+	{
+		get => FilterEmptyResultTemplateImpl;
+		set => FilterEmptyResultTemplateImpl = value;
+	}
+
+	/// <summary>
+	/// Text to display when the filtered results list is empty and when not using <see cref="FilterEmptyResultTemplate"/>.
+	/// </summary>
+	[Parameter]
+	public string FilterEmptyResultText
+	{
+		get => FilterEmptyResultTextImpl;
+		set => FilterEmptyResultTextImpl = value;
+	}
+
+	/// <summary>
+	/// Icon displayed in filter input for searching the filter.
+	/// </summary>
+	[Parameter]
+	public IconBase FilterSearchIcon
+	{
+		get => FilterSearchIconImpl;
+		set => FilterSearchIconImpl = value;
+	}
+
+	/// <summary>
+	/// Icon displayed in filter input for clearing the filter.
+	/// </summary>
+	[Parameter]
+	public IconBase FilterClearIcon
+	{
+		get => FilterClearIconImpl;
+		set => FilterClearIconImpl = value;
+	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelect.nongeneric.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelect.nongeneric.cs
@@ -12,6 +12,10 @@ public sealed class HxSelect
 
 	static HxSelect()
 	{
-		Defaults = new SelectSettings();
+		Defaults = new SelectSettings()
+		{
+			AllowFiltering = false,
+			ClearFilterOnHide = true
+		};
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelectBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxSelectBase.cs
@@ -134,6 +134,69 @@ public abstract class HxSelectBase<TValue, TItem> : HxInputBaseWithInputGroups<T
 	/// </summary>
 	protected Func<TItem, bool> ItemDisabledSelectorImpl { get; set; }
 
+	/// <summary>
+	/// Enables filtering capabilities (renders the Bootstrap Combobox instead of the native <c>select</c>).
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected bool? AllowFilteringImpl { get; set; }
+
+	/// <summary>
+	/// Effective value of the filtering capabilities (<see cref="AllowFilteringImpl"/> property, settings, defaults).
+	/// </summary>
+	protected bool AllowFilteringEffective => AllowFilteringImpl ?? GetSettings()?.AllowFiltering ?? GetDefaults().AllowFiltering;
+
+	/// <summary>
+	/// Defines a custom filtering predicate to apply to the list of items.
+	/// If not specified, the default behavior filters items based on whether the item text (obtained via <see cref="TextSelectorImpl"/>) contains the filter query string.
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected Func<TItem, string, bool> FilterPredicateImpl { get; set; }
+
+	/// <summary>
+	/// When enabled, the filter will be cleared when the menu is closed.
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected bool? ClearFilterOnHideImpl { get; set; }
+
+	/// <summary>
+	/// Effective value of clearing the filter when the menu is closed (<see cref="ClearFilterOnHideImpl"/> property, settings, defaults).
+	/// </summary>
+	protected bool ClearFilterOnHideEffective => ClearFilterOnHideImpl ?? GetSettings()?.ClearFilterOnHide ?? GetDefaults().ClearFilterOnHide;
+
+	/// <summary>
+	/// Template that defines what should be rendered in case of empty filtered items.
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected RenderFragment FilterEmptyResultTemplateImpl { get; set; }
+
+	/// <summary>
+	/// Text to display when the filtered results list is empty and when not using <see cref="FilterEmptyResultTemplateImpl"/>.
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected string FilterEmptyResultTextImpl { get; set; }
+
+	/// <summary>
+	/// Icon displayed in the filter input for searching the filter.
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected IconBase FilterSearchIconImpl { get; set; }
+
+	/// <summary>
+	/// Effective value of the filter search icon (<see cref="FilterSearchIconImpl"/> property, settings, defaults).
+	/// </summary>
+	protected IconBase FilterSearchIconEffective => FilterSearchIconImpl ?? GetSettings()?.FilterSearchIcon ?? GetDefaults().FilterSearchIcon;
+
+	/// <summary>
+	/// Icon displayed in the filter input for clearing the filter.
+	/// Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+	/// </summary>
+	protected IconBase FilterClearIconImpl { get; set; }
+
+	/// <summary>
+	/// Effective value of the filter clear icon (<see cref="FilterClearIconImpl"/> property, settings, defaults).
+	/// </summary>
+	protected IconBase FilterClearIconEffective => FilterClearIconImpl ?? GetSettings()?.FilterClearIcon ?? GetDefaults().FilterClearIcon;
+
 	/// <inheritdoc cref="HxInputBase{TValue}.EnabledEffective" />
 	protected override bool EnabledEffective => base.EnabledEffective && (_itemsToRender != null);
 
@@ -143,12 +206,19 @@ public abstract class HxSelectBase<TValue, TItem> : HxInputBaseWithInputGroups<T
 	/// </summary>
 	protected ElementReference InputElement { get; set; }
 
-	private protected override string CoreInputCssClass => "form-control";
+	private protected override string CoreInputCssClass => AllowFilteringEffective ? "form-control combobox-toggle" : "form-control";
+
+	/// <inheritdoc/>
+	protected override LabelValueRenderOrder RenderOrder =>
+		(AllowFilteringEffective && (LabelTypeEffective == Bootstrap.LabelType.Floating))
+			? LabelValueRenderOrder.ValueOnly // floating label is rendered inside the HxSelectInternal component
+			: base.RenderOrder;
 
 	private IEqualityComparer<TValue> _comparer = EqualityComparer<TValue>.Default;
 	private List<TItem> _itemsToRender;
 	private int _selectedItemIndex;
 	private string _chipValue;
+	private HxSelectInternal<TValue, TItem> _hxSelectInternalComponent;
 
 	/// <inheritdoc/>
 	protected override void BuildRenderInput(RenderTreeBuilder builder)
@@ -156,6 +226,12 @@ public abstract class HxSelectBase<TValue, TItem> : HxInputBaseWithInputGroups<T
 		_chipValue = null;
 
 		RefreshState();
+
+		if (AllowFilteringEffective)
+		{
+			BuildRenderInput_Combobox(builder);
+			return;
+		}
 
 		bool enabledEffective = EnabledEffective;
 
@@ -219,6 +295,54 @@ public abstract class HxSelectBase<TValue, TItem> : HxInputBaseWithInputGroups<T
 			}
 		}
 		builder.CloseElement();
+	}
+
+	/// <summary>
+	/// Renders the Bootstrap Combobox (used when filtering is enabled, <see cref="AllowFilteringEffective"/>).
+	/// </summary>
+	private void BuildRenderInput_Combobox(RenderTreeBuilder builder)
+	{
+		if ((_itemsToRender != null) && (_selectedItemIndex > -1))
+		{
+			_chipValue = SelectorHelpers.GetText(TextSelectorImpl, _itemsToRender[_selectedItemIndex]);
+		}
+
+		builder.OpenComponent<HxSelectInternal<TValue, TItem>>(100);
+		builder.AddAttribute(101, nameof(HxSelectInternal<TValue, TItem>.InputId), InputId);
+		builder.AddAttribute(102, nameof(HxSelectInternal<TValue, TItem>.InputCssClass), GetInputCssClassToRender());
+		builder.AddAttribute(103, nameof(HxSelectInternal<TValue, TItem>.InputSizeEffective), InputSizeEffective);
+		builder.AddAttribute(104, nameof(HxSelectInternal<TValue, TItem>.EnabledEffective), EnabledEffective);
+		builder.AddAttribute(105, nameof(HxSelectInternal<TValue, TItem>.LabelTypeEffective), LabelTypeEffective);
+		builder.AddAttribute(106, nameof(HxSelectInternal<TValue, TItem>.FormValueComponent), this);
+		builder.AddAttribute(107, nameof(HxSelectInternal<TValue, TItem>.ItemsToRender), _itemsToRender);
+		builder.AddAttribute(108, nameof(HxSelectInternal<TValue, TItem>.SelectedItemIndex), _selectedItemIndex);
+		builder.AddAttribute(109, nameof(HxSelectInternal<TValue, TItem>.SelectedItemIndexChanged), EventCallback.Factory.Create<int>(this, HandleComboboxSelectedItemIndexChanged));
+		builder.AddAttribute(110, nameof(HxSelectInternal<TValue, TItem>.NullableEffective), NullableEffective);
+		builder.AddAttribute(111, nameof(HxSelectInternal<TValue, TItem>.NullText), NullTextImpl);
+		builder.AddAttribute(112, nameof(HxSelectInternal<TValue, TItem>.NullDataText), NullDataTextImpl);
+		builder.AddAttribute(113, nameof(HxSelectInternal<TValue, TItem>.TextSelector), TextSelectorImpl);
+		builder.AddAttribute(114, nameof(HxSelectInternal<TValue, TItem>.ItemDisabledSelector), ItemDisabledSelectorImpl);
+		builder.AddAttribute(115, nameof(HxSelectInternal<TValue, TItem>.FilterPredicate), FilterPredicateImpl);
+		builder.AddAttribute(116, nameof(HxSelectInternal<TValue, TItem>.ClearFilterOnHide), ClearFilterOnHideEffective);
+		builder.AddAttribute(117, nameof(HxSelectInternal<TValue, TItem>.FilterEmptyResultTemplate), FilterEmptyResultTemplateImpl);
+		builder.AddAttribute(118, nameof(HxSelectInternal<TValue, TItem>.FilterEmptyResultText), FilterEmptyResultTextImpl);
+		builder.AddAttribute(119, nameof(HxSelectInternal<TValue, TItem>.FilterSearchIcon), FilterSearchIconEffective);
+		builder.AddAttribute(120, nameof(HxSelectInternal<TValue, TItem>.FilterClearIcon), FilterClearIconEffective);
+
+		builder.AddMultipleAttributes(200, AdditionalAttributes);
+
+		builder.AddComponentReferenceCapture(300, r => _hxSelectInternalComponent = (HxSelectInternal<TValue, TItem>)r);
+
+		builder.CloseComponent();
+	}
+
+	/// <summary>
+	/// Handles the item selection in the combobox rendering (<see cref="AllowFilteringEffective"/>).
+	/// Receives the index of the selected item within the sorted items (<c>-1</c> for the <c>null</c> item) and sets the <c>CurrentValue</c>.
+	/// </summary>
+	private void HandleComboboxSelectedItemIndexChanged(int selectedItemIndex)
+	{
+		CurrentValueAsString = selectedItemIndex.ToString();
 	}
 
 	private void RefreshState()
@@ -288,6 +412,19 @@ public abstract class HxSelectBase<TValue, TItem> : HxInputBaseWithInputGroups<T
 	/// <summary>
 	/// Focuses the component.
 	/// </summary>
-	public async ValueTask FocusAsync() => await InputElement.FocusOrThrowAsync(this);
+	public async ValueTask FocusAsync()
+	{
+		if (AllowFilteringEffective)
+		{
+			if (_hxSelectInternalComponent == null)
+			{
+				throw new InvalidOperationException($"[{GetType().Name}] Unable to focus. The component reference is not available. You are most likely calling the method too early. The first render must complete before calling this method.");
+			}
+			await _hxSelectInternalComponent.FocusAsync();
+			return;
+		}
+
+		await InputElement.FocusOrThrowAsync(this);
+	}
 
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor
@@ -1,0 +1,104 @@
+﻿@namespace Havit.Blazor.Components.Web.Bootstrap.Internal
+@typeparam TValue
+@typeparam TItem
+
+<div class="@CssClassHelper.Combine("hx-select", (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null)">
+
+	<button @ref="_toggleElementReference"
+			type="button"
+			id="@InputId"
+			class="@InputCssClass"
+			disabled="@(!EnabledEffective)"
+			aria-haspopup="listbox"
+			aria-expanded="@(_isShown ? "true" : "false")"
+			data-bs-toggle="@(EnabledEffective ? "menu" : null)"
+			@attributes="this.AdditionalAttributes">
+		<span class="@CssClassHelper.Combine("combobox-value", ShowPlaceholderStyle ? "combobox-placeholder" : null)">@GetToggleText()</span>
+		<svg class="combobox-caret" width="10" height="16" viewBox="0 0 10 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.46967 5.46967C0.762563 5.17678 1.23744 5.17678 1.53033 5.46967L5 8.93934L8.46967 5.46967C8.76256 5.17678 9.23744 5.17678 9.53033 5.46967C9.82322 5.76256 9.82322 6.23744 9.53033 6.53033L5.53033 10.5303C5.23744 10.8232 4.76256 10.8232 4.46967 10.5303L0.46967 6.53033C0.176777 6.23744 0.176777 5.76256 0.46967 5.46967Z" fill="currentcolor" /></svg>
+	</button>
+
+	@* The menu must always be rendered, otherwise it does not work after the disabled->enabled transition. *@
+	<div class="@CssClassHelper.Combine("menu", _isShown ? "show" : null)" role="listbox">
+		@if (EnabledEffective)
+		{
+			<div class="combobox-search hx-select-filter-input-wrapper">
+				<input @ref="_filterInputReference"
+					   id="@($"{InputId}_filter")"
+					   type="text"
+					   class="@CssClassHelper.Combine("form-control", "combobox-search-input", InputSizeEffective.AsFormControlCssClass())"
+					   autocomplete="off"
+					   spellcheck="false"
+					   value="@_filterText"
+					   @oninput="HandleFilterInputChanged"
+					   @onclick:stopPropagation
+					   onfocusin="this.select()" />
+
+				<div class="hx-select-filter-input-icon">
+					@if (string.IsNullOrEmpty(_filterText))
+					{
+						<HxIcon CssClass="hx-select-filter-input-icon-search" Icon="@FilterSearchIcon" />
+					}
+					else
+					{
+						<div role="button" @onclick="HandleClearIconClick" @onclick:stopPropagation>
+							<HxIcon CssClass="hx-select-filter-input-icon-clear" Icon="@FilterClearIcon" />
+						</div>
+					}
+				</div>
+			</div>
+
+			if (NullableEffective || (SelectedItemIndex == -1))
+			{
+				bool nullItemSelected = (SelectedItemIndex == -1);
+				<button type="button"
+						class="@CssClassHelper.Combine("menu-item", nullItemSelected ? "selected" : null)"
+						role="option"
+						aria-selected="@(nullItemSelected ? "true" : "false")"
+						@onclick="async () => await HandleItemClickAsync(-1)">
+					<span>@NullText</span>
+					<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16"><path d="m2 7 4 5 8-8" /></svg>
+				</button>
+			}
+
+			var filteredItemIndexes = GetFilteredItemIndexes();
+			if (filteredItemIndexes.Count == 0)
+			{
+				if (FilterEmptyResultTemplate is not null)
+				{
+					@FilterEmptyResultTemplate
+				}
+				else
+				{
+					<div class="combobox-no-results">@GetFilterEmptyResultText()</div>
+				}
+			}
+			else
+			{
+				foreach (int itemIndex in filteredItemIndexes)
+				{
+					int index = itemIndex; // capture for lambda
+					var item = ItemsToRender[index];
+					bool selected = (index == SelectedItemIndex);
+					bool disabled = SelectorHelpers.GetDisabled(ItemDisabledSelector, item);
+
+					<button @key="@index"
+							type="button"
+							class="@CssClassHelper.Combine("menu-item", selected ? "selected" : null)"
+							role="option"
+							aria-selected="@(selected ? "true" : "false")"
+							disabled="@disabled"
+							aria-disabled="@(disabled ? "true" : null)"
+							@onclick="async () => await HandleItemClickAsync(index)">
+						<span>@SelectorHelpers.GetText(TextSelector, item)</span>
+						<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16"><path d="m2 7 4 5 8-8" /></svg>
+					</button>
+				}
+			}
+		}
+	</div>
+
+	@if (LabelTypeEffective == LabelType.Floating)
+	{
+		<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
+	}
+</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor.cs
@@ -1,0 +1,229 @@
+﻿using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
+
+namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+public partial class HxSelectInternal<TValue, TItem> : IAsyncDisposable
+{
+	[Parameter] public string InputId { get; set; }
+
+	[Parameter] public string InputCssClass { get; set; }
+
+	[Parameter] public InputSize InputSizeEffective { get; set; }
+
+	[Parameter] public bool EnabledEffective { get; set; }
+
+	[Parameter] public LabelType LabelTypeEffective { get; set; }
+
+	[Parameter] public IFormValueComponent FormValueComponent { get; set; }
+
+	[Parameter] public List<TItem> ItemsToRender { get; set; }
+
+	/// <summary>
+	/// Index of the selected item within <see cref="ItemsToRender"/> (<c>-1</c> for no selection or the <c>null</c> item).
+	/// </summary>
+	[Parameter] public int SelectedItemIndex { get; set; }
+	[Parameter] public EventCallback<int> SelectedItemIndexChanged { get; set; }
+
+	[Parameter] public bool NullableEffective { get; set; }
+
+	[Parameter] public string NullText { get; set; }
+
+	[Parameter] public string NullDataText { get; set; }
+
+	[Parameter] public Func<TItem, string> TextSelector { get; set; }
+
+	[Parameter] public Func<TItem, bool> ItemDisabledSelector { get; set; }
+
+	[Parameter] public Func<TItem, string, bool> FilterPredicate { get; set; }
+
+	[Parameter] public bool ClearFilterOnHide { get; set; }
+
+	[Parameter] public RenderFragment FilterEmptyResultTemplate { get; set; }
+
+	[Parameter] public string FilterEmptyResultText { get; set; }
+
+	[Parameter] public IconBase FilterSearchIcon { get; set; }
+
+	[Parameter] public IconBase FilterClearIcon { get; set; }
+
+	/// <summary>
+	/// Additional attributes to be splatted onto an underlying HTML element.
+	/// </summary>
+	[Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+	[Inject] private IJSRuntime JSRuntime { get; set; }
+
+	[Inject] private IStringLocalizer<HxSelect> StringLocalizer { get; set; }
+
+	private bool ShowPlaceholderStyle => (ItemsToRender == null) || (SelectedItemIndex == -1);
+
+	private IJSObjectReference _jsModule;
+	private readonly DotNetObjectReference<HxSelectInternal<TValue, TItem>> _dotnetObjectReference;
+	private ElementReference _toggleElementReference;
+	private ElementReference _filterInputReference;
+	private bool _isShown;
+	private string _filterText = string.Empty;
+	private bool _disposed;
+
+	public HxSelectInternal()
+	{
+		_dotnetObjectReference = DotNetObjectReference.Create(this);
+	}
+
+	/// <inheritdoc cref="ComponentBase.OnAfterRenderAsync(bool)" />
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			await EnsureJsModuleAsync();
+			if (_disposed)
+			{
+				return;
+			}
+
+			await _jsModule.InvokeVoidAsync("initialize", _toggleElementReference, _dotnetObjectReference);
+		}
+	}
+
+	private async Task EnsureJsModuleAsync()
+	{
+		_jsModule ??= await JSRuntime.ImportHavitBlazorBootstrapModuleAsync(nameof(HxSelect));
+	}
+
+	private async Task HandleItemClickAsync(int index)
+	{
+		// The Bootstrap Menu closes the menu itself (a click on a menu-item with autoClose=true).
+		// We update the state proactively to keep the C#-owned state consistent (and to support environments where the JS has not been loaded).
+		_isShown = false;
+
+		if (index != SelectedItemIndex)
+		{
+			await SelectedItemIndexChanged.InvokeAsync(index);
+		}
+	}
+
+	private void HandleFilterInputChanged(ChangeEventArgs e)
+	{
+		_filterText = e.Value?.ToString() ?? string.Empty;
+	}
+
+	private void HandleClearIconClick()
+	{
+		_filterText = string.Empty;
+	}
+
+	private string GetToggleText()
+	{
+		if (ItemsToRender == null)
+		{
+			return NullDataText;
+		}
+
+		if (SelectedItemIndex > -1)
+		{
+			return SelectorHelpers.GetText(TextSelector, ItemsToRender[SelectedItemIndex]);
+		}
+
+		return NullText;
+	}
+
+	private List<int> GetFilteredItemIndexes()
+	{
+		if (ItemsToRender == null)
+		{
+			return new List<int>();
+		}
+
+		if (string.IsNullOrEmpty(_filterText))
+		{
+			return Enumerable.Range(0, ItemsToRender.Count).Where(i => ItemsToRender[i] != null).ToList();
+		}
+
+		var filterPredicate = FilterPredicate ?? DefaultFilterPredicate;
+		return Enumerable.Range(0, ItemsToRender.Count)
+			.Where(i => (ItemsToRender[i] != null) && filterPredicate(ItemsToRender[i], _filterText))
+			.ToList();
+
+		bool DefaultFilterPredicate(TItem item, string filter)
+		{
+			return string.IsNullOrEmpty(filter) || (SelectorHelpers.GetText(TextSelector, item)?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false);
+		}
+	}
+
+	private string GetFilterEmptyResultText()
+	{
+		return FilterEmptyResultText ?? StringLocalizer["FilterEmptyResultDefaultText"];
+	}
+
+	/// <summary>
+	/// Focuses the toggle.
+	/// </summary>
+	public async ValueTask FocusAsync()
+	{
+		if (EqualityComparer<ElementReference>.Default.Equals(_toggleElementReference, default))
+		{
+			throw new InvalidOperationException($"[{GetType().Name}] Unable to focus. The method must be called after first render.");
+		}
+		await _toggleElementReference.FocusAsync();
+	}
+
+	/// <summary>
+	/// Receives notification from JavaScript when the menu is shown.
+	/// </summary>
+	[JSInvokable("HxSelect_HandleJsShown")]
+	public async Task HandleJsShown()
+	{
+		_isShown = true;
+		StateHasChanged();
+
+		await _filterInputReference.FocusAsync();
+	}
+
+	/// <summary>
+	/// Receives notification from JavaScript when the menu is hidden.
+	/// </summary>
+	[JSInvokable("HxSelect_HandleJsHidden")]
+	public Task HandleJsHidden()
+	{
+		_isShown = false;
+
+		if (ClearFilterOnHide && (_filterText != string.Empty))
+		{
+			_filterText = string.Empty;
+		}
+
+		StateHasChanged();
+
+		return Task.CompletedTask;
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		await DisposeAsyncCore();
+	}
+
+	protected virtual async ValueTask DisposeAsyncCore()
+	{
+		_disposed = true;
+
+		if (_jsModule != null)
+		{
+			try
+			{
+				await _jsModule.InvokeVoidAsync("dispose", _toggleElementReference);
+				await _jsModule.DisposeAsync();
+			}
+			catch (JSDisconnectedException)
+			{
+				// NOOP
+			}
+			catch (TaskCanceledException)
+			{
+				// NOOP
+			}
+		}
+
+		_dotnetObjectReference?.Dispose();
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor.css
@@ -1,0 +1,22 @@
+﻿.hx-select-filter-input-wrapper {
+	position: relative;
+}
+
+.hx-select-filter-input-icon {
+	display: flex;
+	align-items: center;
+	margin-right: 1rem;
+	position: absolute;
+	top: 50%;
+	right: 0;
+	transform: translateY(-50%);
+	z-index: 5;
+}
+
+.form-control-sm ~ .hx-select-filter-input-icon {
+	font-size: .75rem;
+}
+
+.hx-select-filter-input-icon div[role="button"]:not(:hover) ::deep .hx-icon {
+	opacity: var(--hx-select-filter-input-icon-opacity, .25);
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/SelectSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/SelectSettings.cs
@@ -15,4 +15,23 @@ public record SelectSettings : InputSettings
 	/// </summary>
 	public LabelType? LabelType { get; set; }
 
+	/// <summary>
+	/// Enables filtering capabilities.
+	/// </summary>
+	public bool AllowFiltering { get; set; }
+
+	/// <summary>
+	/// When enabled, the filter will be cleared when the menu is closed.
+	/// </summary>
+	public bool ClearFilterOnHide { get; set; }
+
+	/// <summary>
+	/// Icon displayed in the filter input for searching the filter.
+	/// </summary>
+	public IconBase FilterSearchIcon { get; set; } = BootstrapIcon.Search;
+
+	/// <summary>
+	/// Icon displayed in the filter input for clearing the filter.
+	/// </summary>
+	public IconBase FilterClearIcon { get; set; } = BootstrapIcon.XLg;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.cs.resx
+++ b/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.cs.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterEmptyResultDefaultText" xml:space="preserve">
+    <value>Nic nenalezeno</value>
+  </data>
+</root>

--- a/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.de.resx
+++ b/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.de.resx
@@ -1,0 +1,17 @@
+﻿<root>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="FilterEmptyResultDefaultText" xml:space="preserve">
+		<value>Keine Ergebnisse</value>
+	</data>
+</root>

--- a/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.it-IT.resx
+++ b/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.it-IT.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterEmptyResultDefaultText" xml:space="preserve">
+    <value>Nessun risultato</value>
+  </data>
+</root>

--- a/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.resx
+++ b/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterEmptyResultDefaultText" xml:space="preserve">
+    <value>No results</value>
+  </data>
+</root>

--- a/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.uk.resx
+++ b/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.uk.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterEmptyResultDefaultText" xml:space="preserve">
+    <value>Результатів не знайдено</value>
+  </data>
+</root>

--- a/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.zh-CN.resx
+++ b/Havit.Blazor.Components.Web.Bootstrap/Resources/HxSelect.zh-CN.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterEmptyResultDefaultText" xml:space="preserve">
+    <value>没有结果</value>
+  </data>
+</root>

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxSelect.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxSelect.js
@@ -1,0 +1,34 @@
+﻿export function initialize(toggleElement, hxSelectDotnetObjectReference) {
+	if (!toggleElement) {
+		return;
+	}
+
+	toggleElement.hxSelectDotnetObjectReference = hxSelectDotnetObjectReference;
+	toggleElement.addEventListener('shown.bs.menu', handleMenuShown);
+	toggleElement.addEventListener('hidden.bs.menu', handleMenuHidden);
+
+	new bootstrap.Menu(toggleElement);
+}
+
+function handleMenuShown(event) {
+	event.currentTarget.hxSelectDotnetObjectReference.invokeMethodAsync('HxSelect_HandleJsShown');
+};
+
+function handleMenuHidden(event) {
+	event.currentTarget.hxSelectDotnetObjectReference.invokeMethodAsync('HxSelect_HandleJsHidden');
+};
+
+export function dispose(toggleElement) {
+	if (!toggleElement) {
+		return;
+	}
+
+	toggleElement.removeEventListener('shown.bs.menu', handleMenuShown);
+	toggleElement.removeEventListener('hidden.bs.menu', handleMenuHidden);
+	toggleElement.hxSelectDotnetObjectReference = null;
+
+	const menu = bootstrap.Menu.getInstance(toggleElement);
+	if (menu) {
+		menu.dispose();
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
@@ -146,6 +146,9 @@
 	--hx-list-layout-table-font-size: 								.875rem;
 	--hx-list-layout-header-gap:									.5rem;
 
+	/* HxSelect */
+	--hx-select-filter-input-icon-opacity: 						.25;
+
 	/* HxMultiSelect */
 	--hx-multi-select-background-color: 							var(--bs-body-bg);
 	--hx-multi-select-menu-height: 						300px;

--- a/Havit.Blazor.Documentation/Pages/Components/HxSelectDoc/HxSelect_Demo_CustomFiltering.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSelectDoc/HxSelect_Demo_CustomFiltering.razor
@@ -1,0 +1,37 @@
+﻿@inject IDemoDataService DemoDataService
+
+<HxSelect TItem="EmployeeDto"
+		  TValue="int?"
+		  Label="Employee"
+		  Data="data"
+		  @bind-Value="employeeId"
+		  TextSelector="@(employee => employee.Name)"
+		  ValueSelector="@(employee => employee.Id)"
+		  Nullable="true"
+		  NullText="-select employee-"
+		  NullDataText="Loading employees..."
+		  AllowFiltering="true"
+		  ClearFilterOnHide="false"
+		  FilterPredicate="IsRecordIncluded">
+	<FilterEmptyResultTemplate>
+		<div class="combobox-no-results"><HxIcon Icon="BootstrapIcon.EmojiFrown" /> No employees found</div>
+	</FilterEmptyResultTemplate>
+</HxSelect>
+
+<p class="mt-2">Selected employee ID: @employeeId</p>
+
+@code {
+	private IEnumerable<EmployeeDto> data;
+	private int? employeeId;
+
+	protected override async Task OnInitializedAsync()
+	{
+		data = await DemoDataService.GetAllEmployeesAsync();
+	}
+
+	private bool IsRecordIncluded(EmployeeDto employee, string filterQuery)
+	{
+		return employee.Name.Contains(filterQuery, StringComparison.OrdinalIgnoreCase)
+			|| employee.Email.Contains(filterQuery, StringComparison.OrdinalIgnoreCase);
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxSelectDoc/HxSelect_Demo_Filtering.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSelectDoc/HxSelect_Demo_Filtering.razor
@@ -1,0 +1,26 @@
+﻿@inject IDemoDataService DemoDataService
+
+<HxSelect TItem="EmployeeDto"
+		  TValue="int?"
+		  Label="Employee"
+		  Data="data"
+		  @bind-Value="employeeId"
+		  TextSelector="@(employee => employee.Name)"
+		  ValueSelector="@(employee => employee.Id)"
+		  Nullable="true"
+		  NullText="-select employee-"
+		  NullDataText="Loading employees..."
+		  AllowFiltering="true"
+		  FilterEmptyResultText="No employees found" />
+
+<p class="mt-2">Selected employee ID: @employeeId</p>
+
+@code {
+	private IEnumerable<EmployeeDto> data;
+	private int? employeeId;
+
+	protected override async Task OnInitializedAsync()
+	{
+		data = await DemoDataService.GetAllEmployeesAsync();
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxSelectDoc/HxSelect_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSelectDoc/HxSelect_Documentation.razor
@@ -6,6 +6,25 @@
     <Demo Type="typeof(HxSelect_Demo)" Tabs="false" />
 	<DocDemoDataServiceNote />
 
+	<DocHeading Title="Filtering" />
+	<p>
+		You can enable client-side filtering by setting <code>AllowFiltering="true"</code>.
+		Instead of the native <code>select</code> element, the component then renders the Bootstrap 6
+		<a href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/forms/combobox/">Combobox</a> markup
+		(a toggle with a menu containing a filter input) while the filtering, selection, and menu-content rendering remain fully owned by Blazor (C# state).
+		The <code>combobox.js</code> plugin is intentionally not used, as its direct DOM mutations (filtering by <code>style.display</code>, rewriting item classes and texts)
+		would conflict with the Blazor renderer; only the Bootstrap Menu component is used for positioning and keyboard navigation.<br />
+		You can use the <code>FilterEmptyResultText</code> or <code>FilterEmptyResultTemplate</code> to customize the message displayed when no items are found.
+	</p>
+	<Demo Type="typeof(HxSelect_Demo_Filtering)" />
+
+	<DocHeading Title="Custom filtering" Level="3" />
+	<p>
+		You can customize filtering by setting <code>FilterPredicate</code> to a delegate that returns <code>bool</code> and accepts two parameters: <code>TItem</code> and <code>string</code> (filter).
+		The default behavior filters items based on whether the item text (obtained via <code>TextSelector</code>) contains the filter query string (case-insensitive).
+	</p>
+	<Demo Type="typeof(HxSelect_Demo_CustomFiltering)" />
+
     <DocHeading Title="Disabled options" />
 	<p>You can disable individual options by setting the <code>ItemDisabledSelector</code>.</p>
     <Demo Type="typeof(HxSelect_Demo_ItemDisabledSelector)" />

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -3897,6 +3897,34 @@
             Receives notification from JavaScript when item is hidden.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.SelectedItemIndex">
+            <summary>
+            Index of the selected item within <see cref="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.ItemsToRender"/> (<c>-1</c> for no selection or the <c>null</c> item).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.AdditionalAttributes">
+            <summary>
+            Additional attributes to be splatted onto an underlying HTML element.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.OnAfterRenderAsync(System.Boolean)">
+            <inheritdoc cref="M:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync(System.Boolean)" />
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.FocusAsync">
+            <summary>
+            Focuses the toggle.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.HandleJsShown">
+            <summary>
+            Receives notification from JavaScript when the menu is shown.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxSelectInternal`2.HandleJsHidden">
+            <summary>
+            Receives notification from JavaScript when the menu is hidden.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent">
             <summary>
             Represents properties (and methods) of a component that renders a form value (i.e., form inputs).
@@ -6557,6 +6585,45 @@
             When returns <c>true</c>, the corresponding option will be rendered with <c>disabled</c> attribute.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.AllowFiltering">
+            <summary>
+            Enables filtering capabilities.
+            When enabled, the component renders the Bootstrap Combobox (a toggle with a menu containing a filter input) instead of the native <c>select</c> element.
+            The default is <c>false</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.FilterPredicate">
+            <summary>
+            Defines a custom filtering predicate to apply to the list of items.
+            If not specified, the default behavior filters items based on whether the item text (obtained via <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.TextSelector"/>) contains the filter query string.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.ClearFilterOnHide">
+            <summary>
+            When enabled, the filter will be cleared when the menu is closed.
+            The default is <c>true</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.FilterEmptyResultTemplate">
+            <summary>
+            Template that defines what should be rendered in case of empty filtered items.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.FilterEmptyResultText">
+            <summary>
+            Text to display when the filtered results list is empty and when not using <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.FilterEmptyResultTemplate"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.FilterSearchIcon">
+            <summary>
+            Icon displayed in filter input for searching the filter.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2.FilterClearIcon">
+            <summary>
+            Icon displayed in filter input for clearing the filter.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxSelect">
             <summary>
             Non-generic API for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxSelect`2"/>.
@@ -6667,6 +6734,69 @@
             Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.AllowFilteringImpl">
+            <summary>
+            Enables filtering capabilities (renders the Bootstrap Combobox instead of the native <c>select</c>).
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.AllowFilteringEffective">
+            <summary>
+            Effective value of the filtering capabilities (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.AllowFilteringImpl"/> property, settings, defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterPredicateImpl">
+            <summary>
+            Defines a custom filtering predicate to apply to the list of items.
+            If not specified, the default behavior filters items based on whether the item text (obtained via <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.TextSelectorImpl"/>) contains the filter query string.
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.ClearFilterOnHideImpl">
+            <summary>
+            When enabled, the filter will be cleared when the menu is closed.
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.ClearFilterOnHideEffective">
+            <summary>
+            Effective value of clearing the filter when the menu is closed (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.ClearFilterOnHideImpl"/> property, settings, defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterEmptyResultTemplateImpl">
+            <summary>
+            Template that defines what should be rendered in case of empty filtered items.
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterEmptyResultTextImpl">
+            <summary>
+            Text to display when the filtered results list is empty and when not using <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterEmptyResultTemplateImpl"/>.
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterSearchIconImpl">
+            <summary>
+            Icon displayed in the filter input for searching the filter.
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterSearchIconEffective">
+            <summary>
+            Effective value of the filter search icon (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterSearchIconImpl"/> property, settings, defaults).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterClearIconImpl">
+            <summary>
+            Icon displayed in the filter input for clearing the filter.
+            Base property for direct setup or to be re-published as <c>[Parameter] public</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterClearIconEffective">
+            <summary>
+            Effective value of the filter clear icon (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.FilterClearIconImpl"/> property, settings, defaults).
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.EnabledEffective">
             <inheritdoc cref="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBase`1.EnabledEffective" />
         </member>
@@ -6676,8 +6806,22 @@
             Can be <c>null</c>. 
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.RenderOrder">
+            <inheritdoc/>
+        </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.BuildRenderInput(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
             <inheritdoc/>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.BuildRenderInput_Combobox(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
+            <summary>
+            Renders the Bootstrap Combobox (used when filtering is enabled, <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.AllowFilteringEffective"/>).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.HandleComboboxSelectedItemIndexChanged(System.Int32)">
+            <summary>
+            Handles the item selection in the combobox rendering (<see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.AllowFilteringEffective"/>).
+            Receives the index of the selected item within the sorted items (<c>-1</c> for the <c>null</c> item) and sets the <c>CurrentValue</c>.
+            </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxSelectBase`2.TryParseValueFromString(System.String,`0@,System.String@)">
             <inheritdoc/>
@@ -7841,6 +7985,26 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.SelectSettings.LabelType">
             <summary>
             The label type.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SelectSettings.AllowFiltering">
+            <summary>
+            Enables filtering capabilities.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SelectSettings.ClearFilterOnHide">
+            <summary>
+            When enabled, the filter will be cleared when the menu is closed.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SelectSettings.FilterSearchIcon">
+            <summary>
+            Icon displayed in the filter input for searching the filter.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.SelectSettings.FilterClearIcon">
+            <summary>
+            Icon displayed in the filter input for clearing the filter.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.SwitchSettings">


### PR DESCRIPTION
Fixes #1461

Implements the direction decided on the issue ([evaluation](https://github.com/havit/Havit.Blazor/issues/1461#issuecomment-4673856966)): **no standalone HxCombobox** — `HxSelect` gains opt-in client-side filtering rendering Bootstrap 6's **Combobox** markup/CSS, with all behavior owned by C#. The combobox.js plugin is deliberately not used (its `style.display`/classList/textContent DOM mutations fight Blazor's renderer).

## API (names/semantics identical to HxMultiSelect's filtering)
`AllowFiltering` (default **false** — the default path still renders the native `<select>`, byte-identical to today; existing tests untouched), `FilterPredicate` (default: case-insensitive substring over `TextSelector` text), `ClearFilterOnHide`, `FilterEmptyResultTemplate/Text` (localized via resx, translations mirrored from HxMultiSelect), `FilterSearchIcon`/`FilterClearIcon` — all with full Settings/Defaults plumbing.

## Rendering (`AllowFiltering=true`)
`button.form-control.combobox-toggle` (`aria-haspopup="listbox"`, `aria-expanded`, validation/size classes like HxMultiSelect's toggle) with `span.combobox-value` (+`combobox-placeholder` for NullText) and the upstream `combobox-caret` SVG; sibling `.menu[role=listbox]` with `combobox-search` filter input, `menu-item[role=option]` items with `.selected` + `menu-item-check`, `combobox-no-results` empty state. Positioning/keyboard/auto-close come from the Bootstrap **Menu** plugin (initialized like HxMultiSelect); filtering, selection (→ `CurrentValue`, EditForm validation intact), and toggle text are pure C# state. Null item renders first and is exempt from filtering (it's the clear affordance).

## Docs & tests
HxSelect docs get "Filtering" + "Custom filtering" sections with live demos and a one-sentence rationale for not using the JS plugin. 9 new bUnit tests; existing HxSelect tests pass unmodified.

## Verification
Library `-warnaserror` clean; **517/517** unit, **374/374** documentation tests; BlazorAppTest builds (net10.0 locally; CI covers net8/net9). I re-ran the unit suite independently before pushing.

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_