### PR TITLE
[HxMultiSelect] Align with Bootstrap 6 combobox markup; make accessible

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMultiSelectTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMultiSelectTests.cs
@@ -7,7 +7,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
 public class HxMultiSelectTests : BunitTestBase
 {
 	[Fact]
-	public void HxMultiSelect_Render_DisplaysDropdownStructure()
+	public void HxMultiSelect_Render_DisplaysComboboxStructure()
 	{
 		// Arrange
 		var items = new[] { "Apple", "Banana", "Cherry" };
@@ -28,16 +28,17 @@ public class HxMultiSelectTests : BunitTestBase
 		// Act
 		var cut = Render(componentRenderer);
 
-		// Assert — renders the hx-multi-select container
+		// Assert — renders the hx-multi-select container with the Bootstrap combobox toggle
 		cut.Find(".hx-multi-select");
+		cut.Find("button.combobox-toggle");
 
-		// Assert — renders dropdown menu with items as checkboxes
-		var checkboxes = cut.FindAll("input[type='checkbox']");
-		Assert.Equal(3, checkboxes.Count());
+		// Assert — renders a listbox with one option per item
+		var options = cut.FindAll("[role='option']");
+		Assert.Equal(3, options.Count);
 	}
 
 	[Fact]
-	public void HxMultiSelect_SelectedValues_CheckboxesAreChecked()
+	public void HxMultiSelect_SelectedValues_OptionsAreMarkedSelected()
 	{
 		// Arrange
 		var items = new[] { "Apple", "Banana", "Cherry" };
@@ -58,9 +59,10 @@ public class HxMultiSelectTests : BunitTestBase
 		// Act
 		var cut = Render(componentRenderer);
 
-		// Assert — exactly one checkbox should be checked
-		var checkedBoxes = cut.FindAll("input[type='checkbox'][checked]");
-		Assert.Single(checkedBoxes);
+		// Assert — exactly one option should be marked as selected
+		var selectedOptions = cut.FindAll("[role='option'][aria-selected='true']");
+		Assert.Single(selectedOptions);
+		Assert.Contains("Banana", selectedOptions[0].TextContent);
 	}
 
 	[Fact]
@@ -112,13 +114,14 @@ public class HxMultiSelectTests : BunitTestBase
 		// Act
 		var cut = Render(componentRenderer);
 
-		// Assert — renders without checkboxes
-		var checkboxes = cut.FindAll("input[type='checkbox']");
-		Assert.Empty(checkboxes);
+		// Assert — renders the null-data text in the toggle and no options
+		var toggleValue = cut.Find(".combobox-value");
+		Assert.Contains("No data available", toggleValue.TextContent);
+		Assert.Empty(cut.FindAll("[role='option']"));
 	}
 
 	[Fact]
-	public void HxMultiSelect_Enabled_False_DisablesInput()
+	public void HxMultiSelect_Enabled_False_DisablesToggle()
 	{
 		// Arrange
 		var items = new[] { "Apple" };
@@ -140,13 +143,13 @@ public class HxMultiSelectTests : BunitTestBase
 		// Act
 		var cut = Render(componentRenderer);
 
-		// Assert — the input should be disabled
-		var input = cut.Find("input[type='text']");
-		Assert.NotNull(input.GetAttribute("disabled"));
+		// Assert — the toggle should be disabled
+		var toggle = cut.Find("button.combobox-toggle");
+		Assert.NotNull(toggle.GetAttribute("disabled"));
 	}
 
 	[Fact]
