### PR TITLE
doc: resizable container for container-query demos (v6)

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Demo_Responsive.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Demo_Responsive.razor
@@ -1,0 +1,5 @@
+﻿<HxListGroup Horizontal="ListGroupHorizontal.MediumUp">
+    <HxListGroupItem>An item</HxListGroupItem>
+    <HxListGroupItem>A second item</HxListGroupItem>
+    <HxListGroupItem>A third item</HxListGroupItem>
+</HxListGroup>

--- a/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Documentation.razor
@@ -33,6 +33,11 @@
         <DocHeading Title="Horizontal" />
 		<p>Use the <code>Horizontal</code> parameter to change the layout of the list group items from vertical to horizontal, including the responsive breakpoint.</p>
 		<Demo Type="typeof(HxListGroup_Demo_Horizontal)" />
+		<p>
+			With a responsive breakpoint value (e.g. <code>ListGroupHorizontal.MediumUp</code>), the switch between vertical and horizontal layout is based on the width of the list group's container, not the viewport.
+			Drag the lower-right corner of the example below to preview the behavior.
+		</p>
+		<Demo Type="typeof(HxListGroup_Demo_Responsive)" Resizable="true" />
 
         <DocHeading Title="Colors" />
 		<p>Use the <code>Color</code> parameter to set the contextual color for the list-group item.</p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Documentation.razor
@@ -4,7 +4,7 @@
 	<MainContent>
 
 		<DocHeading Title="Basic usage" />
-		<Demo Type="typeof(HxListLayout_Demo_Basic)" />
+		<Demo Type="typeof(HxListLayout_Demo_Basic)" Resizable="true" />
 		<DocDemoDataServiceNote />
 
 		<DocHeading Title="Infinite scroll with sticky header" Id="sticky-header" />
@@ -32,7 +32,7 @@
 			You can add a search input to the toolbar using the <code>SearchTemplate</code> parameter.<br/>
 			Consider using <code>BindEvent.OnInput</code> and the <a href="concepts/Debouncer">Debouncer</a> to avoid unnecessary requests to the server.
 		</p>
-		<Demo Type="typeof(HxListLayout_Demo_SearchTemplate)" />
+		<Demo Type="typeof(HxListLayout_Demo_SearchTemplate)" Resizable="true" />
 
 		<DocHeading Title="Named views" />
 		<p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Documentation.razor
@@ -8,26 +8,26 @@
 		The component responds to the <strong>container width</strong> (not the viewport width),
 		so it works in any embedded or responsive context.
 	</p>
-	<Demo Type="typeof(HxNavOverflow_Demo)" Tabs="false" />
+	<Demo Type="typeof(HxNavOverflow_Demo)" Tabs="false" Resizable="true" />
 
 	<DocHeading Title="Nav variants" />
 	<p>The overflow pattern works with all nav variants&mdash;default, <code>Pills</code>, <code>Tabs</code>, and <code>Underline</code>.</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_Variants)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_Variants)" Resizable="true" />
 
 	<DocHeading Title="Keep items visible" />
 	<p>
 		Use the <code>HxNavOverflow.KeepVisibleCssClass</code> CSS class (<code>nav-overflow-keep</code>) on items
 		that should never be moved to the overflow menu, e.g. high-priority items like "Home" or "Contact".
 	</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_KeepVisible)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_KeepVisible)" Resizable="true" />
 
 	<DocHeading Title="Disabled items" />
 	<p>Disabled items (<code>Enabled="false"</code>) keep their disabled state when they are moved to the "More" overflow menu.</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_DisabledItems)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_DisabledItems)" Resizable="true" />
 
 	<DocHeading Title="Minimum visible items" />
 	<p>Use <code>MinimumVisibleItems</code> to ensure a minimum number of items remains visible before the overflow kicks in.</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_MinimumVisibleItems)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_MinimumVisibleItems)" Resizable="true" />
 
 	<DocHeading Title="Collapse all" />
 	<p>
