### PR TITLE
Docs: card-header background for inline demo language separator

### DIFF
--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -50,7 +50,7 @@ else
 			@* Inline (non-tabbed) code gets a header separating it from the demo, with the language name and a copy button. *@
 			if (!Tabs)
 			{
-				<div class="d-flex justify-content-between align-items-center ps-3 pe-1 py-1 align-self-stretch border-top border-subtle">
+				<div class="d-flex justify-content-between align-items-center ps-3 pe-1 py-1 align-self-stretch border-top border-bottom border-subtle bg-1">
 					<span class="fg-secondary text-uppercase fs-xs font-monospace">Razor</span>
 					<HxButton Icon="@(_copied ? BootstrapIcon.ClipboardCheck : BootstrapIcon.Clipboard)"
 							  Variant="ButtonVariant.Text"


### PR DESCRIPTION
## What

The inline (non-tabbed) demo card has a header row above the source code showing the language name (`RAZOR`) and a copy button. It previously had only a top border and a transparent background, so it visually blended into the demo content above it.

This adds:
- `bg-1` — the same background token `.card-header` resolves to (`--bs-card-cap-bg` → `var(--bs-bg-1)`)
- `border-bottom` — to close off the row against the code block below

The row now reads as a distinct labeled bar between the demo and the source, consistent with card-header styling.

## Why

Requested polish so the language separator matches the card header background.

## Notes for reviewer

- Single-line change in `Demo.razor`; only affects the non-tabbed (`!Tabs`) demo variant. The tabbed variant renders source under a separate "Source" tab and has no such separator.
- Verified on `/components/HxAlert` (a non-tabbed demo) in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)