-	public void HxMultiSelect_Render_DoesNotEmitListboxOptionRoles()
+	public void HxMultiSelect_Render_EmitsAccessibleListboxRoles()
 	{
 		// Arrange
 		var items = new[] { "Apple", "Banana", "Cherry" };
@@ -167,8 +170,15 @@ public class HxMultiSelectTests : BunitTestBase
 		// Act
 		var cut = Render(componentRenderer);
 
-		// Assert
-		Assert.Empty(cut.FindAll("[role='listbox']"));
-		Assert.Empty(cut.FindAll("[role='option']"));
+		// Assert — the menu is an accessible multi-selectable listbox
+		var listbox = cut.Find("[role='listbox']");
+		Assert.Equal("true", listbox.GetAttribute("aria-multiselectable"));
+
+		// Assert — the toggle is wired up to the listbox popup
+		var toggle = cut.Find("button.combobox-toggle");
+		Assert.Equal("listbox", toggle.GetAttribute("aria-haspopup"));
+		Assert.Equal(listbox.Id, toggle.GetAttribute("aria-controls"));
+
+		Assert.Equal(3, cut.FindAll("[role='option']").Count);
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxMultiSelect.cs
@@ -38,7 +38,7 @@ public class HxMultiSelect<TValue, TItem> : HxInputBase<List<TValue>>, IInputWit
 	InputSize IInputWithSize.InputSizeEffective => InputSizeEffective;
 	string IInputWithSize.GetInputSizeCssClass() => InputSizeEffective.AsFormSelectCssClass();
 
-	private protected override string CoreInputCssClass => "hx-multi-select-input form-control user-select-none";
+	private protected override string CoreInputCssClass => "form-control combobox-toggle";
 
 	/// <summary>
 	/// Items to display. 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
@@ -1,9 +1,10 @@
-﻿@namespace Havit.Blazor.Components.Web.Bootstrap.Internal
+@namespace Havit.Blazor.Components.Web.Bootstrap.Internal
 @typeparam TValue
 @typeparam TItem
 
 @{
 	bool enabled = EnabledEffective && (ItemsToRender != null);
+	string menuId = $"{InputId}_menu";
 }
 <div class="@CssClassHelper.Combine("hx-multi-select",
 									HasInputGroups ? "input-group" : null,
@@ -16,114 +17,105 @@
 	}
 
 	@InputGroupStartTemplate
-	<div @ref="_elementReference"
-		 class="@CssClassHelper.Combine("hx-multi-select-toggle", (LabelTypeEffective == LabelType.Floating) ? "form-floating": null)">
+	<div class="@CssClassHelper.Combine("hx-multi-select-toggle", (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null)">
 
-		<input @ref="_inputElementReference"
-			   type="text"
-			   id="@InputId"
-			   class="@InputCssClass"
-			   value="@(((ItemsToRender == null) && !String.IsNullOrEmpty(NullDataText)) ? NullDataText : InputText)"
-			   disabled="@(!enabled)"
-			   readonly="true"
-			   aria-expanded="@_isShown"
-			   data-bs-toggle="@(enabled ? "menu" : null)"
-			   data-bs-auto-close="outside"
-			   @attributes="this.AdditionalAttributes" />
+		<button @ref="_toggleElementReference"
+				type="button"
+				id="@InputId"
+				class="@InputCssClass"
+				disabled="@(!enabled)"
+				aria-haspopup="listbox"
+				aria-expanded="@(_isShown ? "true" : "false")"
+				aria-controls="@menuId"
+				data-bs-toggle="@(enabled ? "menu" : null)"
+				data-bs-auto-close="outside"
+				@attributes="this.AdditionalAttributes">
+			<span class="@CssClassHelper.Combine("combobox-value", ShowPlaceholderStyle ? "combobox-placeholder" : null)">@GetToggleText()</span>
+			<svg class="combobox-caret" width="10" height="16" viewBox="0 0 10 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.46967 5.46967C0.762563 5.17678 1.23744 5.17678 1.53033 5.46967L5 8.93934L8.46967 5.46967C8.76256 5.17678 9.23744 5.17678 9.53033 5.46967C9.82322 5.76256 9.82322 6.23744 9.53033 6.53033L5.53033 10.5303C5.23744 10.8232 4.76256 10.8232 4.46967 10.5303L0.46967 6.53033C0.176777 6.23744 0.176777 5.76256 0.46967 5.46967Z" fill="currentcolor" /></svg>
+		</button>
 
