### PR TITLE
[doc] [v6] Demo card layout, CodeSnippet header/copy, and BS6 demo alignment

### DIFF
--- a/Havit.Blazor.Documentation.Server/App.razor
+++ b/Havit.Blazor.Documentation.Server/App.razor
@@ -65,9 +65,13 @@
 		window.highlightCode = function () {
 			Prism.highlightAll();
 		};
-		window.copyTextFromElement = function (element) {
+		window.copyTextFromElement = async function (element) {
 			if (element && navigator.clipboard) {
-				navigator.clipboard.writeText(element.textContent.trim());
+				try {
+					await navigator.clipboard.writeText(element.textContent.trim());
+				} catch (e) {
+					// clipboard write failed (e.g., permission denied)
+				}
 			}
 		};
 	</script>

--- a/Havit.Blazor.Documentation.Server/App.razor
+++ b/Havit.Blazor.Documentation.Server/App.razor
@@ -65,6 +65,11 @@
 		window.highlightCode = function () {
 			Prism.highlightAll();
 		};
+		window.copyTextFromElement = function (element) {
+			if (element && navigator.clipboard) {
+				navigator.clipboard.writeText(element.textContent.trim());
+			}
+		};
 	</script>
 </body>
 </html>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAlertDoc/HxAlert_Demo_AdditionalContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAlertDoc/HxAlert_Demo_AdditionalContent.razor
@@ -1,6 +1,8 @@
-﻿<HxAlert Color="ThemeColor.Success">
-	<h4 class="alert-heading">Well done!</h4>
-	<p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
-	<hr>
-	<p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
+<HxAlert Color="ThemeColor.Success">
+	<div class="vstack">
+		<h4 class="alert-heading mb-2">Well done!</h4>
+		<p>Aww yeah, you successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
+		<hr class="my-3">
+		<p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
+	</div>
 </HxAlert>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAlertDoc/HxAlert_Demo_Basic.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAlertDoc/HxAlert_Demo_Basic.razor
@@ -4,5 +4,5 @@
 <HxAlert Color="ThemeColor.Danger">A simple danger alert—check it out!</HxAlert>
 <HxAlert Color="ThemeColor.Warning">A simple warning alert—check it out!</HxAlert>
 <HxAlert Color="ThemeColor.Info">A simple info alert—check it out!</HxAlert>
-<HxAlert Color="ThemeColor.Secondary">A simple light alert—check it out!</HxAlert>
+<HxAlert Color="ThemeColor.Accent">A simple accent alert—check it out!</HxAlert>
 <HxAlert Color="ThemeColor.Inverse">A simple dark alert—check it out!</HxAlert>

--- a/Havit.Blazor.Documentation/Pages/Components/HxAlertDoc/HxAlert_Demo_LinkColor.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxAlertDoc/HxAlert_Demo_LinkColor.razor
@@ -1,4 +1,4 @@
-<HxAlert Color="ThemeColor.Primary">A simple primary alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</HxAlert>
-<HxAlert Color="ThemeColor.Success">A simple success alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</HxAlert>
-<HxAlert Color="ThemeColor.Danger">A simple danger alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</HxAlert>
-<HxAlert Color="ThemeColor.Warning">A simple warning alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</HxAlert>
+<HxAlert Color="ThemeColor.Primary"><p>A simple primary alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</p></HxAlert>
+<HxAlert Color="ThemeColor.Success"><p>A simple success alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</p></HxAlert>
+<HxAlert Color="ThemeColor.Danger"><p>A simple danger alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</p></HxAlert>
+<HxAlert Color="ThemeColor.Warning"><p>A simple warning alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.</p></HxAlert>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Basic.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Basic.razor
@@ -1,6 +1,6 @@
 ﻿<HxMenu>
 	<Toggle>
-		<HxMenuToggleButton Color="ThemeColor.Secondary">Menu button</HxMenuToggleButton>
+		<HxMenuToggleButton Color="ThemeColor.Primary">Toggle menu</HxMenuToggleButton>
 	</Toggle>
 	<Content>
 		<HxMenuItemNavLink Href="/components/HxMenu">Link with Href</HxMenuItemNavLink>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_SplitButton.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_SplitButton.razor
@@ -1,23 +1,14 @@
-﻿<HxButtonGroup>
-	<HxButton Color="ThemeColor.Secondary" OnClick="HandleMainButtonClick">Action button</HxButton>
+<HxButtonGroup>
+	<HxButton Color="ThemeColor.Secondary">Split</HxButton>
 	<HxMenu>
 		<Toggle>
-			<HxMenuToggleButton Color="ThemeColor.Secondary">
+			<HxMenuToggleButton Color="ThemeColor.Secondary" Icon="BootstrapIcon.ChevronExpand">
 				<span class="visually-hidden">Toggle menu</span>@* OPTIONAL (for accessibility) *@
 			</HxMenuToggleButton>
 		</Toggle>
 		<Content>
-			<HxMenuItemNavLink Href="#">Link with Href</HxMenuItemNavLink>
-			<HxMenuItem OnClick="HandleMenuItemClick">Item with OnClick action</HxMenuItem>
-			<HxMenuDivider />
-			<HxMenuText>Something else here</HxMenuText>
+			<HxMenuItemNavLink Href="#">Action</HxMenuItemNavLink>
+			<HxMenuItemNavLink Href="#">Another action</HxMenuItemNavLink>
 		</Content>
 	</HxMenu>
 </HxButtonGroup>
-
-@message
-@code {
-	private string message;
-	private void HandleMainButtonClick() => message = "Main button clicked";
-	private void HandleMenuItemClick() => message = "Menu item clicked";
-}

--- a/Havit.Blazor.Documentation/Pages/GettingStarted/GettingStarted.razor
+++ b/Havit.Blazor.Documentation/Pages/GettingStarted/GettingStarted.razor
@@ -50,7 +50,8 @@
 
 <DocHeading Title="Installation to your project" Id="installation" Level="2" />
 <p>Select your setup to get customized instructions.</p>
-<HxAlert Color="ThemeColor.Secondary">
+<HxCard CssClass="card-demo my-3" BodyCssClass="p-3">
+	<BodyTemplate>
 	<div class="w-100">
 	<HxRadioButtonList Label="Framework version"
 					   TItem="TargetFramework"
@@ -111,7 +112,8 @@
 					   ButtonSize="ButtonSize.Small"
 					   CssClass="mb-2" />
 	</div>
-</HxAlert>
+	</BodyTemplate>
+</HxCard>
 
 
 
@@ -134,7 +136,7 @@ else
 		or execute the following command:
 	</p>
 }