@@ -35,7 +35,7 @@
 		Pass a breakpoint name (e.g. <code>md</code>, resolved from the <code>--bs-breakpoint-md</code> CSS variable)
 		or a pixel value (e.g. <code>768</code>). Items with the <code>nav-overflow-keep</code> CSS class always remain visible.
 	</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_CollapseBelow)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_CollapseBelow)" Resizable="true" />
 
 	<DocHeading Title="Customizing the toggle" />
 	<p>
@@ -43,11 +43,11 @@
 		(set <code>MoreText=""</code> for an icon-only toggle), <code>IconPlacement</code> to position the icon
 		relative to the text, and <code>MenuPlacement</code> to set the placement of the overflow menu.
 	</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_Toggle)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_Toggle)" Resizable="true" />
 
 	<DocHeading Title="Overflow event" />
 	<p>Use <code>OnOverflowChanged</code> to get notified whenever the number of items in the overflow menu changes.</p>
-	<Demo Type="typeof(HxNavOverflow_Demo_OnOverflowChanged)" />
+	<Demo Type="typeof(HxNavOverflow_Demo_OnOverflowChanged)" Resizable="true" />
 
 	<DocHeading Title="How it works" Id="how-it-works" />
 	<p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_BrandImage.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_BrandImage.razor
@@ -1,17 +1,17 @@
-﻿<HxNavbar CssClass="bg-body-tertiary mb-3">
+﻿<HxNavbar CssClass="bg-1 mb-3">
 	<HxNavbarBrand>
 		<img src="HAVIT-Icon_48x48_transparent.png" width="25" alt="HAVIT" />
 	</HxNavbarBrand>
 </HxNavbar>
 
-<HxNavbar CssClass="bg-body-tertiary mb-3">
+<HxNavbar CssClass="bg-1 mb-3">
 	<HxNavbarBrand>
 		<img src="HAVIT-Icon_48x48_transparent.png" width="25" alt="HAVIT" />
 		Brand with image
 	</HxNavbarBrand>
 </HxNavbar>
 
-<HxNavbar CssClass="bg-body-tertiary">
+<HxNavbar CssClass="bg-1">
 	<HxNavbarBrand>
 		<HxIcon Icon="BootstrapIcon.Bootstrap" CssClass="me-1" />
 		Brand with icon

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_BrandText.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_BrandText.razor
@@ -1,7 +1,7 @@
-﻿<HxNavbar CssClass="bg-body-tertiary mb-3">
+﻿<HxNavbar CssClass="bg-1 mb-3">
 	<HxNavbarBrand>Navbar</HxNavbarBrand>
 </HxNavbar>
 
-<HxNavbar CssClass="bg-body-tertiary">
+<HxNavbar CssClass="bg-1">
 	<HxNavbarBrand CssClass="mb-0 h1">Navbar as heading</HxNavbarBrand>
 </HxNavbar>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_Responsive.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_Responsive.razor
@@ -1,21 +1,10 @@
-﻿<HxNavbar CssClass="bg-1">
+﻿<HxNavbar Expand="NavbarExpand.MediumUp" CssClass="bg-1">
     <HxNavbarBrand>Navbar</HxNavbarBrand>
     <HxNavbarToggler />
     <HxNavbarDrawer>
-        <HxNav CssClass="me-auto mb-2 lg:mb-0">
+        <HxNav CssClass="me-auto mb-2 md:mb-0">
             <HxNavLink Href="/components/HxNavbar">Home</HxNavLink>
             <HxNavLink Href="#">Link</HxNavLink>
