### PR TITLE
[doc] [v6] HxMenu: add advanced menu demos (#1516)

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Descriptions.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Descriptions.razor
@@ -1,0 +1,19 @@
+﻿<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Menu</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		<HxMenuItem>
+			<span class="menu-item-content">
+				Publish now
+				<small class="menu-item-description">Make this page visible immediately</small>
+			</span>
+		</HxMenuItem>
+		<HxMenuItem>
+			<span class="menu-item-content">
+				Schedule
+				<small class="menu-item-description">Set a future publish date</small>
+			</span>
+		</HxMenuItem>
+	</Content>
+</HxMenu>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Dividers.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Dividers.razor
@@ -1,0 +1,12 @@
+﻿<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Menu</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		<HxMenuItemNavLink Href="#">Action</HxMenuItemNavLink>
+		<HxMenuItemNavLink Href="#">Another action</HxMenuItemNavLink>
+		<HxMenuItemNavLink Href="#">Something else here</HxMenuItemNavLink>
+		<HxMenuDivider />
+		<HxMenuItemNavLink Href="#">Separated link</HxMenuItemNavLink>
+	</Content>
+</HxMenu>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Forms.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Forms.razor
@@ -1,9 +1,9 @@
-﻿<HxMenu>
+﻿<HxMenu style="--bs-menu-min-width: 300px;">
 	<Toggle>
 		<HxMenuToggleButton Color="ThemeColor.Secondary">Sign in</HxMenuToggleButton>
 	</Toggle>
 	<Content>
-		<EditForm Model="model" class="d-flex flex-column gap-3 p-3" style="--bs-menu-min-width: 300px;">
+		<EditForm Model="model" class="d-flex flex-column gap-3 p-3">
 			<HxInputText Label="Email address" @bind-Value="model.Email" Placeholder="email@example.com" Type="InputType.Email" />
 			<HxInputText Label="Password" @bind-Value="model.Password" Placeholder="Password" Type="InputType.Password" />
 			<HxCheckbox Text="Remember me" @bind-Value="model.RememberMe" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Forms.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Forms.razor
@@ -1,0 +1,23 @@
+﻿<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Sign in</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		<EditForm Model="model" class="d-flex flex-column gap-3 p-3" style="--bs-menu-min-width: 300px;">
+			<HxInputText Label="Email address" @bind-Value="model.Email" Placeholder="email@example.com" Type="InputType.Email" />
+			<HxInputText Label="Password" @bind-Value="model.Password" Placeholder="Password" Type="InputType.Password" />
+			<HxCheckbox Text="Remember me" @bind-Value="model.RememberMe" />
+			<HxSubmit Text="Sign in" Color="ThemeColor.Primary" />
+		</EditForm>
+	</Content>
+</HxMenu>
+@code {
+	private FormModel model = new();
+
+	public class FormModel
+	{
+		public string Email { get; set; }
+		public string Password { get; set; }
+		public bool RememberMe { get; set; }
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Selected.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Selected.razor
@@ -1,0 +1,30 @@
+﻿<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Select status</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		@foreach (var status in statuses)
+		{
+			<HxMenuItem CssClass="@(status.Value == selectedStatus ? "selected" : null)"
+						OnClick="() => selectedStatus = status.Value">
+				<div class="menu-item-content">
+					@status.Title
+					<small class="menu-item-description">@status.Description</small>
+				</div>
+				<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16">
+					<path d="m2 7 4 5 8-8" />
+				</svg>
+			</HxMenuItem>
+		}
+	</Content>
+</HxMenu>
+<p class="mt-2">Selected: <strong>@selectedStatus</strong></p>
+@code {
+	private string selectedStatus = "Published";
+
+	private readonly (string Value, string Title, string Description)[] statuses =
+	[
+		("Published", "Published", "Currently visible to users"),
+		("Draft", "Draft", "Not yet published"),
+	];
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Selected.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Selected.razor
@@ -6,12 +6,13 @@
 		@foreach (var status in statuses)
 		{
 			<HxMenuItem CssClass="@(status.Value == selectedStatus ? "selected" : null)"
+						aria-current="@(status.Value == selectedStatus ? "true" : null)"
 						OnClick="() => selectedStatus = status.Value">
 				<div class="menu-item-content">
 					@status.Title
 					<small class="menu-item-description">@status.Description</small>
 				</div>
-				<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16">
+				<svg class="menu-item-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 16 16" aria-hidden="true">
 					<path d="m2 7 4 5 8-8" />
 				</svg>
 			</HxMenuItem>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Text.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_Text.razor
@@ -1,0 +1,11 @@
+﻿<HxMenu>
+	<Toggle>
+		<HxMenuToggleButton Color="ThemeColor.Secondary">Menu</HxMenuToggleButton>
+	</Toggle>
+	<Content>
+		<HxMenuText>Menu item text</HxMenuText>
+		<HxMenuItemNavLink Href="#">Action</HxMenuItemNavLink>
+		<HxMenuItemNavLink Href="#">Another action</HxMenuItemNavLink>
+		<HxMenuItemNavLink Href="#">Something else here</HxMenuItemNavLink>
+	</Content>
+</HxMenu>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Documentation.razor
@@ -43,6 +43,14 @@
 		<p>Set <code>Enabled="false"</code> to disable the item. The <code>HxFormState.Enabled</code> inheritance is also supported.</p>
 		<Demo Type="typeof(HxMenu_Demo_HeaderDisabledActive)" />
 
+		<DocHeading Title="Dividers" Id="dividers" />
+		<p>Separate groups of related menu items with a <code>HxMenuDivider</code> (renders an <code>hr.menu-divider</code>).</p>
+		<Demo Type="typeof(HxMenu_Demo_Dividers)" />
+
+		<DocHeading Title="Text" Id="text" />
+		<p>Create non-interactive menu items with <code>HxMenuText</code> (renders a <code>span.menu-text</code>). Feel free to style further with custom CSS or text utilities.</p>
+		<Demo Type="typeof(HxMenu_Demo_Text)" />
+
 		<DocHeading Title="Submenus" Id="submenus" />
 		<p>
 			Use <code>HxSubmenu</code> to create a nested menu. Set the trigger via <code>Text</code> (or <code>TitleTemplate</code>)
@@ -55,6 +63,13 @@
 		<DocHeading Title="Custom content" />
 		<p>Place any custom content directly into the <code>Content</code> render fragment.</p>
 		<Demo Type="typeof(HxMenu_Demo_CustomContent)" />
+
+		<DocHeading Title="Forms" Id="forms" />
+		<p>
+			Put a form within a menu and use <a href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/utilities/spacing/">spacing utilities</a>
+			to give it the negative space you require.
+		</p>
+		<Demo Type="typeof(HxMenu_Demo_Forms)" />
 
 		<DocHeading Title="Split button" Id="split-button" />
 		<p>
@@ -101,6 +116,20 @@
 		<DocHeading Title="Menu with icons" Id="icons" />
 		<p>You can use the <code>Icon</code> parameter to add an icon to menu items.</p>
 		<Demo Type="typeof(HxMenu_Demo_Icons)" />
+
+		<DocHeading Title="Descriptions" Id="descriptions" />
+		<p>
+			Use a <code>menu-item-content</code> wrapper for a flex column layout and a <code>menu-item-description</code> element
+			for secondary text below the main label inside the <code>HxMenuItem</code> child content.
+		</p>
+		<Demo Type="typeof(HxMenu_Demo_Descriptions)" />
+
+		<DocHeading Title="Selected" Id="selected" />
+		<p>
+			Add the <code>selected</code> CSS class (through the <code>CssClass</code> parameter) to a <code>HxMenuItem</code>
+			to indicate the current selection. Pair it with a <code>menu-item-check</code> SVG to render the check mark.
+		</p>
+		<Demo Type="typeof(HxMenu_Demo_Selected)" />
 	</MainContent>
 </ApiDoc>
 


### PR DESCRIPTION
Closes #1516.

Adds the missing advanced `HxMenu` documentation demos that mirror the Bootstrap 6 `components/menu` page. Demos/docs only — no component changes (everything uses the existing `CssClass`/`ChildContent` API).

## New demos (`HxMenuDoc/`)
- **Dividers** — `HxMenuDivider` separating groups of items.
- **Text** — `HxMenuText` non-interactive item (`span.menu-text`) alongside regular items.
- **Descriptions** — `HxMenuItem` with `span.menu-item-content` + `small.menu-item-description` secondary text.
- **Selected** — bound demo: `HxMenuItem CssClass="selected"` (conditional) + `menu-item-content` + `svg.menu-item-check`; clicking switches the selection.
- **Forms** — sign-in form (email/password/Remember me/submit) inside the menu with spacing utilities.

All wired into `HxMenu_Documentation.razor` with `DocHeading` + description + `Demo` (anchors: `#dividers`, `#text`, `#forms`, `#descriptions`, `#selected`).

## Notes
- **Sizing** (`[x]` in the issue) — confirmed there is no separate "Sizing" section in the Bootstrap 6 menu page; height/scroll is covered by the existing Scrollable demo. Not added.

## Verification
- `Havit.Blazor.Documentation` builds with `-warnaserror`: **0 warnings / 0 errors**.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>