-<CodeSnippet Language="none">dotnet add package Havit.Blazor.Components.Web.Bootstrap</CodeSnippet>
+<CodeSnippet Language="csharp">dotnet add package Havit.Blazor.Components.Web.Bootstrap</CodeSnippet>
 
 
 
@@ -145,7 +147,8 @@ else
 	Ensure that the link to <code>{YourBlazorApp}.styles.css</code> remains in your <code>@GetHtmlHostFile()</code>
 	and has NOT been removed.
 </p>
-<HxAlert Color="ThemeColor.Secondary">
+<HxCard CssClass="card-demo my-3" BodyCssClass="p-3">
+	<BodyTemplate>
 	<div class="w-100">
 	<HxRadioButtonList Label="Choose a Bootstrap CSS bundle"
 					   TItem="BootstrapTheme"
@@ -161,7 +164,8 @@ else
 					   ButtonSize="ButtonSize.Small"
 					   CssClass="mb-2" />
 	</div>
-</HxAlert>
+	</BodyTemplate>
+</HxCard>
 
 @if ((_setup.BootstrapTheme == BootstrapTheme.HavitBlazor) || (_setup.BootstrapTheme == BootstrapTheme.PlainCdn))
 {

--- a/Havit.Blazor.Documentation/Pages/MigrationGuideV6_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/MigrationGuideV6_Documentation.razor
@@ -33,7 +33,7 @@
 
 <DocHeading Title="NuGet packages" Level="3" />
 <p>Update all <code>Havit.Blazor.*</code> packages to the matching 6.x versions:</p>
-<CodeSnippet Language="none">dotnet add package Havit.Blazor.Components.Web.Bootstrap</CodeSnippet>
+<CodeSnippet Language="csharp">dotnet add package Havit.Blazor.Components.Web.Bootstrap</CodeSnippet>
 
 <DocHeading Title="Bootstrap CSS" Level="3" />
 <p>

--- a/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor
@@ -12,7 +12,7 @@
 		</div>
 	</HeaderTemplate>
 	<BodyTemplate>
-		<pre class="bg-body-tertiary align-self-stretch min-w-0">
+		<pre class="bg-2 align-self-stretch min-w-0">
 			<code @ref="_codeElement" class="language-@(GetEffectiveLanguage())">
 @ChildContent@(_code)
 			</code>

--- a/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor
@@ -1,7 +1,21 @@
-﻿<HxCard CssClass="code-snippet mb-3">
-	<pre class="bg-body-tertiary">
-		<code class="language-@(Language ?? GetLanguageFromFileExtension() ?? "cshtml")">
+<HxCard CssClass="code-snippet mb-3" HeaderCssClass="py-1 pe-1" BodyCssClass="p-0">
+	<HeaderTemplate>
+		<div class="d-flex justify-content-between align-items-center">
+			<span class="fg-secondary text-uppercase fs-xs font-monospace">@GetLanguageLabel()</span>
+			<HxButton Icon="@(_copied ? BootstrapIcon.ClipboardCheck : BootstrapIcon.Clipboard)"
+					  Variant="ButtonVariant.Text"
+					  Color="ThemeColor.Secondary"
+					  Size="ButtonSize.Small"
+					  Tooltip="Copy to clipboard"
+					  OnClick="CopyToClipboardAsync"
+					  CssClass="btn-icon fg-body" />
+		</div>
+	</HeaderTemplate>
+	<BodyTemplate>
+		<pre class="bg-body-tertiary align-self-stretch min-w-0">
+			<code @ref="_codeElement" class="language-@(GetEffectiveLanguage())">
 @ChildContent@(_code)
-		</code>
-	</pre>
+			</code>
+		</pre>
+	</BodyTemplate>
 </HxCard>

--- a/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor.cs
@@ -11,6 +11,44 @@ public partial class CodeSnippet : ComponentBase
 	[Inject] protected IJSRuntime JSRuntime { get; set; }
 
 	private string _code;
+	private ElementReference _codeElement;
+	private bool _copied;
+
+	private async Task CopyToClipboardAsync()
+	{
+		await JSRuntime.InvokeVoidAsync("copyTextFromElement", _codeElement);
+		_copied = true;
+		// Fire-and-forget the revert so the click handler returns immediately
+		// (an awaited delay keeps the button in the "click in progress" state, which shows a spinner).
+		_ = RevertCopiedAfterDelayAsync();
+	}
+
+	private async Task RevertCopiedAfterDelayAsync()
+	{
+		await Task.Delay(2000);
+		_copied = false;
+		await InvokeAsync(StateHasChanged);
+	}
+
+	private string GetEffectiveLanguage() => Language ?? GetLanguageFromFileExtension() ?? "cshtml";
+
+	private string GetLanguageLabel()
+	{
+		return GetEffectiveLanguage() switch
+		{
+			"cshtml" => "Razor",
+			"razor" => "Razor",
+			"html" => "HTML",
+			"css" => "CSS",
+			"csharp" => "C#",
+			"cs" => "C#",
+			"js" => "JavaScript",
+			"json" => "JSON",
+			"xml" => "XML",
+			"none" => null,
+			var other => other?.ToUpperInvariant()
+		};
+	}
 
 	protected override async Task OnParametersSetAsync()
 	{
@@ -52,12 +90,10 @@ public partial class CodeSnippet : ComponentBase
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
 		await base.OnAfterRenderAsync(firstRender);
-		await JSRuntime.InvokeVoidAsync("highlightCode");
-	}
-
-	protected override bool ShouldRender()
-	{
-		return false; // static content
+		if (firstRender)
+		{
+			await JSRuntime.InvokeVoidAsync("highlightCode");
+		}
 	}
 
 }

