### PR TITLE
[doc] [v6] Footer demos for HxDialog & HxDrawer; use native drawer-footer

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxDrawerTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxDrawerTests.cs
@@ -101,7 +101,7 @@ public class HxDrawerTests : BunitTestBase
 			.Add(o => o.FooterTemplate, (RenderFragment)(b => b.AddContent(0, "Footer content"))));
 
 		// Assert
-		var footer = cut.Find("div.hx-drawer-footer");
+		var footer = cut.Find("div.drawer-footer");
 		Assert.NotNull(footer);
 		Assert.Contains("Footer content", footer.TextContent);
 	}

--- a/Havit.Blazor.Components.Web.Bootstrap/Drawers/HxDrawer.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Drawers/HxDrawer.razor
@@ -35,7 +35,7 @@
         }
         @if (FooterTemplate != null)
         {
-            <div class="@CssClassHelper.Combine("hx-drawer-footer", FooterCssClassEffective)">
+            <div class="@CssClassHelper.Combine("drawer-footer", FooterCssClassEffective)">
                 @FooterTemplate
             </div>
         }

--- a/Havit.Blazor.Components.Web.Bootstrap/Drawers/HxDrawer.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Drawers/HxDrawer.razor.css
@@ -1,11 +1,4 @@
-﻿.hx-drawer-footer {
-  display: flex;
-  align-items: center;
-  padding: var(--hx-drawer-footer-padding-y)
-    var(--hx-drawer-footer-padding-x);
-}
-
-.drawer-start.hx-drawer-sm,
+﻿.drawer-start.hx-drawer-sm,
 .drawer-end.hx-drawer-sm {
   width: var(--hx-drawer-horizontal-width-sm);
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/defaults.lib.css
@@ -139,8 +139,6 @@
 
 	/* HxDrawer */
 	--hx-drawer-close-icon-font-size: 							2rem;
-	--hx-drawer-footer-padding-y: 								1rem;
-	--hx-drawer-footer-padding-x: 								1rem;
 	--hx-drawer-horizontal-width-sm: 							400px;
 	--hx-drawer-horizontal-width-lg: 							600px;
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Demo_Footer.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Demo_Footer.razor
@@ -1,0 +1,27 @@
+﻿<HxButton OnClick="HandleShowClick" Color="ThemeColor.Primary">Show dialog</HxButton>
+
+<HxDialog @ref="myDialog" Title="Edit profile">
+	<BodyTemplate>
+		<HxInputText Label="Name" @bind-Value="name" />
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton Text="Cancel" OnClick="HandleHideClick" Color="ThemeColor.Secondary" />
+		<HxButton Text="Save changes" OnClick="HandleHideClick" Color="ThemeColor.Primary" />
+	</FooterTemplate>
+</HxDialog>
+
+@code
+{
+	private HxDialog myDialog;
+	private string name;
+
+	private async Task HandleShowClick()
+	{
+		await myDialog.ShowAsync();
+	}
+
+	private async Task HandleHideClick()
+	{
+		await myDialog.HideAsync();
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDialogDoc/HxDialog_Documentation.razor
@@ -9,6 +9,13 @@
     <DocHeading Title="Basic usage" />
 	<Demo Type="typeof(HxDialog_Demo)" Tabs="false" />
 
+    <DocHeading Title="Footer" />
+	<p>
+		Use the <code>FooterTemplate</code> to add action buttons or other content to the bottom of the dialog.
+		The footer renders as a Bootstrap <code>dialog-footer</code>, so multiple actions are spaced and aligned to the end automatically.
+	</p>
+	<Demo Type="typeof(HxDialog_Demo_Footer)" />
+
     <DocHeading Title="Static backdrop" />
 	<p>When the backdrop is set to <code>DialogBackdrop.Static</code>, the dialog will not close when clicking outside of it.</p>
 	<Demo Type="typeof(HxDialog_Demo_Backdrop)" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxDrawerDoc/HxDrawer_Demo_Footer.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDrawerDoc/HxDrawer_Demo_Footer.razor
@@ -1,0 +1,28 @@
+﻿<HxDrawer @ref="drawerComponent" Title="Edit profile">
+	<BodyTemplate>
+		<p>Content for the drawer goes here. The footer stays pinned to the bottom.</p>
+		<HxInputText Label="Name" @bind-Value="name" />
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="HandleHide" Text="Cancel" Color="ThemeColor.Secondary" />
+		<HxButton OnClick="HandleHide" Text="Save changes" Color="ThemeColor.Primary" />
+	</FooterTemplate>
+</HxDrawer>
+
+<HxButton OnClick="HandleShow" Text="Show" Color="ThemeColor.Primary" />
+
+@code
+{
+	private HxDrawer drawerComponent;
+	private string name;
+
+	private async Task HandleShow()
+	{
+		await drawerComponent.ShowAsync();
+	}
+
+	private async Task HandleHide()
+	{
+		await drawerComponent.HideAsync();
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxDrawerDoc/HxDrawer_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxDrawerDoc/HxDrawer_Documentation.razor
@@ -33,6 +33,13 @@
         <p>Set the size of the <code>HxDrawer</code> with the <code>Size</code> parameter. The default value is <code>DrawerSize.Regular</code>.</p>
         <Demo Type="typeof(HxDrawer_Demo_Size)" />
 
+        <DocHeading Title="Footer" />
+        <p>
+            Use the <code>FooterTemplate</code> to add action buttons or other content pinned to the bottom of the drawer.
+            The footer renders as a Bootstrap <code>drawer-footer</code>, so multiple actions are spaced and aligned to the end automatically.
+        </p>
+        <Demo Type="typeof(HxDrawer_Demo_Footer)" />
+
         <DocHeading Title="Sheet" />
         <p>Set <code>Sheet="true"</code> to render the drawer as a flush-to-edge sheet (no inset, border radius, or shadow) using the <code>drawer-sheet</code> variant.</p>
         <Demo Type="typeof(HxDrawer_Demo_Sheet)" />
@@ -40,12 +47,6 @@
     <CssVariables>
         <ApiDocCssVariable Name="--hx-drawer-close-icon-font-size" Default="2rem">
             Drawer close icon font size.
-        </ApiDocCssVariable>
-        <ApiDocCssVariable Name="--hx-drawer-footer-padding-x" Default="1rem">
-            Horizontal padding of the footer.
-        </ApiDocCssVariable>
-        <ApiDocCssVariable Name="--hx-drawer-footer-padding-y" Default="1rem">
-            Vertical padding of the footer.
         </ApiDocCssVariable>
         <ApiDocCssVariable Name="--hx-drawer-horizontal-width-sm" Default="400px">
             Horizontal width on a small screen size.

--- a/docs/generated/HxDialog.md
+++ b/docs/generated/HxDialog.md
@@ -52,8 +52,11 @@ Component for rendering a dialog as a Bootstrap 6 Dialog (built on the native `<
 - HxDialog_Demo.razor
 - HxDialog_Demo_Animation.razor
 - HxDialog_Demo_Backdrop.razor
+- HxDialog_Demo_Footer.razor
 - HxDialog_Demo_Fullscreen.razor
+- HxDialog_Demo_NonModal.razor
 - HxDialog_Demo_Scrollable.razor
 - HxDialog_Demo_Scrolling.razor
 - HxDialog_Demo_Size.razor
+- HxDialog_Demo_Swapping.razor
 

--- a/docs/generated/HxDrawer.md
+++ b/docs/generated/HxDrawer.md
@@ -52,6 +52,7 @@ Bootstrap Drawer component (aka Drawer).
 - HxDrawer_Demo.razor
 - HxDrawer_Demo_Backdrop.razor
 - HxDrawer_Demo_CustomCloseButtonIcon.razor
+- HxDrawer_Demo_Footer.razor
 - HxDrawer_Demo_Placement.razor
 - HxDrawer_Demo_Responsive.razor
 - HxDrawer_Demo_Sheet.razor

--- a/docs/generated/demos/HxDialog/HxDialog_Demo_Footer.md
+++ b/docs/generated/demos/HxDialog/HxDialog_Demo_Footer.md
@@ -1,0 +1,32 @@
+﻿# HxDialog_Demo_Footer.razor
+
+```razor
+<HxButton OnClick="HandleShowClick" Color="ThemeColor.Primary">Show dialog</HxButton>
+
+<HxDialog @ref="myDialog" Title="Edit profile">
+	<BodyTemplate>
+		<HxInputText Label="Name" @bind-Value="name" />
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton Text="Cancel" OnClick="HandleHideClick" Color="ThemeColor.Secondary" />
+		<HxButton Text="Save changes" OnClick="HandleHideClick" Color="ThemeColor.Primary" />
+	</FooterTemplate>
+</HxDialog>
+
+@code
+{
+	private HxDialog myDialog;
+	private string name;
+
+	private async Task HandleShowClick()
+	{
+		await myDialog.ShowAsync();
+	}
+
+	private async Task HandleHideClick()
+	{
+		await myDialog.HideAsync();
+	}
+}
+
+```

--- a/docs/generated/demos/HxDrawer/HxDrawer_Demo_Footer.md
+++ b/docs/generated/demos/HxDrawer/HxDrawer_Demo_Footer.md
@@ -1,0 +1,33 @@
+﻿# HxDrawer_Demo_Footer.razor
+
+```razor
+<HxDrawer @ref="drawerComponent" Title="Edit profile">
+	<BodyTemplate>
+		<p>Content for the drawer goes here. The footer stays pinned to the bottom.</p>
+		<HxInputText Label="Name" @bind-Value="name" />
+	</BodyTemplate>
+	<FooterTemplate>
+		<HxButton OnClick="HandleHide" Text="Cancel" Color="ThemeColor.Secondary" />
+		<HxButton OnClick="HandleHide" Text="Save changes" Color="ThemeColor.Primary" />
+	</FooterTemplate>
+</HxDrawer>
+
+<HxButton OnClick="HandleShow" Text="Show" Color="ThemeColor.Primary" />
+
+@code
+{
+	private HxDrawer drawerComponent;
+	private string name;
+
+	private async Task HandleShow()
+	{
+		await drawerComponent.ShowAsync();
+	}
+
+	private async Task HandleHide()
+	{
+		await drawerComponent.HideAsync();
+	}
+}
+
+```


### PR DESCRIPTION
Part of the Bootstrap v6 docs gap review. Bootstrap 6 `dialog` and `drawer` both have dedicated Footer sections, but our docs only had footer CSS variables and no footer demo. While verifying the drawer footer, I also found we were still using a custom footer implementation that v6 makes unnecessary.

## What changed

**Footer demos / sections (the docs gap)**
- `HxDialog` — new `Footer` section + `HxDialog_Demo_Footer` demo showing Cancel + Save actions.
- `HxDrawer` — new `Footer` section + `HxDrawer_Demo_Footer` demo showing Cancel + Save actions.

**Drop the custom drawer footer (no longer needed in v6)**
- `HxDrawer` rendered its footer with a custom `hx-drawer-footer` class carried over from the v5 offcanvas, which had no native footer. Bootstrap 6 ships a native `.drawer-footer` (gap, wrap, end-aligned actions, top border), so the component now emits `drawer-footer` directly.
- Removed the custom `.hx-drawer-footer` CSS rule and the now-unused `--hx-drawer-footer-padding-x` / `--hx-drawer-footer-padding-y` variables (the native footer uses `--bs-drawer-padding-*`).
- `HxDialog` already used the native `dialog-footer`, so no component change was needed there.

## Notes for reviewers
- The multi-button demos intentionally rely on the native footer styling (gap + `justify-content: flex-end`) rather than custom spacing.
- Updated the `HxDrawerTests` footer assertion selector to `div.drawer-footer`, and refreshed the `docs/generated` dump for the two affected components only.
- Bootstrap library and Documentation projects both build clean with `-warnaserror`.

Closes #1522