### PR TITLE
[doc] [v6] HxToast: add placement demo

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Demo_Placement.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Demo_Placement.razor
@@ -1,0 +1,16 @@
+<HxButton Text="Show toast" Color="ThemeColor.Primary" OnClick="() => _show = true" />
+
+<HxToastContainer Position="ToastContainerPosition.BottomEnd">
+	@if (_show)
+	{
+		<HxToast HeaderText="Bootstrap"
+				 HeaderIcon="BootstrapIcon.InfoCircleFill"
+				 ContentText="Hello, world! This toast is pinned to the bottom-end of the viewport."
+				 AutohideDelay="5000"
+				 OnToastHidden="() => _show = false" />
+	}
+</HxToastContainer>
+
+@code {
+	private bool _show;
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxToastDoc/HxToast_Documentation.razor
@@ -15,6 +15,13 @@
 		</p>
 		<Demo Type="typeof(HxToast_Demo)" />
 
+		<DocHeading Title="Placement" />
+		<p>
+			Use the <code>Position</code> parameter of <code>HxToastContainer</code> to place toasts in any of the nine viewport positions
+			(for example <code>ToastContainerPosition.BottomEnd</code>). The container is positioned with <code>position-fixed</code>, so the toast appears relative to the viewport.
+		</p>
+		<Demo Type="typeof(HxToast_Demo_Placement)" />
+
 		<DocAlert Type="DocAlertType.Info">
 			<code>HxToast</code> supports static server rendering.
 		</DocAlert>


### PR DESCRIPTION
Adds the Bootstrap 6 "Placement" demo to the `HxToast` docs.

`HxToastContainer.Position` supports all nine viewport positions; the new demo shows a button-triggered toast pinned to the bottom-end of the viewport. Part of #1517 (doc/demo-only).

Note: stacking, custom content, and a live trigger are already shown in the existing "Direct toast rendering" demo. Dark/themed-variant toasts need component support (`data-bs-theme` passthrough) and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL

---
_Generated by [Claude Code](https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL)_