### PR TITLE
[doc] [v6] HxDialog: add Swapping and Non-modal demos

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Demo_NonModal.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Demo_NonModal.razor
@@ -1,0 +1,15 @@
+<HxButton OnClick="() => myDialog.ShowAsync()" Color="ThemeColor.Primary">Open non-modal dialog</HxButton>
+
+<HxDialog @ref="myDialog" Title="Non-modal dialog" NonModal="true">
+	<BodyTemplate>
+		This dialog is opened with the browser-native <code>show()</code> instead of <code>showModal()</code>. There is no backdrop, no focus trap, and the rest of the page stays interactive &ndash; you can keep clicking the button behind it.
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="() => myDialog.HideAsync()" Color="ThemeColor.Primary">Close</HxButton>
+	</FooterTemplate>
+</HxDialog>
+
+@code
+{
+	private HxDialog myDialog;
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Demo_Swapping.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Demo_Swapping.razor
@@ -1,0 +1,27 @@
+<HxButton OnClick="() => firstDialog.ShowAsync()" Color="ThemeColor.Primary">Open first dialog</HxButton>
+
+<HxDialog @ref="firstDialog" Title="First dialog">
+	<BodyTemplate>
+		Opening the second dialog automatically swaps it in place of this one &ndash; the backdrop stays visible the whole time, with no flicker.
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="() => firstDialog.HideAsync()" Color="ThemeColor.Secondary">Close</HxButton>
+		<HxButton OnClick="() => secondDialog.ShowAsync()" Color="ThemeColor.Primary">Open second dialog</HxButton>
+	</FooterTemplate>
+</HxDialog>
+
+<HxDialog @ref="secondDialog" Title="Second dialog">
+	<BodyTemplate>
+		This is the second dialog. You can swap back to the first one.
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="() => secondDialog.HideAsync()" Color="ThemeColor.Secondary">Close</HxButton>
+		<HxButton OnClick="() => firstDialog.ShowAsync()" Color="ThemeColor.Primary">Back to first dialog</HxButton>
+	</FooterTemplate>
+</HxDialog>
+
+@code
+{
+	private HxDialog firstDialog;
+	private HxDialog secondDialog;
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Documentation.razor
@@ -27,6 +27,14 @@
 	<p>Use the <code>Animation</code> parameter to choose the open/close animation of the dialog. The default is <code>DialogAnimation.Fade</code>, use <code>DialogAnimation.None</code> to disable the animation.</p>
 	<Demo Type="typeof(HxDialog_Demo_Animation)" />
 
+    <DocHeading Title="Swapping dialogs" />
+		<p>When a button inside an open dialog opens another dialog, the dialogs <strong>swap</strong> &ndash; the first one closes as the second one opens, and the backdrop stays visible the whole time without flickering. Just call <code>ShowAsync()</code> on the other dialog; you don't need to close the current one first.</p>
+		<Demo Type="typeof(HxDialog_Demo_Swapping)" />
+
+    <DocHeading Title="Non-modal dialogs" />
+		<p>Set <code>NonModal="true"</code> to open the dialog with the browser-native <code>show()</code> instead of <code>showModal()</code>. A non-modal dialog has no backdrop, no focus trap, and does not block the rest of the page.</p>
+		<Demo Type="typeof(HxDialog_Demo_NonModal)" />
+
     <DocHeading Title="Optional sizes" />
 	<Demo Type="typeof(HxDialog_Demo_Size)" />
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Documentation.razor
@@ -28,12 +28,12 @@
 	<Demo Type="typeof(HxDialog_Demo_Animation)" />
 
     <DocHeading Title="Swapping dialogs" />
-		<p>When a button inside an open dialog opens another dialog, the dialogs <strong>swap</strong> &ndash; the first one closes as the second one opens, and the backdrop stays visible the whole time without flickering. Just call <code>ShowAsync()</code> on the other dialog; you don't need to close the current one first.</p>
-		<Demo Type="typeof(HxDialog_Demo_Swapping)" />
+	<p>When a button inside an open dialog opens another dialog, the dialogs <strong>swap</strong> &ndash; the first one closes as the second one opens, and the backdrop stays visible the whole time without flickering. Just call <code>ShowAsync()</code> on the other dialog; you don't need to close the current one first.</p>
+	<Demo Type="typeof(HxDialog_Demo_Swapping)" />
 
     <DocHeading Title="Non-modal dialogs" />
-		<p>Set <code>NonModal="true"</code> to open the dialog with the browser-native <code>show()</code> instead of <code>showModal()</code>. A non-modal dialog has no backdrop, no focus trap, and does not block the rest of the page.</p>
-		<Demo Type="typeof(HxDialog_Demo_NonModal)" />
+	<p>Set <code>NonModal="true"</code> to open the dialog with the browser-native <code>show()</code> instead of <code>showModal()</code>. A non-modal dialog has no backdrop, no focus trap, and does not block the rest of the page.</p>
+	<Demo Type="typeof(HxDialog_Demo_NonModal)" />
 
     <DocHeading Title="Optional sizes" />
 	<Demo Type="typeof(HxDialog_Demo_Size)" />

--- a/docs/generated/demos/HxDialog/HxDialog_Demo_NonModal.md
+++ b/docs/generated/demos/HxDialog/HxDialog_Demo_NonModal.md
@@ -1,0 +1,20 @@
+# HxDialog_Demo_NonModal.razor
+
+```razor
+<HxButton OnClick="() => myDialog.ShowAsync()" Color="ThemeColor.Primary">Open non-modal dialog</HxButton>
+
+<HxDialog @ref="myDialog" Title="Non-modal dialog" NonModal="true">
+	<BodyTemplate>
+		This dialog is opened with the browser-native <code>show()</code> instead of <code>showModal()</code>. There is no backdrop, no focus trap, and the rest of the page stays interactive &ndash; you can keep clicking the button behind it.
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="() => myDialog.HideAsync()" Color="ThemeColor.Primary">Close</HxButton>
+	</FooterTemplate>
+</HxDialog>
+
+@code
+{
+	private HxDialog myDialog;
+}
+
+```

--- a/docs/generated/demos/HxDialog/HxDialog_Demo_Swapping.md
+++ b/docs/generated/demos/HxDialog/HxDialog_Demo_Swapping.md
@@ -1,0 +1,32 @@
+# HxDialog_Demo_Swapping.razor
+
+```razor
+<HxButton OnClick="() => firstDialog.ShowAsync()" Color="ThemeColor.Primary">Open first dialog</HxButton>
+
+<HxDialog @ref="firstDialog" Title="First dialog">
+	<BodyTemplate>
+		Opening the second dialog automatically swaps it in place of this one &ndash; the backdrop stays visible the whole time, with no flicker.
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="() => firstDialog.HideAsync()" Color="ThemeColor.Secondary">Close</HxButton>
+		<HxButton OnClick="() => secondDialog.ShowAsync()" Color="ThemeColor.Primary">Open second dialog</HxButton>
+	</FooterTemplate>
+</HxDialog>
+
+<HxDialog @ref="secondDialog" Title="Second dialog">
+	<BodyTemplate>
+		This is the second dialog. You can swap back to the first one.
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="() => secondDialog.HideAsync()" Color="ThemeColor.Secondary">Close</HxButton>
+		<HxButton OnClick="() => firstDialog.ShowAsync()" Color="ThemeColor.Primary">Back to first dialog</HxButton>
+	</FooterTemplate>
+</HxDialog>
+
+@code
+{
+	private HxDialog firstDialog;
+	private HxDialog secondDialog;
+}
+
+```


### PR DESCRIPTION
Aligns the **HxDialog** documentation with the [Bootstrap 6 Dialog docs](https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/dialog/) by adding the two demo sections that were missing.

The `HxDialog` component itself was already BS6-aligned (sizes, fullscreen, scrollable, static backdrop, fade/instant/slide animations, `NonModal` parameter). This PR is **docs-only** — no component or JS changes.

## Added

- **Swapping dialogs** — `HxDialog_Demo_Swapping.razor`. Two dialogs that swap into each other. `HxDialog.js`'s `show()` already hides the currently-open dialog first, so calling `ShowAsync()` on the other dialog swaps them with the backdrop staying visible (no flicker).
- **Non-modal dialogs** — `HxDialog_Demo_NonModal.razor`. Uses the existing `NonModal="true"` parameter (native `show()` instead of `showModal()`, no backdrop / no focus trap).
- Matching `docs/generated/demos/HxDialog/*.md` source files.
- Two new sections in `HxDialog_Documentation.razor`, ordered to match the BS6 page (after Animation, before Optional sizes).

Sizes and fullscreen already had demos and were left untouched.

## Verified locally (docs server)

- **Swapping**: open first → "Open second dialog" → first closes, second opens, exactly one modal/backdrop throughout, no console errors.
- **Non-modal**: opens with `:modal` = false, `data-bs-modal="false"`, no backdrop, page behind stays interactive.

## Not included

BS6 also documents "Dark dialog" (`data-bs-theme="dark"`) and "Overlays" (tooltips/popovers inside a dialog) — left out as niche; can add on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)