-		@if (LabelTypeEffective == LabelType.Floating)
-		{
-			<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
-		}
-
-		@* Must be always rendered otherwise does not work after disable->enabled scenario *@
-		<ul class="@CssClassHelper.Combine("menu", _isShown ? "show" : null)">
+		@* The menu must always be rendered, otherwise it does not work after the disabled->enabled transition. *@
+		<div id="@menuId" class="@CssClassHelper.Combine("menu", _isShown ? "show" : null)" role="listbox" aria-multiselectable="true">
 			@if (enabled)
 			{
 				if (AllowFiltering)
 				{
-					<li>
-						<div class="hx-multi-select-filter-input-wrapper">
-							<input @ref="_filterInputReference"
-								   id="@($"{InputId}_filter")"
-								   type="text"
-								   class="@CssClassHelper.Combine("form-control", InputSizeEffective.AsFormControlCssClass())"
-								   autocomplete="off"
-								   spellcheck="false"
-								   value="@_filterText"
-								   @oninput="HandleFilterInputChanged"
-								   @onclick:stopPropagation
-								   onfocusin="this.select()" />
+					<div class="combobox-search hx-multi-select-filter-input-wrapper">
+						<input @ref="_filterInputReference"
+							   id="@($"{InputId}_filter")"
+							   type="text"
+							   class="@CssClassHelper.Combine("form-control", "combobox-search-input", InputSizeEffective.AsFormControlCssClass())"
+							   autocomplete="off"
+							   spellcheck="false"
+							   value="@_filterText"
+							   @oninput="HandleFilterInputChanged"
+							   @onclick:stopPropagation
+							   onfocusin="this.select()" />
 
-							<div class="hx-multi-select-filter-input-icon">
-								@if (string.IsNullOrEmpty(_filterText))
-								{
-									<HxIcon CssClass="hx-multi-select-filter-input-icon-search" Icon="@FilterSearchIcon" />
-								}
-								else
-								{
-									<div role="button" @onclick="HandleClearIconClick" @onclick:stopPropagation>
-										<HxIcon CssClass="hx-multi-select-filter-input-icon-clear" Icon="@FilterClearIcon" />
-									</div>
-								}
-							</div>
+						<div class="hx-multi-select-filter-input-icon">
+							@if (string.IsNullOrEmpty(_filterText))
+							{
+								<HxIcon CssClass="hx-multi-select-filter-input-icon-search" Icon="@FilterSearchIcon" />
+							}
+							else
+							{
+								<div role="button" @onclick="HandleClearIconClick" @onclick:stopPropagation>
+									<HxIcon CssClass="hx-multi-select-filter-input-icon-clear" Icon="@FilterClearIcon" />
+								</div>
+							}
 						</div>
-					</li>
+					</div>
 				}
 
 				var filteredItems = GetFilteredItems();
-				if (filteredItems.Count <= 0)
+				if (filteredItems.Count == 0)
 				{
-					<li>
-						@if (FilterEmptyResultTemplate is not null)
-						{
-							@FilterEmptyResultTemplate
-						}
-						else
-						{
-							<span class="p-2">@GetFilterEmptyResultText()</span>
-						}
-					</li>
+					if (FilterEmptyResultTemplate is not null)
+					{
+						@FilterEmptyResultTemplate
+					}
+					else
+					{
+						<div class="combobox-no-results">@GetFilterEmptyResultText()</div>
+					}
 				}
 				else
 				{
 					if (AllowSelectAll)
 					{
-						<li>
-							<button type="button" class="menu-item" @onclick="HandleSelectAllClickedAsync">
-								<div class="form-field">
-									<input class="check" type="checkbox" id="@($"{InputId}_selectall")" checked="@_selectAllChecked" tabindex="-1" />
-									<label for="@($"{InputId}_selectall")" @onclick:preventDefault>
-										@(GetSelectAllText())
-									</label>
-								</div>
-							</button>
-						</li>
+						<button type="button"
+								class="@CssClassHelper.Combine("menu-item", "hx-multi-select-item-select-all", _selectAllChecked ? "selected" : null)"
+								role="option"
+								aria-selected="@(_selectAllChecked ? "true" : "false")"
+								@onclick="HandleSelectAllClickedAsync">
+							<span>@GetSelectAllText()</span>
+							<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16"><path d="m2 7 4 5 8-8" /></svg>
+						</button>
 					}
 
-					for (var i = 0; i < filteredItems.Count; i++)
+					foreach (var item in filteredItems)
 					{
-						string checkboxElementId = InputId + "_" + i.ToString();
-
-						var item = filteredItems[i];
 						TValue value = SelectorHelpers.GetValue<TItem, TValue>(ValueSelector, item);
-
 						bool itemSelected = _currentSelectedValues.Contains(value);
 
-						<li>
-							<button type="button" class="menu-item" @onclick="async () => await HandleItemSelectionChangedAsync(!itemSelected, item)">
-								<div class="form-field">
-									<input class="check" type="checkbox" id="@checkboxElementId" checked="@itemSelected" tabindex="-1" />
-									<label for="@checkboxElementId" @onclick:preventDefault>
-										@SelectorHelpers.GetText(TextSelector, item)
-									</label>
-								</div>
-							</button>
-						</li>
+						<button @key="item"
+								type="button"
+								class="@CssClassHelper.Combine("menu-item", itemSelected ? "selected" : null)"
+								role="option"
+								aria-selected="@(itemSelected ? "true" : "false")"
+								@onclick="async () => await HandleItemSelectionChangedAsync(!itemSelected, item)">
+							<span>@SelectorHelpers.GetText(TextSelector, item)</span>
+							<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16"><path d="m2 7 4 5 8-8" /></svg>
+						</button>
 					}
 				}
 			}
