### PR TITLE
Add HxSubmenu for nested menus in HxMenu (v6)

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMenuTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMenuTests.cs
@@ -170,4 +170,93 @@ public class HxMenuTests : BunitTestBase
 		var span = cut.Find("span.menu-text");
 		Assert.Contains("Plain text", span.TextContent);
 	}
+
+	[Fact]
+	public void HxSubmenu_RendersSubmenuStructure()
+	{
+		// Act
+		var cut = RenderComponent<HxMenu>(p => p
+			.Add<HxSubmenu>(m => m.Content, submenu => submenu
+				.Add(s => s.Text, "File")
+				.AddChildContent<HxMenuItem>(item => item
+					.AddChildContent("New"))));
+
+		// Assert
+		var submenu = cut.Find("div.submenu");
+		var trigger = submenu.QuerySelector("button.menu-item");
+		Assert.NotNull(trigger);
+		Assert.Equal("button", trigger.GetAttribute("type"));
+		Assert.Contains("File", trigger.TextContent);
+		Assert.Equal("true", trigger.GetAttribute("aria-haspopup"));
+		Assert.Equal("false", trigger.GetAttribute("aria-expanded"));
+
+		// the nested menu (sibling of the trigger) contains the items
+		var nestedMenu = submenu.QuerySelector("div.menu");
+		Assert.NotNull(nestedMenu);
+		Assert.Equal(nestedMenu, trigger.NextElementSibling);
+		Assert.Contains("New", nestedMenu.TextContent);
+	}
+
+	[Fact]
+	public void HxSubmenu_TitleTemplate_TakesPrecedenceOverText()
+	{
+		// Act
+		var cut = RenderComponent<HxMenu>(p => p
+			.Add<HxSubmenu>(m => m.Content, submenu => submenu
+				.Add(s => s.Text, "Ignored")
+				.Add(s => s.TitleTemplate, "<strong>Custom</strong>")));
+
+		// Assert
+		var trigger = cut.Find("div.submenu > button.menu-item");
+		Assert.Contains("Custom", trigger.TextContent);
+		Assert.DoesNotContain("Ignored", trigger.TextContent);
+		Assert.NotNull(trigger.QuerySelector("strong"));
+	}
+
+	[Fact]
+	public void HxSubmenu_EnabledFalse_HasDisabledTrigger()
+	{
+		// Act
+		var cut = RenderComponent<HxMenu>(p => p
+			.Add<HxSubmenu>(m => m.Content, submenu => submenu
+				.Add(s => s.Text, "File")
+				.Add(s => s.Enabled, false)));
+
+		// Assert
+		var trigger = cut.Find("div.submenu > button.menu-item");
+		Assert.True(trigger.ClassList.Contains("disabled"), "Disabled submenu trigger should have 'disabled' CSS class.");
+		Assert.True(trigger.HasAttribute("disabled"), "Disabled submenu trigger should have the 'disabled' attribute.");
+	}
+
+	[Fact]
+	public void HxSubmenu_CssClass_IsAppliedToSubmenuWrapper()
+	{
+		// Act
+		var cut = RenderComponent<HxMenu>(p => p
+			.Add<HxSubmenu>(m => m.Content, submenu => submenu
+				.Add(s => s.Text, "File")
+				.Add(s => s.CssClass, "my-submenu")));
+
+		// Assert
+		var submenu = cut.Find("div.submenu");
+		Assert.True(submenu.ClassList.Contains("my-submenu"));
+	}
+
+	[Fact]
+	public void HxSubmenu_NestedSubmenus_RenderNestedStructure()
+	{
+		// Act
+		var cut = RenderComponent<HxMenu>(p => p
+			.Add<HxSubmenu>(m => m.Content, level1 => level1
+				.Add(s => s.Text, "Level 1")
+				.AddChildContent<HxSubmenu>(level2 => level2
+					.Add(s => s.Text, "Level 2")
+					.AddChildContent<HxMenuItem>(item => item
+						.AddChildContent("Deep item")))));
+
+		// Assert
+		var submenus = cut.FindAll("div.submenu");
+		Assert.Equal(2, submenus.Count);
+		Assert.Contains("Deep item", cut.Markup);
+	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Menus/HxSubmenu.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Menus/HxSubmenu.razor
@@ -1,0 +1,22 @@
+@namespace Havit.Blazor.Components.Web.Bootstrap
+@using Havit.Blazor.Components.Web.Bootstrap.Internal
+<div class="@CssClassHelper.Combine("submenu", CssClass)" @attributes="AdditionalAttributes">
+    <button type="button"
+            class="@CssClassHelper.Combine("menu-item", CascadeEnabledComponent.EnabledEffective(this) ? null : "disabled", Color?.ToThemeCss())"
+            disabled="@(CascadeEnabledComponent.EnabledEffective(this) ? null : "disabled")"
+            aria-haspopup="true"
+            aria-expanded="false">
+        <HxMenuItemIconInternal Icon="@Icon" CssClass="@IconCssClass" />
+        @if (TitleTemplate is not null)
+        {
+            @TitleTemplate
+        }
+        else
+        {
+            @Text
+        }
+    </button>
+    <div class="menu">
+        @ChildContent
+    </div>
+</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Menus/HxSubmenu.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Menus/HxSubmenu.razor.cs
@@ -1,0 +1,58 @@
+using Havit.Blazor.Components.Web.Infrastructure;
+
+namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Submenu (nested menu) for the <see cref="HxMenu"/>. Renders a <c>div.submenu</c> wrapper with a <c>button.menu-item</c> trigger
+/// and a nested <c>.menu</c> element (with <see cref="ChildContent"/>). Submenus can be nested to any depth.<br />
+/// See <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/menu/#submenus">Bootstrap 6 submenus</see>.
+/// The opening (hover/click), positioning and keyboard navigation are handled by the parent <c>HxMenu</c>'s Bootstrap instance.
+/// </summary>
+public partial class HxSubmenu : ICascadeEnabledComponent
+{
+	[CascadingParameter] protected FormState FormState { get; set; }
+	FormState ICascadeEnabledComponent.FormState { get => FormState; set => FormState = value; }
+
+	/// <summary>
+	/// Text of the submenu trigger. Ignored when <see cref="TitleTemplate"/> is set.
+	/// </summary>
+	[Parameter] public string Text { get; set; }
+
+	/// <summary>
+	/// Custom content of the submenu trigger. Takes precedence over <see cref="Text"/>.
+	/// </summary>
+	[Parameter] public RenderFragment TitleTemplate { get; set; }
+
+	/// <summary>
+	/// Icon of the submenu trigger (use <see cref="BootstrapIcon" />).
+	/// </summary>
+	[Parameter] public IconBase Icon { get; set; }
+
+	/// <summary>
+	/// Additional CSS class(es) for the submenu trigger icon.
+	/// </summary>
+	[Parameter] public string IconCssClass { get; set; }
+
+	/// <summary>
+	/// Theme color variant of the trigger (renders the <c>theme-*</c> class).
+	/// </summary>
+	[Parameter] public ThemeColor? Color { get; set; }
+
+	/// <summary>
+	/// The nested menu content (typically <see cref="HxMenuItem"/>, <see cref="HxMenuItemNavLink"/>, another <see cref="HxSubmenu"/>, etc.).
+	/// </summary>
+	[Parameter] public RenderFragment ChildContent { get; set; }
+
+	/// <inheritdoc cref="ICascadeEnabledComponent.Enabled" />
+	[Parameter] public bool? Enabled { get; set; }
+
+	/// <summary>
+	/// Additional CSS class for the underlying <c>.submenu</c> element.
+	/// </summary>
+	[Parameter] public string CssClass { get; set; }
+
+	/// <summary>
+	/// Additional attributes to be splatted onto the underlying <c>.submenu</c> element.
+	/// </summary>
+	[Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> AdditionalAttributes { get; set; }
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Submenus.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Submenus.razor
@@ -1,0 +1,32 @@
+<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Submenus</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		<HxMenuItem OnClick='() => Select("New")'>New</HxMenuItem>
+		<HxSubmenu Text="Open recent" Icon="BootstrapIcon.ClockHistory">
+			<HxMenuItem OnClick='() => Select("project-a.sln")'>project-a.sln</HxMenuItem>
+			<HxMenuItem OnClick='() => Select("project-b.sln")'>project-b.sln</HxMenuItem>
+			<HxMenuDivider />
+			<HxSubmenu Text="More…">
+				<HxMenuItem OnClick='() => Select("archived.sln")'>archived.sln</HxMenuItem>
+			</HxSubmenu>
+		</HxSubmenu>
+		<HxMenuDivider />
+		<HxSubmenu Text="Export" Icon="BootstrapIcon.BoxArrowUp">
+			<HxMenuItem OnClick='() => Select("PDF")'>PDF</HxMenuItem>
+			<HxMenuItem OnClick='() => Select("PNG")'>PNG</HxMenuItem>
+		</HxSubmenu>
+		<HxSubmenu Text="Disabled submenu" Enabled="false">
+			<HxMenuItem>Unreachable</HxMenuItem>
+		</HxSubmenu>
+	</Content>
+</HxMenu>
+@if (message is not null)
+{
+	<p class="mt-2">Selected: <strong>@message</strong></p>
+}
+@code {
+	private string message;
+	private void Select(string value) => message = value;
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Documentation.razor
@@ -2,6 +2,7 @@
 @attribute [Route("/components/" + nameof(HxMenuToggleButton))]
 @attribute [Route("/components/" + nameof(HxMenuToggleElement))]
 @attribute [Route("/components/" + nameof(HxMenuItem))]
+@attribute [Route("/components/" + nameof(HxSubmenu))]
 @attribute [Route("/components/" + nameof(HxMenuItemNavLink))]
 @attribute [Route("/components/" + nameof(HxMenuText))]
 @attribute [Route("/components/" + nameof(HxMenuHeader))]
@@ -41,6 +42,15 @@
 		<p>Set <code>CssClass="active"</code> to highlight the item.</p>
 		<p>Set <code>Enabled="false"</code> to disable the item. The <code>HxFormState.Enabled</code> inheritance is also supported.</p>
 		<Demo Type="typeof(HxMenu_Demo_HeaderDisabledActive)" />
+
+		<DocHeading Title="Submenus" Id="submenus" />
+		<p>
+			Use <code>HxSubmenu</code> to create a nested menu. It renders a <code>.submenu</code> trigger that opens the nested
+			<code>Content</code> on hover or click. Submenus can be nested to any depth, and support the same <code>Icon</code> and
+			<code>Enabled</code> behavior as <code>HxMenuItem</code>.
+			See the <a href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/menu/#submenus">Bootstrap documentation</a>.
+		</p>
+		<Demo Type="typeof(HxMenu_Demo_Submenus)" />
 
 		<DocHeading Title="Custom content" />
 		<p>Place any custom content directly into the <code>Content</code> render fragment.</p>
@@ -89,6 +99,7 @@
 <ApiDoc Type="typeof(HxMenuToggleButton)" />
 <ApiDoc Type="typeof(HxMenuToggleElement)" />
 <ApiDoc Type="typeof(HxMenuItem)" />
+<ApiDoc Type="typeof(HxSubmenu)" />
 <ApiDoc Type="typeof(HxMenuItemNavLink)" />
 <ApiDoc Type="typeof(HxMenuText)" />
 <ApiDoc Type="typeof(HxMenuHeader)" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Documentation.razor
@@ -45,9 +45,9 @@
 
 		<DocHeading Title="Submenus" Id="submenus" />
 		<p>
-			Use <code>HxSubmenu</code> to create a nested menu. It renders a <code>.submenu</code> trigger that opens the nested
-			<code>Content</code> on hover or click. Submenus can be nested to any depth, and support the same <code>Icon</code> and
-			<code>Enabled</code> behavior as <code>HxMenuItem</code>.
+			Use <code>HxSubmenu</code> to create a nested menu. Set the trigger via <code>Text</code> (or <code>TitleTemplate</code>)
+			and place the nested items in its child content; the submenu opens on hover or click. Submenus can be nested to any depth,
+			and the trigger supports the same <code>Icon</code> and <code>Enabled</code> behavior as <code>HxMenuItem</code>.
 			See the <a href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/menu/#submenus">Bootstrap documentation</a>.
 		</p>
 		<Demo Type="typeof(HxMenu_Demo_Submenus)" />

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -11083,6 +11083,57 @@
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxMenuToggleElement.DisposeAsync">
             <inheritdoc/>
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu">
+            <summary>
+            Submenu (nested menu) for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxMenu"/>. Renders a <c>div.submenu</c> wrapper with a <c>button.menu-item</c> trigger
+            and a nested <c>.menu</c> element (with <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.ChildContent"/>). Submenus can be nested to any depth.<br />
+            See <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/menu/#submenus">Bootstrap 6 submenus</see>.
+            The opening (hover/click), positioning and keyboard navigation are handled by the parent <c>HxMenu</c>'s Bootstrap instance.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.Text">
+            <summary>
+            Text of the submenu trigger. Ignored when <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.TitleTemplate"/> is set.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.TitleTemplate">
+            <summary>
+            Custom content of the submenu trigger. Takes precedence over <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.Text"/>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.Icon">
+            <summary>
+            Icon of the submenu trigger (use <see cref="T:Havit.Blazor.Components.Web.Bootstrap.BootstrapIcon" />).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.IconCssClass">
+            <summary>
+            Additional CSS class(es) for the submenu trigger icon.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.Color">
+            <summary>
+            Theme color variant of the trigger (renders the <c>theme-*</c> class).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.ChildContent">
+            <summary>
+            The nested menu content (typically <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxMenuItem"/>, <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxMenuItemNavLink"/>, another <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu"/>, etc.).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.Enabled">
+            <inheritdoc cref="P:Havit.Blazor.Components.Web.Infrastructure.ICascadeEnabledComponent.Enabled" />
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.CssClass">
+            <summary>
+            Additional CSS class for the underlying <c>.submenu</c> element.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxSubmenu.AdditionalAttributes">
+            <summary>
+            Additional attributes to be splatted onto the underlying <c>.submenu</c> element.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.IHxMenuToggle">
             <summary>
             Interface to help keep the menu-toggle implementations aligned.


### PR DESCRIPTION
## What

Adds support for [Bootstrap 6 submenus](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/menu/#submenus) to `HxMenu` via a new **`HxSubmenu`** component.

## Why

`HxMenu` (the Bootstrap 6 replacement for the Dropdown) didn't support nested menus. Bootstrap 6 introduced submenus, so the component family needs a matching API.

## How

Bootstrap implements submenus purely as DOM structure — a `.submenu` wrapper containing a `.menu-item` trigger plus a nested `.menu`. The parent `HxMenu`'s existing Bootstrap `Menu` instance auto-wires hover/click activation, keyboard navigation, and viewport-aware positioning through **delegated** events on `.submenu > .menu-item`, so **no `HxMenu.js` changes were required** — only the correct markup.

`HxSubmenu` mirrors `HxMenuItem`'s surface:
- `Text` / `TitleTemplate` (rich trigger content), `Icon` / `IconCssClass`, `Color`
- `Enabled` via `ICascadeEnabledComponent` (so `HxFormState` inheritance works)
- `CssClass`, `AdditionalAttributes`
- `ChildContent` for the nested items

Submenus can be nested to any depth. `aria-haspopup` / `aria-expanded` are rendered statically (Bootstrap toggles them at runtime), matching the existing `HxMenuToggleButton` pattern.

No per-submenu placement parameter is exposed — Bootstrap hardcodes submenu placement to `end-start` with viewport-aware flip/shift.

## Changes

- `Menus/HxSubmenu.razor` + `.razor.cs` — new component
- `HxMenuTests.cs` — 5 new tests (structure, `TitleTemplate` precedence, disabled, `CssClass`, multi-level nesting)
- `HxMenu_Demo_Submenus.razor` — demo (icons, nested submenus, disabled submenu)
- `HxMenu_Documentation.razor` — Submenus section + route + ApiDoc
- regenerated `XmlDoc` for the new members

## Verification

- Component lib + Documentation build clean (0 warnings / 0 errors)
- All 564 unit tests pass
- Runtime (live docs site): submenu flies out on hover at the expected `end-start` position, `aria-expanded` toggles, multi-level nesting and the disabled trigger render correctly, no console errors

## Reviewer note — naming

Named **`HxSubmenu`** (matches Bootstrap's `.submenu`). The rest of the family uses an `HxMenu*` prefix (`HxMenuItem`, `HxMenuText`…), so if strict prefix-consistency is preferred it'd be `HxMenuSubmenu`. Easy to rename — flag it if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)