### PR TITLE
[v6] HxAlert: push dismiss button to the end with ms-auto

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Alerts/HxAlert.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Alerts/HxAlert.razor
@@ -3,6 +3,6 @@
 	@ChildContent
 	@if (Dismissible)
 	{
-		<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+		<button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
 	}
 </div>


### PR DESCRIPTION
In Bootstrap 6 `.alert` is a flex container, so the dismiss button needs `ms-auto` to sit at the end instead of immediately after the content.

## Change
- `HxAlert` renders the close button as `btn-close ms-auto` when `Dismissible`.

Verified in the documentation app: the close button aligns to the trailing edge of the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)