### PR TITLE
[doc] [v6] Mobile navbar dropdown, centered search, demo code header

### DIFF
--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -47,8 +47,22 @@ else
 		}
 		else
 		{
-			<pre class="@CssClassHelper.Combine("align-self-stretch min-w-0", !Tabs ? "bg-2" : null)">
-				<code class="language-cshtml">
+			@* Inline (non-tabbed) code gets a header separating it from the demo, with the language name and a copy button. *@
+			if (!Tabs)
+			{
+				<div class="d-flex justify-content-between align-items-center ps-3 pe-1 py-1 align-self-stretch border-top border-subtle">
+					<span class="fg-secondary text-uppercase fs-xs font-monospace">Razor</span>
+					<HxButton Icon="@(_copied ? BootstrapIcon.ClipboardCheck : BootstrapIcon.Clipboard)"
+							  Variant="ButtonVariant.Text"
+							  Color="ThemeColor.Secondary"
+							  Size="ButtonSize.Small"
+							  Tooltip="Copy to clipboard"
+							  OnClick="CopyCodeAsync"
+							  CssClass="btn-icon fg-body" />
+				</div>
+			}
+			<pre class="@CssClassHelper.Combine("align-self-stretch min-w-0 mb-0", !Tabs ? "bg-2" : null)">
+				<code @ref="_codeElement" class="language-cshtml">
 					@(_code.Trim())
 				</code>
 			</pre>

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
@@ -12,8 +12,25 @@ public partial class Demo : PerformanceLoggingComponentBase
 	[Inject] protected IJSRuntime JSRuntime { get; set; }
 
 	private string _code;
+	private ElementReference _codeElement;
+	private bool _copied;
 	private readonly RenderFragment _renderDemo;
 	private readonly RenderFragment _renderCode;
+
+	private async Task CopyCodeAsync()
+	{
+		await JSRuntime.InvokeVoidAsync("copyTextFromElement", _codeElement);
+		_copied = true;
+		// Fire-and-forget the revert so the click handler returns immediately (an awaited delay would show a spinner on the button).
+		_ = RevertCopiedAfterDelayAsync();
+	}
+
+	private async Task RevertCopiedAfterDelayAsync()
+	{
+		await Task.Delay(2000);
+		_copied = false;
+		await InvokeAsync(StateHasChanged);
+	}
 	private readonly CardSettings _cardSettings = new()
 	{
 		CssClass = "card-demo",

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
@@ -3,7 +3,7 @@ using Microsoft.JSInterop;
 
 namespace Havit.Blazor.Documentation.Shared.Components;
 
-public partial class Demo : PerformanceLoggingComponentBase
+public partial class Demo : PerformanceLoggingComponentBase, IDisposable
 {
 	[Parameter] public Type Type { get; set; }
 	[Parameter] public bool Tabs { get; set; } = true;
@@ -14,23 +14,47 @@ public partial class Demo : PerformanceLoggingComponentBase
 	private string _code;
 	private ElementReference _codeElement;
 	private bool _copied;
+	private CancellationTokenSource _copiedCts;
 	private readonly RenderFragment _renderDemo;
 	private readonly RenderFragment _renderCode;
 
 	private async Task CopyCodeAsync()
 	{
 		await JSRuntime.InvokeVoidAsync("copyTextFromElement", _codeElement);
+
+		// Cancel any in-flight revert before starting a new one.
+		if (_copiedCts is not null)
+		{
+			await _copiedCts.CancelAsync();
+			_copiedCts.Dispose();
+		}
+		_copiedCts = new CancellationTokenSource();
+
 		_copied = true;
 		// Fire-and-forget the revert so the click handler returns immediately (an awaited delay would show a spinner on the button).
-		_ = RevertCopiedAfterDelayAsync();
+		_ = RevertCopiedAfterDelayAsync(_copiedCts.Token);
 	}
 
-	private async Task RevertCopiedAfterDelayAsync()
+	private async Task RevertCopiedAfterDelayAsync(CancellationToken cancellationToken)
 	{
-		await Task.Delay(2000);
+		try
+		{
+			await Task.Delay(2000, cancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+			return;
+		}
 		_copied = false;
 		await InvokeAsync(StateHasChanged);
 	}
+
+	public void Dispose()
+	{
+		_copiedCts?.Cancel();
+		_copiedCts?.Dispose();
+	}
+
 	private readonly CardSettings _cardSettings = new()
 	{
 		CssClass = "card-demo",

--- a/Havit.Blazor.Documentation/Shared/Components/DocAlert.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/DocAlert.razor
@@ -1,4 +1,4 @@
-﻿<HxAlert Color="GetColor()" CssClass="mb-3" @attributes="AdditionalAttributes">
+﻿<HxAlert Color="GetColor()" @attributes="AdditionalAttributes">
 	<div class="row">
 		<div class="col-auto align-top">
 			<HxIcon Icon="GetBootstrapIcon()" CssClass="fs-5 lh-sm" />

--- a/Havit.Blazor.Documentation/Shared/Components/Search/Search.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Search/Search.razor
@@ -1,4 +1,4 @@
-﻿@namespace Havit.Blazor.Documentation.Shared.Components
+@namespace Havit.Blazor.Documentation.Shared.Components
 @using System.Globalization
 
 <div class="position-relative search-wrapper">
@@ -11,13 +11,12 @@
 				   MinimumLength="1"
 				   Delay="1"
 				   CssClass="sidebar-search"
+				   SearchIcon="BootstrapIcon.Search"
 				   DataProvider="ProvideSuggestions">
 		<ItemTemplate Context="searchItem"><span class="small">@searchItem.Title</span></ItemTemplate>
 		<EmptyTemplate>
 			<span class="p-2">No matches found</span>
 		</EmptyTemplate>
 	</HxAutosuggest>
-	<small class="search-shortcut-hint position-absolute top-50 translate-middle-y text-muted user-select-none" style="pointer-events: none; font-size: 0.75rem; right: 2.75rem;">
-		@(_isMac ? "⌘K" : "Ctrl+K")
-	</small>
+	<kbd class="search-shortcut-hint position-absolute top-50 translate-middle-y border rounded bg-body fg-secondary fw-normal user-select-none py-0" style="right: 2.75rem; pointer-events: none;">@(_isMac ? "⌘K" : "Ctrl+K")</kbd>
 </div>

--- a/Havit.Blazor.Documentation/Shared/Navbar.razor
+++ b/Havit.Blazor.Documentation/Shared/Navbar.razor
@@ -25,10 +25,10 @@
 				</Toggle>
 				<Content>
 					<HxMenuItemNavLink Href="" Match="NavLinkMatch.All">Home</HxMenuItemNavLink>
-					<HxMenuItemNavLink Href="getting-started">Docs</HxMenuItemNavLink>
-					<HxMenuItemNavLink Href="https://blocks.havit.blazor.eu">Blocks</HxMenuItemNavLink>
-					<HxMenuItemNavLink Href="showcase">Showcase</HxMenuItemNavLink>
-					<HxMenuItemNavLink Href="premium">Premium</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="getting-started" Match="NavLinkMatch.Prefix">Docs</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="https://blocks.havit.blazor.eu" Match="@((NavLinkMatch?)null)">Blocks</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="showcase" Match="NavLinkMatch.Prefix">Showcase</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="premium" Match="NavLinkMatch.Prefix">Premium</HxMenuItemNavLink>
 				</Content>
 			</HxMenu>
 		</div>

--- a/Havit.Blazor.Documentation/Shared/Navbar.razor
+++ b/Havit.Blazor.Documentation/Shared/Navbar.razor
@@ -1,35 +1,50 @@
-﻿<div class="@CssClassHelper.Combine(CssClass, "nav-container mx-auto sticky-top bg-body border-bottom border-subtle")">
-	<HxNavbar ContainerCssClass="container-fluid">
-		<HxNavbarBrand CssClass="py-0">
-			<img src="./logo.png" width="32" height="30" alt="HAVIT Blazor">
-			<span class="fw-semibold">HAVIT Blazor</span>
-		</HxNavbarBrand>
-		<HxNavbarToggler CssClass="border-0" />
-		<HxNavbarDrawer>
-			<HxNav CssClass="mx-auto justify-content-center gap-3 my-3 lg:my-0">
-				<HxNavLink Href="" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover" Match="NavLinkMatch.All">
-					Introduction
-				</HxNavLink>
-				<HxNavLink Href="getting-started" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">
-					Documentation
-				</HxNavLink>
-				<HxNavLink Href="https://blocks.havit.blazor.eu" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">
-					Blocks
-				</HxNavLink>
-				<HxNavLink Href="showcase" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">
-					Showcase
-				</HxNavLink>
-				<HxNavLink Href="premium" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">
-					Premium
-				</HxNavLink>
-			</HxNav>
-            <div class="d-flex gap-3 align-items-center justify-content-center">
-                <Search />
+@inject NavigationManager NavigationManager
 
-				<a href="https://github.com/havit/Havit.Blazor" class="btn-text theme-secondary btn-icon" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
-					<HxIcon Icon="BootstrapIcon.Github" />
-				</a>
-				<Havit.Blazor.Documentation.Shared.Components.DocColorMode.DocColorModeSwitcher />
+<div class="@CssClassHelper.Combine(CssClass, "nav-container mx-auto sticky-top border-bottom border-subtle")">
+	<HxNavbar CssClass="navbar-translucent" ContainerCssClass="container-fluid position-relative">
+		<HxNavbarBrand CssClass="py-0 d-flex align-items-center gap-2 me-0 xl:me-3">
+			<img src="./logo.png" width="32" height="30" alt="HAVIT Blazor">
+			<span class="fw-semibold d-none sm:d-inline">HAVIT Blazor</span>
+		</HxNavbarBrand>
+
+		@* Separator between the brand and the mobile section dropdown (Bootstrap docs style: "Brand / Docs"). *@
+		<span class="xl:d-none text-body-secondary mx-2" aria-hidden="true">/</span>
+
+		@* Main navigation as a dropdown below xl; the inline nav in the drawer takes over at xl+.
+		   Wrap in an xl:d-none element because HxMenu's own CssClass applies to the menu panel, not the toggle. *@
+		<div class="xl:d-none">
+			<HxMenu>
+				<Toggle>
+					<HxMenuToggleButton Color="ThemeColor.Secondary"
+										Variant="ButtonVariant.Text"
+										Icon="BootstrapIcon.ChevronExpand"
+										IconPlacement="ButtonIconPlacement.End"
+										CssClass="nav-link fw-medium link-body-emphasis">
+						@GetCurrentSectionLabel()
+					</HxMenuToggleButton>
+				</Toggle>
+				<Content>
+					<HxMenuItemNavLink Href="" Match="NavLinkMatch.All">Home</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="getting-started">Docs</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="https://blocks.havit.blazor.eu">Blocks</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="showcase">Showcase</HxMenuItemNavLink>
+					<HxMenuItemNavLink Href="premium">Premium</HxMenuItemNavLink>
+				</Content>
+			</HxMenu>
+		</div>
+
+		<HxNavbarDrawer>
+			@* Inline horizontal navigation for xl+ (below xl the main nav collapses to the dropdown so it doesn't overlap the centered search); aligned to the left. *@
+			<HxNav CssClass="d-none xl:d-flex fs-sm gap-2 my-3 lg:my-0">
+				<HxNavLink Href="getting-started" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">Docs</HxNavLink>
+				<HxNavLink Href="https://blocks.havit.blazor.eu" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">Blocks</HxNavLink>
+				<HxNavLink Href="showcase" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">Showcase</HxNavLink>
+				<HxNavLink Href="premium" CssClass="px-3 link-body-emphasis link-opacity-75 link-opacity-100-hover">Premium</HxNavLink>
+			</HxNav>
+
+			@* Search absolutely centered in the navbar on lg+ (see site.css .navbar-search-center); normal flow in the mobile drawer. *@
+			<div class="d-flex justify-content-center my-3 lg:my-0 navbar-search-center">
+				<Search />
 			</div>
 
 			@* Component navigation for mobile (the desktop sidebar is hidden below the lg breakpoint by the layout).
@@ -38,10 +53,38 @@
 				<Sidebar Embedded="true" />
 			</div>
 		</HxNavbarDrawer>
+
+		@* GitHub link + theme switcher stay always visible in the navbar (not tucked into the offcanvas on mobile). *@
+		<div class="d-flex gap-3 align-items-center ms-auto">
+			<a href="https://github.com/havit/Havit.Blazor" class="btn-text theme-secondary btn-icon" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
+				<HxIcon Icon="BootstrapIcon.Github" />
+			</a>
+			<Havit.Blazor.Documentation.Shared.Components.DocColorMode.DocColorModeSwitcher />
+		</div>
+
+		<HxNavbarToggler CssClass="border-0 ms-3" />
 	</HxNavbar>
 </div>
 
 @code
 {
 	[Parameter] public string CssClass { get; set; }
+
+	private string GetCurrentSectionLabel()
+	{
+		var relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri).ToLowerInvariant();
+		if (string.IsNullOrEmpty(relativePath))
+		{
+			return "Home";
+		}
+		if (relativePath.StartsWith("showcase"))
+		{
+			return "Showcase";
+		}
+		if (relativePath.StartsWith("premium"))
+		{
+			return "Premium";
+		}
+		return "Docs";
+	}
 }

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -21,6 +21,16 @@
 	align-self: stretch;
 }
 
+/* Center the docs search in the navbar on lg+ (absolute, so the nav stays hard-left and the controls hard-right).
+   In the mobile drawer (< lg) the search stays in normal flow. */
+@media (min-width: 1024px) {
+	.nav-container .navbar-search-center {
+		position: absolute;
+		left: 50%;
+		transform: translateX(-50%);
+	}
+}
+
 #blazor-error-ui {
 	background: lightyellow;
 	bottom: 0;
@@ -44,6 +54,16 @@ code[class*=language-],
 pre[class*=language-] {
 	text-shadow: none;
 	color: var(--bs-secondary-color);
+}
+
+/* Inline code (not the Prism-highlighted source blocks) colored with a pink theme color. */
+.prose code:not([class*="language-"]) {
+	color: var(--bs-pink-500);
+}
+
+/* The active item in the navbar mobile dropdown is shown in medium weight. */
+.nav-container .menu .menu-item.active {
+	font-weight: 500;
 }
 
 


### PR DESCRIPTION
Reworks the documentation navbar/search for Bootstrap 6 and adds a few docs polish items.

## Navbar
- **Mobile main nav → dropdown** (Bootstrap docs style) instead of folding into the offcanvas. It collapses to the dropdown **below `xl`** so it no longer overlaps the absolutely-centered search; the inline nav returns at `xl`+.
- Dropped **Introduction**; keep **Docs / Blocks / Showcase / Premium**; added a mobile-only **Home** item; **"/" brand separator** (Bootstrap "Brand / Section" style); active item in `fw-medium`.
- **`navbar-translucent`** (blurred, semi-transparent bar).
- **GitHub + theme switcher always visible** in the bar, spaced from the toggler.
- **Logo-only on phones** (brand text hidden `< sm`) so the always-visible utilities fit on one row.
- Main nav `fs-sm`, `gap-2`.

## Search
- Centered (absolute) in the navbar, search icon on the **right**, with a **⌘K / Ctrl+K** shortcut badge inside the field.

## Demo
- Non-tabbed demo cards: the inline source code now has a **header** with the language name + a **copy button** (matching the CodeSnippet header).

## Other
- **DocAlert**: removed the now-obsolete `mb-3` (spacing comes from the `prose` gap).
- **site.css**: inline `<code>` colored with a pink theme color; tab-content stretches full-width in card demos; active dropdown item `fw-medium`.

Verified across breakpoints (375 / 1150 / 1280 / 1400) in the docs app: dropdown vs inline switch, no search overlap, translucent bar, code header copy, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)