### PR TITLE
HxTabPanel: align tab markup with Bootstrap 6

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tabs/HxTabPanel.razor
@@ -45,7 +45,6 @@
 					           role="tab"
 					           id="@(tab.Id + "-header")"
 					           aria-controls="@((RenderMode == TabPanelRenderMode.AllTabs || IsActive(tab)) ? tab.Id : null)"
-					           aria-describedby="@((RenderMode == TabPanelRenderMode.AllTabs || IsActive(tab)) ? tab.Id : null)"
 					           aria-selected="@(IsActive(tab) ? "true" : "false")"
 					           tabindex="@(IsActive(tab) ? "0" : "-1")">
 						@tab.Title
@@ -66,7 +65,7 @@
 					if ((RenderMode == TabPanelRenderMode.AllTabs)
 					|| ((RenderMode == TabPanelRenderMode.ActiveTabOnly) && IsActive(tab)))
 					{
-                        <div @key="@tab.Id" id="@tab.Id" role="tabpanel" aria-labelledby="@(tab.Id + "-header")" tabindex="0"  class="@CssClassHelper.Combine("tab-pane", (IsActive(tab) ? "active" : String.Empty), tab.ContentCssClass)">
+                        <div @key="@tab.Id" id="@tab.Id" role="tabpanel" aria-labelledby="@(tab.Id + "-header")" tabindex="0"  class="@CssClassHelper.Combine("tab-pane fade", (IsActive(tab) ? "show active" : null), tab.ContentCssClass)">
                             @tab.Content
 						</div>
 					}


### PR DESCRIPTION
Aligns `HxTabPanel`'s rendered markup with the [Bootstrap 6 nav-tab reference](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/tab/#nav-tab).

## Changes
- **`fade show` on the active tab pane.** BS6 renders panes as `tab-pane fade show active`; we rendered only `tab-pane active`. Active panes now get `fade show active`, inactive panes get `tab-pane fade`, enabling the fade transition (visible in `AllTabs` render mode).
- **Removed the non-standard `aria-describedby`** from tab headers. It duplicated `aria-controls` and isn't part of the BS6 tab pattern.

Roles/ARIA (`role="tablist"/"tab"/"tabpanel"`, `aria-selected`, `aria-controls`, `aria-labelledby`) and the roving `tabindex` are unchanged.

## Not included (intentional)
- The Blazor-driven toggle (no `data-bs-toggle`/`data-bs-target`) is kept — `HxTabPanel` manages active state via `OnClick` + re-render rather than Bootstrap's tab JS.
- Tab controls still render as `<a>` (via `HxNavLink`) rather than `<button type="button">`; switching to `<button>` is a broader `HxNav`/`HxNavLink` change tracked separately.

## Verification
Verified in the documentation app: the active pane renders `tab-pane fade show active` (opacity 1, visible), tab switching works, and `aria-describedby` is gone while other ARIA attributes remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)