### PR TITLE
Documentation: migration guide from v4.x to v6

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Concepts/MigrationGuideV6_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Concepts/MigrationGuideV6_Documentation.razor
@@ -1,0 +1,518 @@
+﻿@page "/concepts/migration-guide-v6"
+
+<DocHeadContent CanonicalRelativeUrl="/concepts/migration-guide-v6" />
+
+<h1>Migration guide: v4.x to v6</h1>
+<p>
+	Havit.Blazor v6 adopts <a href="https://v6-dev--twbs-bootstrap.netlify.app/">Bootstrap 6</a> (replacing Bootstrap 5).
+	Bootstrap 6 redesigns the theme color system, switches responsive classes to a prefix syntax, rebuilds several core components
+	on native HTML elements, and ships JavaScript as ES modules only. The library version jumps from 4.x straight to 6
+	to align with the underlying Bootstrap major version.
+</p>
+<p>
+	This guide lists the breaking changes between v4.x and v6, each with the corresponding migration step.
+	Work through it top to bottom &ndash; the early sections (packages, CSS classes, theme colors) affect the whole application,
+	the later ones are per-component.
+</p>
+<DocAlert Type="DocAlertType.Info">
+	Prerequisites: .NET 8 or newer (the library targets <code>net8.0</code>, <code>net9.0</code>, and <code>net10.0</code>).
+</DocAlert>
+
+<DocHeading Title="AI-assisted migration" Id="ai-assisted-migration" />
+<p>
+	Most of the changes below are mechanical renames and class-syntax conversions &ndash; a great fit for an AI coding agent.
+	We recommend letting an agent perform the first pass and reviewing the result against this guide.
+</p>
+<DocAlert Type="DocAlertType.Info">
+	A ready-made <strong>migration skill for AI agents</strong> (Claude Code, GitHub Copilot, and other agents supporting the skills format)
+	is available in the <a href="https://github.com/havit/Havit.Blazor">Havit.Blazor repository</a> under <code>skills/havit-blazor-v6-migration</code>.
+	Point your agent at the skill and let it drive the upgrade of your project.
+</DocAlert>
+
+<DocHeading Title="Update packages and assets" Id="packages-and-assets" />
+
+<DocHeading Title="NuGet packages" Level="3" />
+<p>Update all <code>Havit.Blazor.*</code> packages to the matching 6.x versions:</p>
+<CodeSnippet Language="none">dotnet add package Havit.Blazor.Components.Web.Bootstrap</CodeSnippet>
+
+<DocHeading Title="Bootstrap CSS" Level="3" />
+<p>
+	The CSS reference itself does not change &ndash; keep <code>HxSetup.RenderBootstrapCssReference()</code>
+	(or the direct <code>_content/Havit.Blazor.Components.Web.Bootstrap/bootstrap.min.css</code> link); it now serves the compiled Bootstrap&nbsp;6 build.
+	The <code>BootstrapFlavor.PlainBootstrap</code> flavor is temporarily served from a pinned <code>twbs/bootstrap</code> commit via jsDelivr
+	(Bootstrap&nbsp;6 alpha is not published to npm/CDN yet).
+</p>
+<DocAlert Type="DocAlertType.Warning">
+	If you maintain a <strong>custom Bootstrap build</strong> (own SCSS), you have to rebuild it on the Bootstrap 6 sources.
+	Bootstrap 6 uses the Sass module system (<code>@@use ... with (...)</code> instead of variable overrides before <code>@@import</code>)
+	and emits CSS cascade layers (<code>@@layer</code>).
+</DocAlert>
+<p>
+	Also make sure the link to <code>{YourBlazorApp}.styles.css</code> (scoped styles bundle) remains in your host page
+	&ndash; the library's component isolation CSS is required.
+</p>
+
+<DocHeading Title="Bootstrap JavaScript" Id="bootstrap-javascript" Level="3" />
+<p>
+	Bootstrap 6 ships <strong>ES modules only</strong> &ndash; there is no UMD bundle and no implicit <code>window.bootstrap</code> global anymore.
+	Remove any CDN <code>bootstrap.bundle.min.js</code> script tag (and any separate Popper reference &ndash; Popper.js was replaced by Floating UI, which is bundled)
+	and use the reference rendered by the library instead:
+</p>
+<CodeSnippet Language="razor">@("""@((MarkupString)HxSetup.RenderBootstrapJavaScriptReference())""")</CodeSnippet>
+<p>
+	This renders a <code>&lt;script type="module"&gt;</code> tag importing the Bootstrap 6 bundle shipped with the library
+	(as a static web asset, in lock-step with the compiled CSS) and re-exposes <code>window.bootstrap</code> as a compatibility bridge.
+	The library's JavaScript initializer additionally guarantees the bridge is established before the Blazor runtime starts,
+	but keeping the script reference is recommended for an early bundle download.
+</p>
+
+<DocHeading Title="CSS classes & utilities" Id="css-classes-and-utilities" />
+
+<DocHeading Title="Changed breakpoint values" Id="breakpoints" Level="3" />
+<p>Bootstrap 6 raised the upper breakpoints and renamed <code>xxl</code> to <code>2xl</code>:</p>
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>Breakpoint</td>
+				<td>v4.x (Bootstrap 5)</td>
+				<td>v6 (Bootstrap 6)</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>sm</code></td><td>576px</td><td>576px (unchanged)</td></tr>
+			<tr><td><code>md</code></td><td>768px</td><td>768px (unchanged)</td></tr>
+			<tr><td><code>lg</code></td><td>992px</td><td><strong>1024px</strong></td></tr>
+			<tr><td><code>xl</code></td><td>1200px</td><td><strong>1280px</strong></td></tr>
+			<tr><td><code>xxl</code></td><td>1400px</td><td><strong><code>2xl</code></strong>, 1536px</td></tr>
+		</tbody>
+	</table>
+</div>
+<p>
+	The C# enum member names (e.g. <code>NavbarExpand</code>, <code>DrawerResponsiveBreakpoint</code> values) are unchanged &ndash; only the generated CSS classes
+	use <code>2xl</code>. Review layouts that depend on the exact <code>lg</code>/<code>xl</code> pixel values.
+</p>
+
+<DocHeading Title="Responsive prefix syntax" Id="responsive-prefix-syntax" Level="3" />
+<p>
+	Bootstrap 6 replaced the responsive <em>infix</em> syntax with a <em>prefix</em> syntax for all responsive classes,
+	including the grid. The components generate the new classes automatically; you have to convert the classes in your own markup:
+</p>
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>v4.x (Bootstrap 5)</td>
+				<td>v6 (Bootstrap 6)</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>col-md-6</code></td><td><code>md:col-6</code></td></tr>
+			<tr><td><code>d-md-none</code> / <code>d-md-flex</code></td><td><code>md:d-none</code> / <code>md:d-flex</code></td></tr>
+			<tr><td><code>flex-md-row</code></td><td><code>md:flex-row</code></td></tr>
+			<tr><td><code>sticky-md-top</code></td><td><code>md:sticky-top</code></td></tr>
+			<tr><td><code>navbar-expand-md</code></td><td><code>md:navbar-expand</code></td></tr>
+			<tr><td><code>list-group-horizontal-md</code></td><td><code>md:list-group-horizontal</code></td></tr>
+			<tr><td><code>modal-fullscreen-xxl-down</code></td><td><code>2xl-down:dialog-fullscreen</code></td></tr>
+			<tr><td><code>offcanvas-md</code></td><td><code>md:drawer</code></td></tr>
+		</tbody>
+	</table>
+</div>
+<p>
+	<strong>Migration step:</strong> sweep your <code>.razor</code>/<code>.cshtml</code>/<code>.html</code> files for infix responsive utilities
+	(regex like <code>\b[a-z-]+-(sm|md|lg|xl|xxl)-</code>) and convert them; rename every <code>xxl</code> usage to <code>2xl</code>.
+</p>
+
+<DocHeading Title="Theme colors and theme-* classes" Id="theme-colors" Level="3" />
+<p>
+	Bootstrap 6 applies theme colors to components via a composable <code>theme-*</code> class instead of per-component color classes,
+	and renames the color utilities. Changes in the <code>ThemeColor</code> enum:
+</p>
+<ul>
+	<li><code>ThemeColor.Light</code> and <code>ThemeColor.Dark</code> were <strong>removed</strong> (no Bootstrap 6 equivalents). Migrate <code>Light</code> &rarr; <code>Secondary</code> (typically combined with a subtle component variant) and <code>Dark</code> &rarr; <code>Inverse</code>.</li>
+	<li>New members: <code>ThemeColor.Accent</code> and <code>ThemeColor.Inverse</code> (dark in light color mode, light in dark color mode).</li>
+</ul>
+<p>CSS class mapping (relevant if you write these classes by hand or override them in CSS):</p>
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>v4.x (Bootstrap 5)</td>
+				<td>v6 (Bootstrap 6)</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>text-primary</code></td><td><code>fg-primary</code></td></tr>
+			<tr><td><code>text-primary-emphasis</code></td><td><code>fg-emphasis-primary</code></td></tr>
+			<tr><td><code>bg-primary-subtle</code></td><td><code>bg-subtle-primary</code></td></tr>
+			<tr><td><code>border-primary-subtle</code></td><td><code>border-subtle-primary</code></td></tr>
+			<tr><td><code>text-bg-primary</code></td><td><code>theme-primary</code> (composable theme class)</td></tr>
+			<tr><td><code>btn btn-primary</code></td><td><code>btn btn-solid theme-primary</code></td></tr>
+			<tr><td><code>btn btn-outline-primary</code></td><td><code>btn btn-outline theme-primary</code></td></tr>
+			<tr><td><code>alert alert-danger</code></td><td><code>alert theme-danger</code></td></tr>
+			<tr><td><code>badge text-bg-success</code></td><td><code>badge theme-success</code></td></tr>
+			<tr><td><code>list-group-item-success</code></td><td><code>theme-success</code></td></tr>
+		</tbody>
+	</table>
+</div>
+<p>
+	<strong>Migration step:</strong> replace removed <code>ThemeColor.Light</code>/<code>Dark</code> usages, then convert hand-written
+	color utility classes per the table above.
+</p>
+
+<DocHeading Title="Button variants" Id="button-variants" Level="3" />
+<p>
+	Buttons compose a <strong>variant</strong> (<code>btn-solid</code>, <code>btn-outline</code>, <code>btn-subtle</code>, <code>btn-text</code>, <code>btn-link</code>)
+	with a <code>theme-*</code> color class. On <code>HxButton</code> (and <code>ButtonSettings</code>, <code>HxSmartPasteButton</code>),
+	the <code>Outline</code> (bool) parameter was <strong>removed</strong> in favor of the new <code>Variant</code> parameter
+	(<code>ButtonVariant</code>: <code>Solid</code> (default), <code>Outline</code>, <code>Subtle</code>, <code>Text</code>, <code>Link</code>):
+</p>
+<CodeSnippet Language="razor">@("""
+<!-- v4.x -->
+<HxButton Color="ThemeColor.Primary" Outline="true" Text="Save" />
+
+<!-- v6 -->
+<HxButton Color="ThemeColor.Primary" Variant="ButtonVariant.Outline" Text="Save" />
+""")</CodeSnippet>
+<ul>
+	<li><code>ThemeColor.Link</code> still maps to the link-styled button; without a <code>Color</code>, a neutral <code>.btn</code> is rendered.</li>
+	<li>New: <code>ButtonSize.ExtraSmall</code> (<code>btn-xs</code>, new in Bootstrap 6).</li>
+	<li>The <code>ToButtonColorCss()</code> extension method on <code>ThemeColor</code> was removed.</li>
+</ul>
+
+<DocHeading Title="Toggle buttons (btn-check structure)" Id="toggle-buttons" Level="3" />
+<p>
+	Bootstrap 6 nests the input <em>inside</em> the label: <code>.btn-check</code> moves to the <code>&lt;label&gt;</code> together with the
+	variant and theme classes, and the <code>id</code>/<code>for</code> pairing is no longer needed. The toggle-button render modes of
+	<code>HxCheckbox</code>, <code>HxCheckboxList</code>, and <code>HxRadioButtonList</code> render this automatically
+	(their <code>Outline</code> parameter was likewise replaced by <code>Variant</code>); update only hand-written markup:
+</p>
+<CodeSnippet Language="html">@("""
+<!-- v4.x -->
+<input type="checkbox" class="btn-check" id="toggle1" autocomplete="off" />
+<label class="btn btn-outline-primary" for="toggle1">Toggle</label>
+
+<!-- v6 -->
+<label class="btn-check btn-outline theme-primary">
+	<input type="checkbox" autocomplete="off" />
+	Toggle
+</label>
+""")</CodeSnippet>
+
+<DocHeading Title="form-select removal" Id="form-select" Level="3" />
+<p>
+	Bootstrap 6 consolidates select styling into <code>form-control</code>. <code>HxSelect</code>, <code>HxMultiSelect</code>,
+	and the <code>HxCalendar</code> month/year selects now render <code>class="form-control"</code>
+	(sizes via <code>form-control-sm</code>/<code>form-control-lg</code>).
+	<strong>Migration step:</strong> update any custom CSS or test selectors targeting <code>.form-select</code> on these components.
+</p>
+
+<DocHeading Title="Renamed and reworked components" Id="renamed-components" />
+<p>
+	Bootstrap 6 renamed Modal &rarr; Dialog, Offcanvas &rarr; Drawer, and Dropdown &rarr; Menu, rebuilding the first two on the native
+	<code>&lt;dialog&gt;</code> element. The library follows with hard renames (no obsolete forwarders) &ndash; a compile-time find &amp; replace.
+</p>
+
+<DocHeading Title="HxModal → HxDialog" Id="hxmodal-hxdialog" Level="3" />
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>v4.x</td>
+				<td>v6</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>HxModal</code></td><td><code>HxDialog</code></td></tr>
+			<tr><td><code>ModalSize</code>, <code>ModalFullscreen</code>, <code>ModalBackdrop</code>, <code>ModalRenderMode</code></td><td><code>DialogSize</code>, <code>DialogFullscreen</code>, <code>DialogBackdrop</code>, <code>DialogRenderMode</code></td></tr>
+			<tr><td><code>ModalHidingEventArgs</code>, <code>ModalSettings</code></td><td><code>DialogHidingEventArgs</code>, <code>DialogSettings</code> (incl. the <code>HxMessageBox.ModalSettings</code> parameter &rarr; <code>DialogSettings</code>)</td></tr>
+			<tr><td><code>HxDialogBase.Modal</code> (protected)</td><td><code>HxDialogBase.Dialog</code></td></tr>
+			<tr><td><code>Animated</code> (bool)</td><td><code>Animation</code> (<code>DialogAnimation</code>: <code>Fade</code>, <code>None</code>, <code>SlideDown</code>, <code>SlideUp</code>)</td></tr>
+			<tr><td><code>Centered</code></td><td>removed &ndash; v6 dialogs are natively centered</td></tr>
+			<tr><td><code>DialogCssClass</code>, <code>ContentCssClass</code></td><td>merged into <code>CssClass</code> (single element)</td></tr>
+			<tr><td><code>CloseButtonSettings</code></td><td>removed (see <a href="#other-component-updates">HxCloseButton</a>)</td></tr>
+		</tbody>
+	</table>
+</div>
+<p>
+	The component renders a native <code>&lt;dialog class="dialog"&gt;</code> with <code>dialog-header/body/footer</code> as direct children
+	&ndash; there is no <code>.modal-dialog</code>/<code>.modal-content</code> wrapper and no <code>.modal-backdrop</code> element
+	(the backdrop is the native <code>::backdrop</code> pseudo-element). New opt-in: <code>NonModal</code> (no backdrop/focus trap).
+	<strong>Migration step:</strong> rename the types/parameters, and update custom CSS and E2E selectors
+	(<code>.modal.show</code> &rarr; <code>dialog.dialog[open]</code>).
+</p>
+
+<DocHeading Title="HxOffcanvas → HxDrawer" Id="hxoffcanvas-hxdrawer" Level="3" />
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>v4.x</td>
+				<td>v6</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>HxOffcanvas</code></td><td><code>HxDrawer</code></td></tr>
+			<tr><td><code>OffcanvasPlacement</code>, <code>OffcanvasSize</code>, <code>OffcanvasBackdrop</code>, <code>OffcanvasRenderMode</code>, <code>OffcanvasResponsiveBreakpoint</code></td><td><code>DrawerPlacement</code>, <code>DrawerSize</code>, <code>DrawerBackdrop</code>, <code>DrawerRenderMode</code>, <code>DrawerResponsiveBreakpoint</code></td></tr>
+			<tr><td><code>OffcanvasHidingEventArgs</code>, <code>OffcanvasSettings</code></td><td><code>DrawerHidingEventArgs</code>, <code>DrawerSettings</code></td></tr>
+			<tr><td><code>HxListLayout.FilterOffcanvasSettings</code></td><td><code>HxListLayout.FilterDrawerSettings</code></td></tr>
+			<tr><td><code>--hx-offcanvas-*</code> CSS variables</td><td><code>--hx-drawer-*</code></td></tr>
+		</tbody>
+	</table>
+</div>
+<p>
+	The drawer renders a native <code>&lt;dialog class="drawer drawer-{placement}"&gt;</code> (shares the Dialog base &ndash; native backdrop,
+	top layer, focus trapping, built-in swipe-to-dismiss). Responsive variants use prefix classes (<code>md:drawer</code>).
+	New opt-in: <code>Sheet</code> (flush-to-edge <code>drawer-sheet</code> variant).
+	<strong>Migration step:</strong> rename the types/parameters and update custom CSS/selectors targeting <code>.offcanvas*</code> classes.
+</p>
+
+<DocHeading Title="HxDropdown → HxMenu" Id="hxdropdown-hxmenu" Level="3" />
+<p>
+	The Dropdown family was replaced by the Bootstrap 6 Menu family. <code>HxMenu</code> is a renderless coordinator with
+	<code>Toggle</code> and <code>Content</code> render fragments &ndash; there is no wrapper element; the toggle and the <code>.menu</code> are direct siblings:
+</p>
+<CodeSnippet Language="razor">@("""
+<!-- v4.x -->
+<HxDropdownButtonGroup>
+	<HxDropdownToggleButton Color="ThemeColor.Secondary">Menu button</HxDropdownToggleButton>
+	<HxDropdownMenu>
+		<HxDropdownItemNavLink Href="/somewhere">Link</HxDropdownItemNavLink>
+		<HxDropdownItem OnClick="HandleClick">Action</HxDropdownItem>
+		<HxDropdownDivider />
+		<HxDropdownItemText>Some text</HxDropdownItemText>
+	</HxDropdownMenu>
+</HxDropdownButtonGroup>
+
+<!-- v6 -->
+<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Menu button</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		<HxMenuItemNavLink Href="/somewhere">Link</HxMenuItemNavLink>
+		<HxMenuItem OnClick="HandleClick">Action</HxMenuItem>
+		<HxMenuDivider />
+		<HxMenuText>Some text</HxMenuText>
+	</Content>
+</HxMenu>
+""")</CodeSnippet>
+<ul>
+	<li><code>DropdownDirection</code> and <code>DropdownMenuAlignment</code> were replaced by <code>MenuPlacement</code> (plus <code>ResponsivePlacement</code>); auto-close via <code>MenuAutoClose</code>.</li>
+	<li><code>HxDropdownButtonGroup</code> was <strong>dropped</strong> &ndash; build split buttons with <code>HxButtonGroup</code> + <code>HxMenu</code>.</li>
+	<li>The <code>Caret</code> parameter was dropped (Bootstrap 6 has no toggle caret class).</li>
+	<li><code>HxContextMenu</code>: <code>PopperStrategy</code> &rarr; <code>FloatingStrategy</code> (Floating UI replaces Popper.js); new <code>MenuCssClass</code>/<code>MenuPlacement</code>.</li>
+	<li><code>HxMultiSelect.ShowDropdownAsync()</code>/<code>HideDropdownAsync()</code> &rarr; <code>ShowMenuAsync()</code>/<code>HideMenuAsync()</code>.</li>
+	<li>CSS/JS: <code>.dropdown-menu</code>/<code>.dropdown-item</code> &rarr; <code>.menu</code>/<code>.menu-item</code>; JS events <code>*.bs.dropdown</code> &rarr; <code>*.bs.menu</code>; <code>--hx-*-dropdown-*</code> CSS variables &rarr; <code>--hx-*-menu-*</code>.</li>
+</ul>
+
+<DocHeading Title="HxNavbarCollapse → HxNavbarDrawer" Id="hxnavbarcollapse-hxnavbardrawer" Level="3" />
+<p>
+	Bootstrap 6 removed <code>.navbar-collapse</code> entirely &ndash; the responsive navbar content is a <strong>Drawer</strong>:
+	below the navbar's expand breakpoint it opens as a drawer, at/above the breakpoint the drawer markup is flattened into inline
+	navbar content by the CSS.
+</p>
+<ul>
+	<li><code>HxNavbarCollapse</code> &rarr; <code>HxNavbarDrawer</code> (renders <code>dialog.drawer</code>; new <code>Title</code> and <code>Placement</code> parameters; closes automatically on in-app navigation).</li>
+	<li>The default target element id suffix changed from <code>-collapse</code> to <code>-drawer</code> (<code>HxNavbar.GetDefaultCollapseId()</code> &rarr; <code>GetDefaultDrawerId()</code>) &ndash; update custom <code>Id</code>/CSS/test selectors.</li>
+	<li><code>HxNavbarToggler</code> was rewritten: it targets the drawer via <code>data-bs-toggle="drawer"</code> and renders the v6 <code>btn-icon</code> toggler; it no longer derives from the Collapse components.</li>
+</ul>
+
+<DocHeading Title="HxAccordion" Id="hxaccordion" Level="3" />
+<p>
+	Rebuilt on native <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code> elements
+	(<code>details.accordion-item</code> + <code>summary.accordion-header</code> + <code>div.accordion-body</code>);
+	<code>.accordion-button</code>/<code>.accordion-collapse</code> and the Collapse JS dependency are gone.
+	The public API is unchanged (<code>ExpandedItemId(s)</code>, <code>StayOpen</code>, <code>OnExpanded</code>/<code>OnCollapsed</code>),
+	but the events now fire immediately on state change (no transition wait). New <code>Color</code> parameter (<code>theme-*</code> variants).
+	<strong>Migration step:</strong> update custom CSS/test selectors targeting the old accordion classes.
+</p>
+
+<DocHeading Title="Form inputs: form-field layout" Id="form-field-layout" Level="3" />
+<p>
+	Every Hx input is now wrapped in the Bootstrap 6 <code>.form-field</code> CSS-grid wrapper, which lays out label + control +
+	help text + validation feedback with gap-based spacing (Bootstrap 6 removed the <code>form-text</code> margins accordingly).
+	The server-side <code>.is-invalid</code>/<code>.is-valid</code> validation flow with <code>EditForm</code> is unchanged;
+	the validation background icons (<code>$enable-validation-icons</code>) no longer exist in v6.
+	<strong>Migration step:</strong> review custom CSS that targeted the old per-input wrappers or relied on <code>form-text</code> margins.
+</p>
+
+<DocHeading Title="Checks, radios and switches" Id="checks-radios-switches" Level="3" />
+<p>
+	Bootstrap 6 replaced the <code>.form-check</code> family: <code>HxCheckbox</code> renders <code>input.check</code> with a plain label
+	(no <code>form-check</code> wrapper), <code>HxRadioButtonList</code> items render <code>input.radio</code>, and <code>HxSwitch</code> renders
+	the input nested in <code>div.switch</code> with <code>role="switch"</code>. The <code>Inline</code>/<code>Reverse</code> parameters keep working
+	(now expressed via Bootstrap utilities), and <code>HxCheckbox</code>/<code>HxSwitch</code> gain a <code>Color</code> parameter (<code>theme-*</code>).
+	<strong>Migration step:</strong> update custom CSS/test selectors using <code>.form-check*</code> classes.
+</p>
+
+<DocHeading Title="Composite inputs: form-adorn" Id="form-adorn" Level="3" />
+<p>
+	<code>HxAutosuggest</code>, <code>HxSearchBox</code>, <code>HxInputDate</code>, and <code>HxInputDateRange</code> adopt the Bootstrap 6
+	<em>adorn</em> pattern: a <code>div.form-control.form-adorn</code> wrapper owns the field chrome (border, background, focus via
+	<code>:focus-within</code>), the inner input is an unstyled <code>.form-ghost</code>, and icons are regular DOM-ordered
+	<code>.form-adorn-icon</code> elements (replacing the absolutely-positioned icons over the input).
+	<code>.is-invalid</code> stays on the inner input and is reflected on the wrapper by Bootstrap.
+	<strong>Migration step:</strong> update custom CSS that styled the old input/icon structure.
+	Floating labels are no longer supported on these components &ndash; see <a href="#floating-labels">below</a>.
+</p>
+
+<DocHeading Title="Chips: HxChipList and HxInputTags" Id="chips" Level="3" />
+<p>
+	<code>HxChipList</code> renders the native Bootstrap 6 <code>.chip</code> markup (with <code>.chip-dismiss</code> close button)
+	instead of restyled badges; <code>HxInputTags</code> renders the v6 <code>.chip-input</code> wrapper with <code>.chip</code> tags
+	and a <code>.form-ghost</code> inner input. Both gain a <code>Color</code> parameter (<code>ThemeColor</code>).
+</p>
+<DocAlert Type="DocAlertType.Warning">
+	The <strong>default appearance changed</strong>: chips/tags now render as the native un-themed chip (the v4.x default was a themed badge).
+	Set <code>Color="ThemeColor.Secondary"</code> to approximate the previous look.
+	<code>ChipBadgeSettings</code> (HxChipList) and <code>TagBadgeSettings</code> (HxInputTags) are <code>[Obsolete]</code>
+	&ndash; their <code>Color</code>/<code>CssClass</code> values are honored as a fallback; migrate to the new parameters.
+</DocAlert>
+
+<DocHeading Title="Other component updates" Id="other-component-updates" Level="3" />
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>Component</td>
+				<td>Change</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>HxBadge</code></td><td>New <code>Variant</code> parameter (<code>BadgeVariant</code>: <code>Solid</code>/<code>Subtle</code>/<code>Outline</code>); <code>TextColor</code> removed (theme tokens handle contrast); renders <code>badge theme-*</code>.</td></tr>
+			<tr><td><code>HxAlert</code></td><td>Renders <code>alert theme-*</code> instead of <code>alert-*</code>.</td></tr>
+			<tr><td><code>HxListGroupItem</code></td><td>Color renders <code>theme-*</code> instead of <code>list-group-item-*</code>.</td></tr>
+			<tr><td><code>HxToast</code></td><td>New <code>Translucent</code> parameter (<code>toast-translucent</code>, new in Bootstrap 6); contrast logic uses <code>Accent</code>/<code>Inverse</code>.</td></tr>
+			<tr><td><code>HxCard</code></td><td>New <code>Variant</code> (<code>CardVariant</code>: <code>Regular</code>/<code>Subtle</code>/<code>Translucent</code>), <code>Color</code> (<code>theme-*</code>), and <code>Horizontal</code> (<code>card-row</code>) parameters.</td></tr>
+			<tr><td><code>HxBreadcrumb</code></td><td><code>Divider</code> (string) replaced by <code>DividerTemplate</code> (<code>RenderFragment</code>); v6 markup uses <code>a.breadcrumb-link</code> and explicit <code>li.breadcrumb-divider</code> separators (an empty divider renders the built-in chevron).</td></tr>
+			<tr><td><code>HxCloseButton</code></td><td><code>White</code> parameter and <code>CloseButtonSettings</code> removed &ndash; the v6 <code>btn-close</code> is tinted with <code>currentcolor</code>; use <code>data-bs-theme="dark"</code> for dark surfaces. The <code>HxDialog.CloseButtonSettings</code> parameter was removed as well.</td></tr>
+			<tr><td><code>HxTabPanel</code></td><td><code>card-header-pills</code> no longer exists in Bootstrap 6 (only <code>card-header-tabs</code> remains).</td></tr>
+			<tr><td><code>HxProgress</code></td><td>Adopts the v6 progress structure (the v5.3-deprecated markup was removed upstream): each bar's <code>.progress</code> wrapper carries the role/aria/sizing; stacked bars use <code>.progress-stacked</code>. Public API unchanged; update custom CSS selectors.</td></tr>
+			<tr><td><code>HxCalendar</code> (+ date pickers)</td><td>Visuals aligned with the Bootstrap 6 Datepicker and driven by its <code>--bs-datepicker-*</code> tokens; the calendar stays Blazor-rendered (no JS dependency, <code>CultureInfo</code> localization).</td></tr>
+		</tbody>
+	</table>
+</div>
+
+<DocHeading Title="Removed APIs" Id="removed-apis" />
+
+<DocHeading Title="HxSidebar: mobile mode removed" Id="hxsidebar-mobile-mode" Level="3" />
+<p>
+	<code>HxSidebar</code> no longer implements mobile navigation &ndash; its only mode is the horizontal (icon rail) collapse.
+	The <code>ResponsiveBreakpoint</code> parameter, the <code>SidebarResponsiveBreakpoint</code> enum, and the built-in hamburger toggler
+	were <strong>removed</strong>. Mobile navigation is the application layout's concern: hide the sidebar below your breakpoint of choice
+	with display utilities and provide mobile navigation with another component, typically <a href="/components/HxNavbar">HxNavbar</a>
+	(its responsive content opens as a drawer in v6):
+</p>
+<CodeSnippet Language="razor">@("""
+@inherits LayoutComponentBase
+
+<HxNavbar><!-- always visible on mobile; HxNavbarDrawer opens the navigation as a drawer --></HxNavbar>
+
+<div class="md:d-flex min-vh-100">
+	<HxSidebar CssClass="sticky-top d-none md:d-flex">
+		...
+	</HxSidebar>
+	<div class="main p-4 flex-grow-1 overflow-hidden">
+		@Body
+	</div>
+</div>
+""")</CodeSnippet>
+<p>
+	See the <a href="/components/HxSidebar">HxSidebar documentation</a> for the full responsive layout sample
+	(this documentation site uses the same pattern).
+</p>
+
+<DocHeading Title="Floating labels on composite inputs" Id="floating-labels" Level="3" />
+<p>
+	Bootstrap 6 floating labels require the input itself to be the <code>form-control</code>, which conflicts with the
+	<a href="#form-adorn">adorn/chip-input wrapper</a> owning the field chrome. <code>LabelType.Floating</code> therefore now throws
+	<code>InvalidOperationException</code> on <code>HxAutosuggest</code>, <code>HxSearchBox</code>, <code>HxInputDate</code>,
+	<code>HxInputDateRange</code>, and <code>HxInputTags</code>. Use the default <code>LabelType.Regular</code> on these components
+	&ndash; and beware of a global <code>HxSetup.Defaults.LabelType = LabelType.Floating</code>, which now needs a per-component override for them.
+</p>
+
+<DocHeading Title="Other removals" Id="other-removals" Level="3" />
+<ul>
+	<li><code>ThemeColor.Light</code>, <code>ThemeColor.Dark</code> (see <a href="#theme-colors">theme colors</a>)</li>
+	<li><code>HxButton.Outline</code> + <code>ToButtonColorCss()</code> (see <a href="#button-variants">button variants</a>)</li>
+	<li><code>HxDropdownButtonGroup</code>, <code>Caret</code>, <code>DropdownDirection</code>, <code>DropdownMenuAlignment</code> (see <a href="#hxdropdown-hxmenu">HxMenu</a>)</li>
+	<li><code>HxModal.Centered</code>, <code>Animated</code>, <code>DialogCssClass</code>/<code>ContentCssClass</code>, <code>CloseButtonSettings</code> (see <a href="#hxmodal-hxdialog">HxDialog</a>)</li>
+	<li><code>HxCloseButton.White</code>, <code>CloseButtonSettings</code>; <code>HxBadge.TextColor</code>; <code>HxTabPanel</code> card-header pills (see <a href="#other-component-updates">component updates</a>)</li>
+	<li><code>ChipBadgeSettings</code>/<code>TagBadgeSettings</code> are <code>[Obsolete]</code> (see <a href="#chips">chips</a>)</li>
+</ul>
+
+<DocHeading Title="CSS variables and tokens" Id="css-variables" />
+
+<DocHeading Title="Bootstrap --bs-* tokens" Id="bs-tokens" Level="3" />
+<p>
+	Bootstrap 6 reworked its CSS custom property system. If your styles reference <code>--bs-*</code> tokens, re-verify each one against
+	the compiled v6 bundle. Frequent renames:
+</p>
+<div class="table-responsive">
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<td>v4.x (Bootstrap 5)</td>
+				<td>v6 (Bootstrap 6)</td>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><code>--bs-body-bg</code> / <code>--bs-body-color</code></td><td><code>--bs-bg-body</code> / <code>--bs-fg-body</code> (the <code>fg</code>/<code>bg</code> token families)</td></tr>
+			<tr><td><code>--bs-secondary-bg</code>, <code>--bs-tertiary-bg</code></td><td>numbered surfaces <code>--bs-bg-1</code>/<code>--bs-bg-2</code>/... (note: dark-mode semantics changed)</td></tr>
+			<tr><td><code>--bs-border-radius</code>(<code>-sm</code>/<code>-lg</code>/...)</td><td>radius scale <code>--bs-radius-1</code> ... <code>--bs-radius-6</code></td></tr>
+			<tr><td><code>--bs-primary-rgb</code> and other <code>*-rgb</code> triplets</td><td>removed &ndash; use <code>color-mix()</code> with the full-color tokens instead of <code>rgba(var(--bs-*-rgb), x)</code></td></tr>
+		</tbody>
+	</table>
+</div>
+
+<DocHeading Title="RGB-triplet variables now take full colors" Id="rgb-triplet-variables" Level="3" />
+<p>
+	Several library CSS variables that previously expected an <strong>RGB triplet</strong> (e.g. <code>13, 110, 253</code>, wrapped in
+	<code>rgba()</code> internally) now take a <strong>full color value</strong> (e.g. <code>#0d6efd</code>, <code>rgb(13 110 253 / 50%)</code>, or a token):
+	<code>--hx-sidebar-item-*-background-color</code>, <code>--hx-tree-view-item-*-background</code>, and
+	<code>--hx-calendar-day-today-background</code>. <strong>Migration step:</strong> convert your overrides of these variables to full colors.
+</p>
+
+<DocHeading Title="Overriding styles: cascade layers" Id="cascade-layers" Level="3" />
+<p>
+	The Bootstrap 6 CSS is organized in cascade layers and declares a dedicated <code>custom</code> layer for your overrides,
+	ordered after the component styles but before helpers and utilities. Put your component-style overrides into
+	<code>@@layer custom</code> &ndash; they then beat Bootstrap's component rules regardless of stylesheet order, while utility classes
+	still win over them (the v6 replacement for the v5 specificity battles; note that v6 utilities no longer use <code>!important</code>,
+	so any <em>unlayered</em> custom CSS overrides everything, including utilities):
+</p>
+<CodeSnippet Language="css">@("""
+@layer custom {
+	.btn {
+		/* your override - beats Bootstrap's component styles, loses to utilities */
+	}
+}
+""")</CodeSnippet>
+
+<DocHeading Title="JavaScript" Id="javascript" />
+<p>
+	Bootstrap 6 JavaScript is <strong>ESM-only</strong>: no UMD build, no automatic <code>window.bootstrap</code> global, and Popper.js
+	was replaced by Floating UI (bundled). The library ships the bundle as a static web asset and maintains a <code>window.bootstrap</code>
+	compatibility bridge (via <code>HxSetup.RenderBootstrapJavaScriptReference()</code> and its JS initializer &ndash; see
+	<a href="#bootstrap-javascript">Bootstrap JavaScript</a> above).
+</p>
+<p>For your own scripts that use Bootstrap plugins:</p>
+<ul>
+	<li>Code using the <code>bootstrap.*</code> global keeps working through the bridge, but must not run before Blazor starts (the bridge is guaranteed from Blazor start onward).</li>
+	<li>Alternatively, <code>import</code> the ESM bundle explicitly: <code>import * as bootstrap from "_content/Havit.Blazor.Components.Web.Bootstrap/bootstrap.bundle.min.js";</code></li>
+	<li>Do not load a second Bootstrap copy (CDN UMD bundle) &ndash; duplicate bundles register the delegated data-API listeners twice.</li>
+	<li>Plugin renames apply to JS too: <code>bootstrap.Modal</code> &rarr; <code>bootstrap.Dialog</code>, <code>bootstrap.Offcanvas</code> &rarr; <code>bootstrap.Drawer</code>, <code>bootstrap.Dropdown</code> &rarr; <code>bootstrap.Menu</code>; events <code>*.bs.modal</code>/<code>*.bs.offcanvas</code>/<code>*.bs.dropdown</code> &rarr; <code>*.bs.dialog</code>/<code>*.bs.drawer</code>/<code>*.bs.menu</code>; <code>popperConfig</code> &rarr; <code>data-bs-floating-config</code>.</li>
+</ul>
+
+<DocHeading Title="New components and features" Id="new-components" />
+<p>Not breaking, but worth adopting while you are at it:</p>
+<ul>
+	<li><a href="/components/HxAvatar">HxAvatar</a> + <a href="/components/HxAvatarStack">HxAvatarStack</a> &ndash; Bootstrap 6 Avatar</li>
+	<li><a href="/components/HxStepper">HxStepper</a> &ndash; Bootstrap 6 Stepper</li>
+	<li><a href="/components/HxOtpInput">HxOtpInput</a> &ndash; Bootstrap 6 OTP Input</li>
+	<li><a href="/components/HxPasswordStrength">HxPasswordStrength</a> &ndash; Bootstrap 6 Password Strength</li>
+	<li><a href="/components/HxNavOverflow">HxNavOverflow</a> &ndash; Priority+ navigation</li>
+	<li><a href="/components/HxSelect">HxSelect</a> <code>AllowFiltering</code> &ndash; opt-in client-side filtering rendering the Bootstrap 6 Combobox markup</li>
+	<li><a href="/components/HxDrawer">HxDrawer</a> <code>Sheet</code>, <a href="/components/HxToast">HxToast</a> <code>Translucent</code>, <a href="/components/HxCard">HxCard</a> variants, <code>ButtonVariant.Subtle</code>/<code>Text</code>, <code>ButtonSize.ExtraSmall</code>, <a href="/components/HxAccordion">HxAccordion</a> <code>Color</code>, <a href="/components/HxDialog">HxDialog</a> <code>Animation</code>/<code>NonModal</code></li>
+</ul>

--- a/Havit.Blazor.Documentation/Pages/Concepts/MigrationGuideV6_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Concepts/MigrationGuideV6_Documentation.razor
@@ -401,16 +401,27 @@
 	<code>HxSidebar</code> no longer implements mobile navigation &ndash; its only mode is the horizontal (icon rail) collapse.
 	The <code>ResponsiveBreakpoint</code> parameter, the <code>SidebarResponsiveBreakpoint</code> enum, and the built-in hamburger toggler
 	were <strong>removed</strong>. Mobile navigation is the application layout's concern: hide the sidebar below your breakpoint of choice
-	with display utilities and provide mobile navigation with another component, typically <a href="/components/HxNavbar">HxNavbar</a>
-	(its responsive content opens as a drawer in v6):
+	with display utilities and provide the mobile navigation via <a href="/components/HxNavbar">HxNavbar</a> with
+	<code>HxNavbarDrawer</code> (the navbar's responsive content opens as a drawer in v6):
 </p>
 <CodeSnippet Language="razor">@("""
 @inherits LayoutComponentBase
 
-<HxNavbar><!-- always visible on mobile; HxNavbarDrawer opens the navigation as a drawer --></HxNavbar>
+<HxNavbar>
+	<HxNavbarBrand>My application</HxNavbarBrand>
+	<HxNavbarToggler />
+	<HxNavbarDrawer>
+		<HxNav>...top-level links...</HxNav>
+		@* mobile-only navigation; hidden at/above the navbar expand breakpoint (lg by default),
+		   where the drawer content is flattened inline into the navbar *@
+		<div class="lg:d-none mt-3">
+			...navigation items mirroring the sidebar...
+		</div>
+	</HxNavbarDrawer>
+</HxNavbar>
 
-<div class="md:d-flex min-vh-100">
-	<HxSidebar CssClass="sticky-top d-none md:d-flex">
+<div class="lg:d-flex min-vh-100">
+	<HxSidebar CssClass="sticky-top d-none lg:d-flex">
 		...
 	</HxSidebar>
 	<div class="main p-4 flex-grow-1 overflow-hidden">

--- a/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
+++ b/Havit.Blazor.Documentation/Services/DocumentationCatalogService.cs
@@ -111,6 +111,7 @@ public class DocumentationCatalogService : IDocumentationCatalogService
 		new("/components/HxValidationMessage", "HxValidationMessage", "form"),
 
 		// Concepts
+		new("/concepts/migration-guide-v6", "Migration guide (v4 → v6)", "upgrade breaking changes bootstrap 6 migration migrate"),
 		new("/concepts/defaults-and-settings", "Defaults & Settings", "configuration themes wide preset"),
 		new("/concepts/Debouncer", "Debouncer", "delay timer"),
 		new("/concepts/dark-color-mode-theme", "Dark color mode", "dark color theme"),

--- a/Havit.Blazor.Documentation/Shared/Sidebar.razor
+++ b/Havit.Blazor.Documentation/Shared/Sidebar.razor
@@ -133,6 +133,7 @@
         </HxSidebarItem>
 
         <HxSidebarItem Text="Concepts" Icon="BootstrapIcon.Lightbulb">
+            <HxSidebarItem Href="/concepts/migration-guide-v6" Text="Migration guide (v4 → v6)" />
             <HxSidebarItem Href="/concepts/defaults-and-settings" Text="Defaults & Settings" />
             <HxSidebarItem Href="/concepts/Debouncer" Text="Debouncer" />
             <HxSidebarItem Href="/concepts/dark-color-mode-theme" Text="Dark color mode" />


### PR DESCRIPTION
Fixes #1497

New documentation page **`/concepts/migration-guide-v6`** — the human-readable contract for upgrading from v4.x (Bootstrap 5) to v6 (Bootstrap 6), compiled from the actual migration PRs' change logs and **verified against the sources and the compiled v6 bundle** (every documented class, token, and API name was checked to exist — and every removed one to be absent).

## Structure
1. Intro (scope, .NET 8+ prerequisite)
2. **AI-assisted migration** — points to the `skills/havit-blazor-v6-migration` agent skill (#1498)
3. Update packages and assets (NuGet, CSS reference incl. PlainBootstrap pinned-commit note, `{App}.styles.css`, ESM-only JS + `window.bootstrap` bridge)
4. CSS classes & utilities — breakpoint **values** table (lg 1024 / xl 1280 / xxl→2xl 1536), responsive **prefix syntax** table (`col-md-6` → `md:col-6`), theme-color system (`ThemeColor.Light/Dark` removed, utility rename tables), button variants before/after, nested `btn-check` structure, `form-select` removal
5. Renamed/reworked components — HxModal→HxDialog, HxOffcanvas→HxDrawer, HxDropdown→HxMenu, HxNavbarCollapse→HxNavbarDrawer, accordion, form-field layout, checks/radios, composite-input form-adorn, chips (obsoleted `ChipBadgeSettings`/`TagBadgeSettings` + default-appearance warning), other-updates table
6. Removed APIs — HxSidebar mobile mode with the layout-utilities + navbar-drawer recipe, floating labels throwing on composite inputs
7. CSS variables and tokens — `--bs-*` renames, RGB-triplet → full-color variables, `@layer custom` override guidance
8. JavaScript — ESM-only model, bridge timing, plugin/event renames
9. New components and features

Registered in the sidebar (Concepts) and the documentation catalog (searchable by "upgrade", "breaking changes", "migrate").

## Verification
Documentation build clean; **395/395** documentation tests.

https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f

---
_Generated by [Claude Code](https://claude.ai/code/session_014cbUmT7f6vBDamsjMn8L6f)_