-		</ul>
+		</div>
+
+		@if (LabelTypeEffective == LabelType.Floating)
+		{
+			<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
+		}
 	</div>
 	@InputGroupEndTemplate
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
@@ -93,12 +93,13 @@
 						</button>
 					}
 
-					foreach (var item in filteredItems)
+					for (var i = 0; i < filteredItems.Count; i++)
 					{
+						var item = filteredItems[i];
 						TValue value = SelectorHelpers.GetValue<TItem, TValue>(ValueSelector, item);
 						bool itemSelected = _currentSelectedValues.Contains(value);
 
-						<button @key="item"
+						<button @key="i"
 								type="button"
 								class="@CssClassHelper.Combine("menu-item", itemSelected ? "selected" : null)"
 								role="option"

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -279,8 +279,9 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		{
 			_filterText = string.Empty;
 			SynchronizeSelectAllCheckbox();
-			StateHasChanged();
 		}
+
+		StateHasChanged();
 
 		return Task.CompletedTask;
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.cs
@@ -71,10 +71,11 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 	protected bool HasInputGroupEnd => !String.IsNullOrWhiteSpace(InputGroupEndText) || (InputGroupEndTemplate is not null);
 	protected bool HasInputGroupStart => !String.IsNullOrWhiteSpace(InputGroupStartText) || (InputGroupStartTemplate is not null);
 
+	private bool ShowPlaceholderStyle => (ItemsToRender == null) || (_currentSelectedValues.Count == 0);
+
 	private IJSObjectReference _jsModule;
 	private readonly DotNetObjectReference<HxMultiSelectInternal<TValue, TItem>> _dotnetObjectReference;
-	private ElementReference _inputElementReference;
-	private ElementReference _elementReference;
+	private ElementReference _toggleElementReference;
 	private ElementReference _filterInputReference;
 	private bool _isShown;
 	private string _filterText = string.Empty;
@@ -105,7 +106,7 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 				return;
 			}
 
