### PR TITLE
Docs: increase .doc-content side padding on md+ screens

### DIFF
--- a/Havit.Blazor.Documentation/Shared/MainLayout.razor
+++ b/Havit.Blazor.Documentation/Shared/MainLayout.razor
@@ -9,7 +9,7 @@
 <div class="doc-container container-fluid md:d-flex min-vh-100">
 	<Sidebar CssClass="d-none lg:d-flex" />
 
-	<div style="min-width: 0;" class="doc-content prose main md:p-4 pt-0 flex-grow-1 overflow-hidden">
+	<div style="min-width: 0;" class="doc-content prose main md:p-7 pt-0 flex-grow-1 overflow-hidden">
         <CascadingValue Value="_docHeadContentTracker" IsFixed="true">
 		    @Body
         </CascadingValue>


### PR DESCRIPTION
## Why

The documentation content wrapper (`.doc-content`) felt cramped against the sidebar and viewport edges on larger screens. This gives the prose more breathing room on the sides.

## What

Bumps the responsive padding on the `.doc-content` wrapper in `MainLayout.razor` from `md:p-4` (1rem) to `md:p-7` (2rem). The change only affects medium and larger breakpoints; mobile spacing is unchanged.

Targets the `v6` branch.