-            <HxMenu>
-                <Toggle>
-                    <HxMenuToggleElement ElementName="a" role="button">Menu</HxMenuToggleElement>
-                </Toggle>
-                <Content>
-                    <HxMenuItemNavLink Href="#">Action</HxMenuItemNavLink>
-                    <HxMenuItemNavLink Href="#">Another action</HxMenuItemNavLink>
-                    <HxMenuDivider />
-                    <HxMenuItemNavLink Href="#">Something else here</HxMenuItemNavLink>
-                </Content>
-            </HxMenu>
             <HxNavLink Enabled="false">Disabled</HxNavLink>
         </HxNav>
         <EditForm Model="@query">

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_Text.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Demo_Text.razor
@@ -1,8 +1,8 @@
-﻿<HxNavbar CssClass="bg-body-tertiary">
+﻿<HxNavbar CssClass="bg-1">
 	<HxNavbarText>Navbar text with an inline element</HxNavbarText>
 </HxNavbar>
 
-<HxNavbar CssClass="bg-body-tertiary mt-3">
+<HxNavbar CssClass="bg-1 mt-3">
 	<HxNavbarBrand>Navbar w/ text</HxNavbarBrand>
 	<HxNavbarToggler />
 	<HxNavbarDrawer>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavbarDoc/HxNavbar_Documentation.razor
@@ -6,13 +6,15 @@
 
 <ApiDoc Type="typeof(HxNavbar)">
 
-	<DocAlert Type="DocAlertType.Warning">
-		<strong>UPDATE v4.0.1:</strong> As Bootstrap 5.3 now expects you to use <a href="https://getbootstrap.com/docs/5.3/components/navbar/#color-schemes">text and background color CSS utilities</a> to customize the navbar with the <code>CssClass</code> parameter,
-		we have changed the default value of the <code>Color</code> parameter to <code>ThemeColor.None</code> to avoid interfering with your CSS classes. You can still use <code>Color="ThemeColor.Secondary"</code> to get the original navbar color.
-	</DocAlert>
-
     <DocHeading Title="Basic usage" />
 	<Demo Type="typeof(HxNavbar_Demo_Basic)" Tabs="false" />
+
+    <DocHeading Title="Responsive expand" />
+	<p>
+		Use the <code>Expand</code> parameter to set the breakpoint at which the navbar expands from its collapsed (toggler) state into a full horizontal bar.
+		The collapse is driven by the width of the navbar's container, not the viewport &ndash; drag the lower-right corner of the example below to preview the behavior.
+	</p>
+	<Demo Type="typeof(HxNavbar_Demo_Responsive)" Resizable="true" />
 
     <DocHeading Title="Brand" />
     <DocHeading Title="Text brand" Level="3" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxStepperDoc/HxStepper_Documentation.razor
@@ -26,7 +26,7 @@
 		The responsive classes are container query based (they react to the width of the containing element, not the viewport);
 		the required <code>contains-inline</code> parent element is rendered by the component automatically.
 	</p>
-	<Demo Type="typeof(HxStepper_Demo_Responsive)" />
+	<Demo Type="typeof(HxStepper_Demo_Responsive)" Resizable="true" />
 
 	<DocHeading Title="Gap" />
 	<p>Customize the gap between the steps by overriding the <code>--bs-stepper-gap</code> CSS variable.</p>
@@ -44,7 +44,7 @@
 		Set <code>Overflow="true"</code> to wrap the stepper in a <code>stepper-overflow</code> container
 		which enables horizontal scrolling when the stepper overflows its parent.
 	</p>
-	<Demo Type="typeof(HxStepper_Demo_Overflow)" />
+	<Demo Type="typeof(HxStepper_Demo_Overflow)" Resizable="true" />
 
 	<DocHeading Title="Complex content" />
 	<p>

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -33,7 +33,19 @@ else
 	private void RenderDemo(RenderTreeBuilder __builder)
 	{
 		<div class="@CssClassHelper.Combine("demo-content p-3 align-self-stretch vstack gap-3", DemoCardCssClass)">
-			<DynamicComponent Type="Type" />
+			@if (Resizable)
+			{
+				<div class="demo-resizable">
+					<DynamicComponent Type="Type" />
+				</div>
+				<p class="demo-resizable-hint text-body-secondary small mb-0">
+					Use the lower-right corner grip to resize and preview the responsive behavior.
+				</p>
+			}
+			else
+			{
+				<DynamicComponent Type="Type" />
+			}
 		</div>
 	}
 

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.cs
@@ -9,6 +9,12 @@ public partial class Demo : PerformanceLoggingComponentBase, IDisposable
 	[Parameter] public bool Tabs { get; set; } = true;
 	[Parameter] public string DemoCardCssClass { get; set; }
 