-			await _jsModule.InvokeVoidAsync("initialize", _elementReference, _dotnetObjectReference);
+			await _jsModule.InvokeVoidAsync("initialize", _toggleElementReference, _dotnetObjectReference);
 		}
 	}
 
@@ -211,6 +212,16 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		}
 	}
 
+	private string GetToggleText()
+	{
+		if ((ItemsToRender == null) && !string.IsNullOrEmpty(NullDataText))
+		{
+			return NullDataText;
+		}
+
+		return InputText;
+	}
+
 	private string GetSelectAllText()
 	{
 		return SelectAllText ?? StringLocalizer["SelectAllDefaultText"];
@@ -223,12 +234,11 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 
 	public async ValueTask FocusAsync()
 	{
-		if (EqualityComparer<ElementReference>.Default.Equals(_inputElementReference, default))
+		if (EqualityComparer<ElementReference>.Default.Equals(_toggleElementReference, default))
 		{
 			throw new InvalidOperationException($"[{GetType().Name}] Unable to focus. The method must be called after first render.");
 		}
-		await _inputElementReference.FocusAsync();
-		_isShown = true;
+		await _toggleElementReference.FocusAsync();
 	}
 
 	/// <summary>
@@ -241,7 +251,7 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		{
 			return;
 		}
-		await _jsModule.InvokeVoidAsync("show", _elementReference);
+		await _jsModule.InvokeVoidAsync("show", _toggleElementReference);
 	}
 
 	/// <summary>
@@ -254,7 +264,7 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		{
 			return;
 		}
-		await _jsModule.InvokeVoidAsync("hide", _elementReference);
+		await _jsModule.InvokeVoidAsync("hide", _toggleElementReference);
 	}
 
 	/// <summary>
