### PR TITLE
HxPager: add Size parameter (Small/Regular/Large)

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxPager_Basic_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxPager_Basic_Tests.cs
@@ -107,6 +107,45 @@ public class HxPager_Basic_Tests : BunitTestBase
 		}
 	}
 
+	[Theory]
+	[InlineData(PagerSize.Regular, null)]
+	[InlineData(PagerSize.Small, "pagination-sm")]
+	[InlineData(PagerSize.Large, "pagination-lg")]
+	public void HxPager_Render_Size_AppliesPaginationSizeCssClass(PagerSize size, string expectedCssClass)
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxPager>(parameters => parameters
+			.Add(p => p.TotalPages, 5)
+			.Add(p => p.CurrentPageIndex, 0)
+			.Add(p => p.Size, size));
+
+		// Assert
+		var pagination = cut.Find("ul.pagination");
+		if (expectedCssClass is null)
+		{
+			Assert.DoesNotContain("pagination-sm", pagination.ClassList);
+			Assert.DoesNotContain("pagination-lg", pagination.ClassList);
+		}
+		else
+		{
+			Assert.Contains(expectedCssClass, pagination.ClassList);
+		}
+	}
+
+	[Fact]
+	public void HxPager_Render_DefaultSize_DoesNotApplyPaginationSizeCssClass()
+	{
+		// Arrange & Act
+		var cut = RenderComponent<HxPager>(parameters => parameters
+			.Add(p => p.TotalPages, 5)
+			.Add(p => p.CurrentPageIndex, 0));
+
+		// Assert - the default size (Regular) renders no pagination-sm/pagination-lg modifier
+		var pagination = cut.Find("ul.pagination");
+		Assert.DoesNotContain("pagination-sm", pagination.ClassList);
+		Assert.DoesNotContain("pagination-lg", pagination.ClassList);
+	}
+
 	[Fact]
 	public void HxPager_Render_WrappedInLabeledNavLandmark()
 	{

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor
@@ -11,7 +11,7 @@
 }
 
 <nav aria-label="@HxPagerLocalizer["PaginationLandmark"]">
-	<ul class="@CssClassHelper.Combine("hx-pager pagination", CssClassEffective)">
+	<ul class="@CssClassHelper.Combine("hx-pager pagination", SizeCssClass, CssClassEffective)">
 		@if (showFirstLast)
 		{
 			<li class="@previousPageItemDisabledCssClass">
@@ -27,7 +27,7 @@
 					}
 					else
 					{
-						<HxIcon Icon="@FirstPageIconEffective" />
+						<HxIcon Icon="@FirstPageIconEffective" CssClass="d-flex" />
 					}
 				</button>
 			</li>
@@ -48,7 +48,7 @@
 					}
 					else
 					{
-						<HxIcon Icon="@PreviousPageIconEffective" />
+						<HxIcon Icon="@PreviousPageIconEffective" CssClass="d-flex" />
 					}
 				</button>
 			</li>
@@ -94,7 +94,7 @@
 					}
 					else
 					{
-						<HxIcon Icon="@NextPageIconEffective" />
+						<HxIcon Icon="@NextPageIconEffective" CssClass="d-flex" />
 					}
 				</button>
 			</li>
@@ -115,7 +115,7 @@
 					}
 					else
 					{
-						<HxIcon Icon="@LastPageIconEffective" />
+						<HxIcon Icon="@LastPageIconEffective" CssClass="d-flex" />
 					}
 				</button>
 			</li>

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
@@ -23,7 +23,8 @@ public partial class HxPager : ComponentBase
 			LastPageIcon = BootstrapIcon.ChevronDoubleRight,
 			PreviousPageIcon = BootstrapIcon.ChevronLeft,
 			NextPageIcon = BootstrapIcon.ChevronRight,
-			NumericButtonsCount = 10
+			NumericButtonsCount = 10,
+			Size = PagerSize.Regular
 		};
 	}
 
@@ -116,6 +117,19 @@ public partial class HxPager : ComponentBase
 	/// </summary>
 	[Parameter] public int? NumericButtonsCount { get; set; }
 	protected int NumericButtonsCountEffective => NumericButtonsCount ?? GetSettings()?.NumericButtonsCount ?? GetDefaults().NumericButtonsCount ?? throw new InvalidOperationException(nameof(NumericButtonsCount) + " default for " + nameof(HxPager) + " has to be set.");
+
+	/// <summary>
+	/// Size of the pager. The default is <see cref="PagerSize.Regular"/>.
+	/// </summary>
+	[Parameter] public PagerSize? Size { get; set; }
+	protected PagerSize SizeEffective => Size ?? GetSettings()?.Size ?? GetDefaults().Size ?? throw new InvalidOperationException(nameof(Size) + " default for " + nameof(HxPager) + " has to be set.");
+	private string SizeCssClass => SizeEffective switch
+	{
+		PagerSize.Regular => null,
+		PagerSize.Small => "pagination-sm",
+		PagerSize.Large => "pagination-lg",
+		_ => throw new InvalidOperationException($"Unknown {nameof(PagerSize)} value {SizeEffective:g}.")
+	};
 
 	/// <summary>
 	/// Any additional CSS class to apply.

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/PagerSettings.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/PagerSettings.cs
@@ -31,6 +31,11 @@ public record PagerSettings
 	public int? NumericButtonsCount { get; set; }
 
 	/// <summary>
