### PR TITLE
[doc] [v6] HxNavOverflow: add disabled-items demo

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Demo_DisabledItems.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Demo_DisabledItems.razor
@@ -1,0 +1,13 @@
+<div class="border rounded p-2" style="resize: horizontal; overflow: hidden; min-width: 250px; max-width: 100%;">
+	<HxNavOverflow>
+		<HxNavLink Href="#" Text="Home" />
+		<HxNavLink Href="#" Text="Dashboard" />
+		<HxNavLink Href="#" Text="Products" Enabled="false" />
+		<HxNavLink Href="#" Text="Services" />
+		<HxNavLink Href="#" Text="Analytics" Enabled="false" />
+		<HxNavLink Href="#" Text="Reports" />
+		<HxNavLink Href="#" Text="Settings" />
+		<HxNavLink Href="#" Text="Help" />
+	</HxNavOverflow>
+</div>
+<p class="mt-2 mb-0 small text-secondary">Disabled items keep their disabled state when moved to the "More" menu.</p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Documentation.razor
@@ -21,6 +21,10 @@
 	</p>
 	<Demo Type="typeof(HxNavOverflow_Demo_KeepVisible)" />
 
+	<DocHeading Title="Disabled items" />
+	<p>Disabled items (<code>Enabled="false"</code>) keep their disabled state when they are moved to the "More" overflow menu.</p>
+	<Demo Type="typeof(HxNavOverflow_Demo_DisabledItems)" />
+
 	<DocHeading Title="Minimum visible items" />
 	<p>Use <code>MinimumVisibleItems</code> to ensure a minimum number of items remains visible before the overflow kicks in.</p>
 	<Demo Type="typeof(HxNavOverflow_Demo_MinimumVisibleItems)" />


### PR DESCRIPTION
Adds the Bootstrap 6 "With disabled items" demo to the `HxNavOverflow` docs.

Shows that nav items with `Enabled="false"` keep their disabled state when moved into the "More" overflow menu. Part of #1525 (doc/demo-only).

Note: the "in a navbar" item from #1525 is left for a follow-up — `HxNavbar` has its own responsive collapse, so combining it with `HxNavOverflow` warrants a dedicated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL

---
_Generated by [Claude Code](https://claude.ai/code/session_012HXqrHvYs7xNSPC1n1XLHL)_