@@ -279,6 +289,7 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 	public async Task HandleJsShown()
 	{
 		_isShown = true;
+		StateHasChanged();
 
 		if (AllowFiltering)
 		{
@@ -299,7 +310,7 @@ public partial class HxMultiSelectInternal<TValue, TItem> : IAsyncDisposable
 		{
 			try
 			{
-				await _jsModule.InvokeVoidAsync("dispose", _elementReference);
+				await _jsModule.InvokeVoidAsync("dispose", _toggleElementReference);
 				await _jsModule.DisposeAsync();
 			}
 			catch (JSDisconnectedException)

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.css
@@ -1,36 +1,16 @@
-﻿.hx-multi-select-toggle {
-	flex-grow: 1;
+.hx-multi-select-toggle {
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .menu {
-    min-width: var(--hx-multi-select-menu-width);
-    overflow: auto;
-    max-height: var(--hx-multi-select-menu-height);
+	min-width: var(--hx-multi-select-menu-width);
+	max-height: var(--hx-multi-select-menu-height);
+	overflow-y: auto;
 }
 
-.form-select[readonly]:not([disabled]) {
-    background-color: var(--hx-multi-select-background-color);
-}
-
-button.menu-item,
-.form-control[readonly] {
-    cursor: default;
-}
-
-.form-check {
-    margin-bottom: 0;
-}
-
-.form-check-input {
-    margin-left: -1.625em;
-}
-
-.hx-multi-select-input:hover {
-	cursor: default;
-}
-
-.form-check-label {
-	color: inherit;
+.hx-multi-select-filter-input-wrapper {
+	position: relative;
 }
 
 .hx-multi-select-filter-input-icon {
@@ -44,28 +24,20 @@ button.menu-item,
 	z-index: 5;
 }
 
-.hx-multi-select-filter-input-wrapper {
-	position: relative;
-	flex: 1 1 auto;
-	width: 100%;
-	min-width: 0;
-	padding: 0.25em;
-}
-
 .form-control-sm ~ .hx-multi-select-filter-input-icon {
 	font-size: .75rem;
 }
 
 .hx-multi-select-filter-input-icon div[role="button"]:not(:hover) ::deep .hx-icon {
-	opacity: var(--hx-multi-select-filter-input-icon-opacity);
+	opacity: var(--hx-multi-select-filter-input-icon-opacity, .25);
 }
 
-.input-group-start ::deep .form-select {
+.input-group-start .combobox-toggle {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }
 
-.input-group-end ::deep .form-select {
+.input-group-end .combobox-toggle {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
@@ -152,7 +152,6 @@
 	--hx-select-filter-input-icon-opacity: 						.25;
 
 	/* HxMultiSelect */
-	--hx-multi-select-background-color: 							var(--bs-bg-body);
 	--hx-multi-select-menu-height: 						300px;
 	--hx-multi-select-filter-input-icon-opacity: 					.25;
 	--hx-multi-select-menu-width: 							100%;

--- a/Havit.Blazor.Documentation/Pages/Components/HxMultiSelectDoc/HxMultiSelect_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMultiSelectDoc/HxMultiSelect_Documentation.razor
@@ -38,10 +38,6 @@
 			Minimal width of the menu.
 		</ApiDocCssVariable>
 
-		<ApiDocCssVariable Name="--hx-multi-select-background-color" Default="var(--bs-bg-body)">
-			Background color of the menu.
-		</ApiDocCssVariable>
-
 		<ApiDocCssVariable Name="--hx-multi-select-filter-input-icon-opacity" Default=".25">
 			Opacity of the filter input icon.
 		</ApiDocCssVariable>


### PR DESCRIPTION
## What

Rebuilds `HxMultiSelect` on the **Bootstrap 6 combobox** pattern and makes it accessible, mirroring the combobox markup already shipped for `HxSelect` (filtering) in #1492.

The internal markup changes from a readonly `form-select` input + `<ul>/<li>` + checkboxes to:

- a `.combobox-toggle` button with `.combobox-value` + caret, `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls`
- a `div.menu[role="listbox"][aria-multiselectable="true"]` whose **direct children** are `.menu-item[role="option"]` buttons carrying `aria-selected` / `.selected` / `menu-item-check`
- the existing `.combobox-search` filter input, select-all row, and no-results message, restyled to the combobox classes

## Why

The previous markup exposed **no listbox/option roles and no keyboard navigation** — it was only mechanically renamed (`dropdown` → `menu`) during the v6 migration. This brings it in line with the Bootstrap 6 combobox and the sibling `HxSelect`.

## How it works

- Keyboard nav (↑/↓ roving, Home/End, Enter/Space, Esc), focus and open/close are owned by the Bootstrap 6 `Menu` plugin (`data-bs-toggle="menu"`). `data-bs-auto-close="outside"` keeps the menu open while toggling items.
- Selection state stays **C#-owned** (two-way binding, select-all, custom filtering, templates all preserved) — we deliberately do not use the `Combobox` JS plugin, which manages its own DOM state and would fight Blazor.
- Selected items keep the **comma-separated** display in the toggle.

## Notes for reviewers

- `HxSelect` / `HxSelectInternal` are intentionally **untouched** (mirror approach, not a shared dual-mode internal — avoids regressing the just-shipped HxSelect filtering).
- `HxMultiSelect.js` needed no change: it already drives `bootstrap.Menu` on the toggle and bridges `shown/hidden.bs.menu` to .NET.
- Dropped the now-orphaned `--hx-multi-select-background-color` CSS variable (it styled the old readonly `form-select`) and its docs entry.
- Unit tests previously locked in the old checkbox markup and asserted the *absence* of listbox/option roles; updated to assert the accessible combobox markup.

## Verification

- Build clean with `-warnaserror` (0/0).
- 1118 unit tests pass on net9.0 and net10.0.
- Verified live in the Documentation app: open/close, multi-select keeps menu open, comma toggle text, check icons, keyboard navigation (arrows / Home / End / Esc returns focus to toggle), filtering (auto-focus, no-results, clear icon), select-all / deselect-all. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)