+	/// <summary>
+	/// Wraps the demo in a horizontally resizable container so the reader can drag the lower-right
+	/// corner to preview container-query driven responsive behavior (e.g. <c>HxListLayout</c>).
+	/// </summary>
+	[Parameter] public bool Resizable { get; set; }
+
 	[Inject] protected IJSRuntime JSRuntime { get; set; }
 
 	private string _code;

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.css
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.css
@@ -1,0 +1,10 @@
+.demo-resizable {
+	min-width: 280px;
+	max-width: 100%;
+	padding: 1rem;
+	overflow: auto;
+	resize: horizontal;
+	background-color: var(--bs-body-bg);
+	border: 1px dashed var(--bs-border-color);
+	border-radius: var(--bs-border-radius);
+}

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.css
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.css
@@ -7,4 +7,8 @@
 	background-color: var(--bs-body-bg);
 	border: 1px dashed var(--bs-border-color);
 	border-radius: var(--bs-border-radius);
+	/* Establish a query container so components whose container queries rely on an ancestor
+	   (e.g. list-group-horizontal) respond to the box width. Components that set their own
+	   container-type (navbar, HxListLayout's card) still resolve to their nearer container. */
+	container-type: inline-size;
 }


### PR DESCRIPTION
## What

Adds an opt-in `Resizable` parameter to the shared documentation `Demo` component. When set, the demo is wrapped in a horizontally resizable container — a dashed box with a drag grip plus a short hint — mirroring Bootstrap v6's `.bd-resizable-container`. Readers can drag the lower-right corner to preview responsive behavior driven by **container width** rather than the viewport.

Enabled on demos whose layout/behavior responds to container width:

| Component | Demos | Mechanism |
|---|---|---|
| HxListLayout | Basic, Search | custom `@container` header layout |
| HxNavbar | new **Responsive expand** demo | `@container` (`md` expand → collapse) |
| HxListGroup | new responsive demo | `@container` (`MediumUp`, vertical↔horizontal) |
| HxNavOverflow | all demos | JS / ResizeObserver (overflow into the "More" menu) |
| HxStepper | Responsive, Overflow | `@container` (`md`, vertical↔horizontal) |

## Why

Several components now respond to their container's width instead of the viewport (Bootstrap 6 container queries, plus HxNavOverflow's ResizeObserver). Their demos showed nothing at the static documentation width — you had to resize the whole browser to see the behavior. The resizable container makes the responsive switch directly demonstrable inline, matching how Bootstrap v6's own docs present navbar/list-group.

## Implementation notes

- The resizable box sets `container-type: inline-size`, so it acts as a query container for components that rely on an **ancestor** container (e.g. `list-group-horizontal`). Components that establish their own container (navbar, HxListLayout's card, stepper's `contains-inline`) still resolve to the nearer one — verified that adding it didn't change their behavior.
- New demo files: `HxNavbar_Demo_Responsive`, `HxListGroup_Demo_Responsive`. The navbar one uses `md` expand intentionally so the collapse is reachable within the docs column width (a resizable box can only shrink from 100%).
- Drive-by cleanup on HxNavbar: replaced the obsolete `bg-body-tertiary` utility with `bg-1` across all navbar demos, and removed the stale **v4.0.1** color-default alert.

## Reviewer notes

- **Targets `v6`** (this branch is based on the v6 line, not `main`).
- All five components' resize behavior was verified live in the running docs preview (layout switch / toggler / overflow-menu appearance at narrow vs. wide widths).
- **Deliberately not made resizable:** HxGrid stacked/responsive tables (BS6 docs don't either, and clipping a wide table in a narrow box is awkward). Easy to add later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)