### PR TITLE
[doc] [v6] HxPopover: add disabled-elements demo

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_DisabledElements.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_DisabledElements.razor
@@ -1,3 +1,3 @@
-<HxPopover Title="Popover title" Content="Popovers work on disabled elements too.">
+<HxPopover Title="Popover title" Content="Popovers work on disabled elements too." Trigger="PopoverTrigger.Hover">
 	<HxButton Color="ThemeColor.Primary" Text="Disabled button" Enabled="false" />
 </HxPopover>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_DisabledElements.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_DisabledElements.razor
@@ -1,0 +1,3 @@
+<HxPopover Title="Popover title" Content="Popovers work on disabled elements too.">
+	<HxButton Color="ThemeColor.Primary" Text="Disabled button" Enabled="false" />
+</HxPopover>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Documentation.razor
@@ -31,8 +31,8 @@
 
     <DocHeading Title="Disabled elements" />
 	<p>
-		Elements with the <code>disabled</code> attribute aren't interactive, so they can't be hovered or clicked to trigger a popover.
-		<code>HxPopover</code> renders a <code>&lt;span&gt;</code> wrapper around its content, so the popover works on disabled elements out of the box&mdash;no extra markup required.
+		Disabled elements use <code>pointer-events: none</code>, so they can't directly receive the hover, focus, or click events that trigger a popover.
+		<code>HxPopover</code> wraps its content in a <code>&lt;span&gt;</code> and attaches the trigger to that wrapper, so popovers work on disabled elements out of the box&mdash;no extra markup required.
 	</p>
 	<Demo Type="typeof(HxPopover_Demo_DisabledElements)" Tabs="false" />
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Documentation.razor
@@ -29,6 +29,13 @@
 	</DocAlert>
 	<Demo Type="typeof(HxPopover_Demo_Dismissible)" />
 
+    <DocHeading Title="Disabled elements" />
+	<p>
+		Elements with the <code>disabled</code> attribute aren't interactive, so they can't be hovered or clicked to trigger a popover.
+		<code>HxPopover</code> renders a <code>&lt;span&gt;</code> wrapper around its content, so the popover works on disabled elements out of the box&mdash;no extra markup required.
+	</p>
+	<Demo Type="typeof(HxPopover_Demo_DisabledElements)" Tabs="false" />
+
     <DocHeading Title="Programmability" />
 	<p>
 		You can use the <code>ShowAsync()</code> and <code>HideAsync()</code> methods, as well as the <code>OnShown</code> and <code>OnHidden</code> events,


### PR DESCRIPTION
Adds the Bootstrap 6 "Disabled elements" demo to the `HxPopover` docs.

`HxPopover` renders a `<span>` wrapper around its content, so popovers work on disabled elements with no extra markup. The new demo shows a popover on a disabled `HxButton`.

Part of #1523 (doc/demo-only). Responsive-placement and custom-container from that issue need component support and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL

---
_Generated by [Claude Code](https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL)_