### PR TITLE
[doc] [v6] HxTooltip: add disabled-elements demo

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Demo_DisabledElements.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Demo_DisabledElements.razor
@@ -1,3 +1,3 @@
-<HxTooltip Text="Tooltip on a disabled button">
+<HxTooltip Text="Tooltip on a disabled button" Trigger="TooltipTrigger.Hover">
 	<HxButton Color="ThemeColor.Primary" Text="Disabled button" Enabled="false" />
 </HxTooltip>

--- a/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Demo_DisabledElements.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Demo_DisabledElements.razor
@@ -1,0 +1,3 @@
+<HxTooltip Text="Tooltip on a disabled button">
+	<HxButton Color="ThemeColor.Primary" Text="Disabled button" Enabled="false" />
+</HxTooltip>

--- a/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Documentation.razor
@@ -32,8 +32,9 @@
 
     <DocHeading Title="Disabled elements" />
 	<p>
-		Elements with the <code>disabled</code> attribute aren't interactive, so they can't be hovered or focused to trigger a tooltip.
-		<code>HxTooltip</code> renders a <code>&lt;span&gt;</code> wrapper around its content, so the tooltip works on disabled elements out of the box&mdash;no extra markup required.
+		Disabled elements use <code>pointer-events: none</code>, so they can't directly receive the events that trigger a tooltip.
+		<code>HxTooltip</code> wraps its content in a <code>&lt;span&gt;</code> and attaches the trigger to that wrapper, so a <strong>hover</strong>-triggered tooltip works on disabled elements out of the box&mdash;no extra markup required.
+		Focus triggering doesn't apply here, as neither the disabled control nor the wrapper is focusable.
 	</p>
 	<Demo Type="typeof(HxTooltip_Demo_DisabledElements)" Tabs="false" />
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTooltipDoc/HxTooltip_Documentation.razor
@@ -30,6 +30,13 @@
 	<p>Use <code>Html="true"</code> to enable HTML in the tooltip.</p>
 	<Demo Type="typeof(HxTooltip_Demo_HtmlContent)" />
 
+    <DocHeading Title="Disabled elements" />
+	<p>
+		Elements with the <code>disabled</code> attribute aren't interactive, so they can't be hovered or focused to trigger a tooltip.
+		<code>HxTooltip</code> renders a <code>&lt;span&gt;</code> wrapper around its content, so the tooltip works on disabled elements out of the box&mdash;no extra markup required.
+	</p>
+	<Demo Type="typeof(HxTooltip_Demo_DisabledElements)" Tabs="false" />
+
     <DocHeading Title="Programmability" />
 	<p>
 		You can use the <code>ShowAsync()</code> and <code>HideAsync()</code> methods, as well as the <code>OnShown</code> and <code>OnHidden</code> events,


### PR DESCRIPTION
Adds the Bootstrap 6 "Disabled elements" demo to the `HxTooltip` docs.

`HxTooltip` renders a `<span>` wrapper around its content, so tooltips work on disabled elements with no extra markup. The new demo shows a tooltip on a disabled `HxButton`.

Part of #1523 (doc/demo-only). Responsive-placement and custom-container from that issue need component support and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL

---
_Generated by [Claude Code](https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL)_