### PR TITLE
HxAutosuggest: close menu on mouse item-click (Bootstrap 6 Menu regression)

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInternal.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Autosuggests/Internal/HxAutosuggestInternal.razor.cs
@@ -337,7 +337,6 @@ public partial class HxAutosuggestInternal<TItem, TValue> : IAsyncDisposable
 		{
 			if ((focusedItem is not null) && (!focusedItem.Equals(default)))
 			{
-				await DestroyMenuAsync();
 				await HandleItemSelected(focusedItem);
 				StateHasChanged();
 			}
@@ -384,6 +383,9 @@ public partial class HxAutosuggestInternal<TItem, TValue> : IAsyncDisposable
 	private async Task HandleItemSelected(TItem item)
 	{
 		// user selected an item in the "menu".
+		// Close the menu explicitly: unlike the Bootstrap 5 Dropdown, the Bootstrap 6 Menu does not
+		// auto-close on item click (the item button stops click propagation, so Menu.clearMenus never runs).
+		await DestroyMenuAsync();
 		_userInput = TextSelectorEffective(item);
 		_userInputModified = false;
 		await SetValueItemWithEventCallback(item);

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxMenu.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxMenu.js
@@ -11,10 +11,10 @@
 
 	if (options) {
 		prepareOptions(options);
-		const d = new bootstrap.Menu(element, options);
+		new bootstrap.Menu(element, options);
 	}
 	else {
-		const d = new bootstrap.Menu(element);
+		new bootstrap.Menu(element);
 	}
 }
 
@@ -41,10 +41,10 @@ export function update(element, options) {
 
 	if (options) {
 		prepareOptions(options);
-		const d = new bootstrap.Menu(element, options);
+		new bootstrap.Menu(element, options);
 	}
 	else {
-		const d = new bootstrap.Menu(element);
+		new bootstrap.Menu(element);
 	}
 }
 


### PR DESCRIPTION
## What

Close the suggestion menu explicitly when an item is selected by mouse, instead of relying on Bootstrap to auto-close it.

## Why

The `HxDropdown → HxMenu` rename (#1476) was mechanical, but Bootstrap 6 `Menu` behaves differently from Bootstrap 5 `Dropdown`: **it does not auto-close on item click.** The `.menu-item` buttons carry `@onclick:stopPropagation="true"`, so the click never reaches the document and the document-level `Menu.clearMenus` listener never fires. The keyboard-Enter path already closed the menu explicitly (`DestroyMenuAsync`); the mouse path leaned on Bootstrap's auto-close, which no longer happens.

Consequence: after a mouse selection the menu stays open. In the `ValueChanged`-clearing scenario this broke the **second** selection — the next input click toggled the stale menu shut, and the delayed `hidden.bs.menu → HandleMenuHidden` then tore down the freshly reopened menu. Playwright reported the menu item flickering: `element is not stable → not visible`, then a 30s timeout.

This surfaced as the failing E2E test `HxAutosuggest_ValueChangedClearing_InputIsClearedOnSecondSelection`.

## Fix

- Move `DestroyMenuAsync()` into `HandleItemSelected` so both mouse and keyboard selection close the menu.
- Drop the now-redundant `DestroyMenuAsync()` from the keyboard-Enter path.

The component no longer depends on Bootstrap auto-closing on click.

## Verification

- Target test: **fail (33s timeout) → pass (2.7s)**
- All 5 HxAutosuggest E2E tests: pass
- All 6 HxAutosuggest unit tests: pass

Reproduced the failure live in a browser first (menu observably left open after the first selection, toggled shut on the second), then confirmed the fix.

## Note for reviewers

The same Dropdown→Menu auto-close difference could affect **other Hx components** that render `.menu-item` with `stopPropagation` and previously relied on Bootstrap closing the menu on click. This PR only addresses HxAutosuggest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)