+	/// Size of the pager.
+	/// </summary>
+	public PagerSize? Size { get; set; }
+
+	/// <summary>
 	/// Any additional CSS class to apply.
 	/// </summary>
 	public string CssClass { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/PagerSize.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/PagerSize.cs
@@ -1,0 +1,22 @@
+namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// Represents the size of an <see cref="HxPager"/>.
+/// </summary>
+public enum PagerSize
+{
+	/// <summary>
+	/// Regular size.
+	/// </summary>
+	Regular = 0,
+
+	/// <summary>
+	/// Small size.
+	/// </summary>
+	Small,
+
+	/// <summary>
+	/// Large size.
+	/// </summary>
+	Large
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Demo_Basic.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Demo_Basic.razor
@@ -19,6 +19,7 @@
 				@bind-SelectedDataItem="currentEmployee"
 				@bind-SelectedDataItem:after="HandleSelectedDataItemChanged"
 				PageSize="5"
+				PagerSettings="@(new PagerSettings { Size = PagerSize.Small })"
 				Responsive="true">
 			<Columns>
 				<HxGridColumn HeaderText="Name" ItemTextSelector="employee => employee.Name" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxPagerDoc/HxPager_Demo_Sizes.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPagerDoc/HxPager_Demo_Sizes.razor
@@ -1,0 +1,5 @@
+<HxPager CurrentPageIndex="0" TotalPages="10" Size="PagerSize.Large" />
+<br />
+<HxPager CurrentPageIndex="0" TotalPages="10" Size="PagerSize.Regular" />
+<br />
+<HxPager CurrentPageIndex="0" TotalPages="10" Size="PagerSize.Small" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxPagerDoc/HxPager_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPagerDoc/HxPager_Documentation.razor
@@ -6,6 +6,10 @@
         <p>Although <code>HxPager</code> is mainly used within <code>HxGrid</code>, you can use it on its own to solve any other paging scenarios.</p>
         <Demo Type="typeof(HxPager_Demo)" Tabs="false" />
 
+        <DocHeading Title="Sizes" />
+        <p>Use the <code>Size</code> parameter to render a <code>Small</code> or <code>Large</code> pager (the default is <code>Regular</code>).</p>
+        <Demo Type="typeof(HxPager_Demo_Sizes)" Tabs="false" />
+
         <DocHeading Title="Customization" />
         <p>There are several parameters that allow pager customization.</p>
         <Demo Type="typeof(HxPager_Demo_Customization)" />

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -9954,6 +9954,11 @@
             Count of numbers to display. The default value is 10.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxPager.Size">
+            <summary>
+            Size of the pager. The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.PagerSize.Regular"/>.
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxPager.CssClass">
             <summary>
             Any additional CSS class to apply.
@@ -10063,9 +10068,34 @@
             Number of buttons with numbers to display.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.PagerSettings.Size">
+            <summary>
+            Size of the pager.
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.PagerSettings.CssClass">
             <summary>
             Any additional CSS class to apply.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.PagerSize">
+            <summary>
+            Represents the size of an <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxPager"/>.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.PagerSize.Regular">
+            <summary>
+            Regular size.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.PagerSize.Small">
+            <summary>
+            Small size.
+            </summary>
+        </member>
+        <member name="F:Havit.Blazor.Components.Web.Bootstrap.PagerSize.Large">
+            <summary>
+            Large size.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.SortingItem`1">


### PR DESCRIPTION
## What

Adds a `Size` parameter to `HxPager` (`Small` / `Regular` / `Large`, default `Regular`) following the standard HAVIT defaults/settings/parameter pattern. It renders Bootstrap 6's `pagination-sm` / `pagination-lg` modifier on the `ul.pagination` element.

## Why / how it reaches Grid & ListLayout

- New `PagerSize` enum, `PagerSettings.Size`, and `HxPager.Size` with the usual effective-value resolution (parameter → `Settings` → `Defaults`).
- `HxGrid` already forwards `PagerSettingsEffective` to its pager (and to the `GridPaginationTemplateContext`), so the size flows through `GridSettings.PagerSettings` to grids automatically — **including grids hosted inside `HxListLayout`** (no Grid/ListLayout code change needed).

## Also

- Navigation icons (First/Previous/Next/Last) are now `d-flex` so they stay centered within the `page-link` buttons.

## Docs & tests

- New **Sizes** section + `HxPager_Demo_Sizes` demo on the HxPager page; the `Size` parameter auto-appears in the API table.
- The HxListLayout *Basic* demo now sets `PagerSettings { Size = PagerSize.Small }` to match its compact table and demonstrate the flow-through.
- Tests assert the correct `pagination-sm` / `pagination-lg` class per size (and none for `Regular`).

## Notes for reviewer

- Targets the **`v6`** branch (Bootstrap 6 `pagination-sm`/`-lg`).
- Verified in the running docs site: all three sizes render and the chevron icons are centered.
- `pagination-sm`/`pagination-lg` are standard Bootstrap classes — worth a sanity check that the compiled v6 CSS bundle ships those rules.