--- a/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/CodeSnippet.razor.cs
@@ -2,7 +2,7 @@
 
 namespace Havit.Blazor.Documentation.Shared.Components;
 
-public partial class CodeSnippet : ComponentBase
+public partial class CodeSnippet : ComponentBase, IDisposable
 {
 	[Parameter] public string File { get; set; }
 	[Parameter] public RenderFragment ChildContent { get; set; }
@@ -13,21 +13,42 @@ public partial class CodeSnippet : ComponentBase
 	private string _code;
 	private ElementReference _codeElement;
 	private bool _copied;
+	private CancellationTokenSource _revertCts;
 
 	private async Task CopyToClipboardAsync()
 	{
+		if (_revertCts is not null)
+		{
+			await _revertCts.CancelAsync();
+			_revertCts.Dispose();
+		}
+		_revertCts = new CancellationTokenSource();
+
 		await JSRuntime.InvokeVoidAsync("copyTextFromElement", _codeElement);
 		_copied = true;
 		// Fire-and-forget the revert so the click handler returns immediately
 		// (an awaited delay keeps the button in the "click in progress" state, which shows a spinner).
-		_ = RevertCopiedAfterDelayAsync();
+		_ = RevertCopiedAfterDelayAsync(_revertCts.Token);
 	}
 
-	private async Task RevertCopiedAfterDelayAsync()
+	private async Task RevertCopiedAfterDelayAsync(CancellationToken cancellationToken)
 	{
-		await Task.Delay(2000);
+		try
+		{
+			await Task.Delay(2000, cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+			return;
+		}
 		_copied = false;
 		await InvokeAsync(StateHasChanged);
+	}
+
+	public void Dispose()
+	{
+		_revertCts?.Cancel();
+		_revertCts?.Dispose();
 	}
 
 	private string GetEffectiveLanguage() => Language ?? GetLanguageFromFileExtension() ?? "cshtml";

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -32,7 +32,7 @@ else
 @code {
 	private void RenderDemo(RenderTreeBuilder __builder)
 	{
-		<div class="@CssClassHelper.Combine("p-3", DemoCardCssClass)">
+		<div class="@CssClassHelper.Combine("demo-content p-3 align-self-stretch vstack gap-3", DemoCardCssClass)">
 			<DynamicComponent Type="Type" />
 		</div>
 	}
@@ -47,7 +47,7 @@ else
 		}
 		else
 		{
-			<pre class="@(!Tabs ? "bg-body-tertiary" : null)">
+			<pre class="@CssClassHelper.Combine("align-self-stretch min-w-0", !Tabs ? "bg-body-tertiary" : null)">
 				<code class="language-cshtml">
 					@(_code.Trim())
 				</code>

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -47,7 +47,7 @@ else
 		}
 		else
 		{
-			<pre class="@CssClassHelper.Combine("align-self-stretch min-w-0", !Tabs ? "bg-body-tertiary" : null)">
+			<pre class="@CssClassHelper.Combine("align-self-stretch min-w-0", !Tabs ? "bg-2" : null)">
 				<code class="language-cshtml">
 					@(_code.Trim())
 				</code>

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
@@ -16,7 +16,7 @@ public partial class Demo : PerformanceLoggingComponentBase
 	private readonly RenderFragment _renderCode;
 	private readonly CardSettings _cardSettings = new()
 	{
-		CssClass = "card-demo my-3",
+		CssClass = "card-demo",
 		BodyCssClass = "p-0"
 	};
 

--- a/Havit.Blazor.Documentation/Shared/Components/DocAlert.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/DocAlert.razor
@@ -1,4 +1,4 @@
-﻿<HxAlert Color="GetColor()" @attributes="AdditionalAttributes">
+﻿<HxAlert Color="GetColor()" CssClass="mb-3" @attributes="AdditionalAttributes">
 	<div class="row">
 		<div class="col-auto align-top">
 			<HxIcon Icon="GetBootstrapIcon()" CssClass="fs-5 lh-sm" />

--- a/Havit.Blazor.Documentation/Shared/MainLayout.razor
+++ b/Havit.Blazor.Documentation/Shared/MainLayout.razor
@@ -9,7 +9,7 @@
 <div class="doc-container container-fluid md:d-flex min-vh-100">
 	<Sidebar CssClass="d-none lg:d-flex" />
 
-	<div style="min-width: 0;" class="doc-content main md:p-4 pt-0 flex-grow-1 overflow-hidden">
+	<div style="min-width: 0;" class="doc-content prose main md:p-4 pt-0 flex-grow-1 overflow-hidden">
         <CascadingValue Value="_docHeadContentTracker" IsFixed="true">
 		    @Body
         </CascadingValue>

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -12,7 +12,7 @@
    stretch full-width by design. Buttons and button groups should keep their natural width. */
 .demo-content > .btn,
 .demo-content > .btn-group {
-	align-self: start;
+	align-self: flex-start;
 }
 
 /* In the tabbed demo variant the tab content is a flex child of the (flex-column) card body;

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -15,6 +15,12 @@
 	align-self: start;
 }
 
+/* In the tabbed demo variant the tab content is a flex child of the (flex-column) card body;
+   stretch it so the demo fills the full width like the non-tabbed variant. */
+.card-demo > .card-body > .tab-content {
+	align-self: stretch;
+}
+
 #blazor-error-ui {
 	background: lightyellow;
 	bottom: 0;

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -8,6 +8,13 @@
 	--hx-sidebar-body-padding: 				0 1rem 0 0;
 }
 
+/* Demo content uses vstack to stack and space items; block-level elements (e.g. alerts)
+   stretch full-width by design. Buttons and button groups should keep their natural width. */
+.demo-content > .btn,
+.demo-content > .btn-group {
+	align-self: start;
+}
+
 #blazor-error-ui {
 	background: lightyellow;
 	bottom: 0;


### PR DESCRIPTION
Documentation/demo improvements from a working session, batched into one PR.

## Changes
- **Demo card layout** — demo content & source code stretch to full card width (`min-w-0` so long code lines scroll), `vstack gap-3` spacing, buttons keep natural width via `align-self`, `prose` on the doc content column, dropped demo-card vertical margin.
- **CodeSnippet** — wrap the code in a card body (gives the BS6 card its border), add a header with the language label and a text-variant icon button that copies to the clipboard and briefly shows a check.
- **HxAlert demos** — align Additional content / Basic / Link color demos with Bootstrap 6; add `mb-3` to `DocAlert`.
- **HxMenu demos** — align basic and split-button demos with Bootstrap 6 (chevron icon, reference content).
- **Getting started / migration** — present setup options in demo cards; label `dotnet add package` snippets as C#.
- **Tabbed demo width** — stretch tab content so tabbed demos (e.g. HxCarousel) fill the card.

## Notes
- Targets `v6` directly. Overlaps PR #1526 on several demo files, so whichever merges second will need a small rebase.
- The `HxAlert` `ms-auto` library fix from the same session is split out into #1539.
- Verified: `Havit.Blazor.Documentation` builds clean (0 warnings / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)