### PR TITLE
HxListLayout: Bootstrap 6 layout fixes, flush variant, h4 title, icon/text filter button

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor
@@ -10,7 +10,7 @@
                 {
                     <div class="hx-list-layout-named-view">
                         <span role="button" id="namedViewsMenuLink" class="hx-list-layout-menu-link" data-bs-toggle="menu" aria-haspopup="true" aria-expanded="false">
-                            <h5 class="card-title text-truncate">
+                            <h4 class="card-title text-truncate">
                                 @if (TitleFromNamedView && (SelectedNamedView is not null))
                                 {
                                     @SelectedNamedView.Name
@@ -25,7 +25,7 @@
                                 {
                                     @Title
                                 }
-                            </h5>
+                            </h4>
                             <HxIcon CssClass="ms-1" Icon="@BootstrapIcon.ChevronDown" />
                         </span>
                         <div class="hx-named-view menu" aria-labelledby="namedViewsMenuLink">
@@ -44,13 +44,13 @@
                 }
                 else if (TitleTemplate != null)
                 {
-                    <h5 class="hx-list-layout-title card-title d-flex align-items-center">
+                    <h4 class="hx-list-layout-title card-title d-flex align-items-center">
                         @TitleTemplate
-                    </h5>
+                    </h4>
                 }
                 else if (!String.IsNullOrEmpty(Title))
                 {
-                    <h5 class="hx-list-layout-title card-title text-truncate">@Title</h5>
+                    <h4 class="hx-list-layout-title card-title text-truncate">@Title</h4>
                 }
 
                 @if (SearchTemplate != null)
@@ -69,7 +69,11 @@
 						}
 						@if (FilterTemplate != null)
 						{
-							<HxButton Settings="FilterOpenButtonSettingsEffective" OnClick="ShowFilterDrawerAsync" AriaLabel="@Localizer["FilterButtonAriaLabel"]" />
+							<HxButton Settings="FilterOpenButtonSettingsEffective"
+									  OnClick="ShowFilterDrawerAsync"
+									  Text="@FilterButtonText"
+									  CssClass="@(String.IsNullOrEmpty(FilterButtonText) ? CssClassHelper.Combine(FilterOpenButtonSettingsEffective.CssClass, "btn-icon") : null)"
+									  AriaLabel="@(String.IsNullOrEmpty(FilterButtonText) ? (string)Localizer["FilterButtonAriaLabel"] : null)" />
 						}
 					</div>
 				}
@@ -100,7 +104,9 @@
             }
         </BodyTemplate>
         <ChildContent>
-            @DataTemplate
+            <div class="card-body hx-list-layout-data">
+                @DataTemplate
+            </div>
         </ChildContent>
     </HxCard>
     @DetailTemplate

--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor
@@ -71,9 +71,9 @@
 						{
 							<HxButton Settings="FilterOpenButtonSettingsEffective"
 									  OnClick="ShowFilterDrawerAsync"
-									  Text="@FilterButtonText"
-									  CssClass="@(String.IsNullOrEmpty(FilterButtonText) ? CssClassHelper.Combine(FilterOpenButtonSettingsEffective.CssClass, "btn-icon") : null)"
-									  AriaLabel="@(String.IsNullOrEmpty(FilterButtonText) ? (string)Localizer["FilterButtonAriaLabel"] : null)" />
+									  Text="@(String.IsNullOrWhiteSpace(FilterButtonText) ? null : FilterButtonText)"
+									  CssClass="@(String.IsNullOrWhiteSpace(FilterButtonText) ? CssClassHelper.Combine(FilterOpenButtonSettingsEffective.CssClass, "btn-icon") : null)"
+									  AriaLabel="@(String.IsNullOrWhiteSpace(FilterButtonText) ? (string)Localizer["FilterButtonAriaLabel"] : null)" />
 						}
 					</div>
 				}

--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor.cs
@@ -100,6 +100,12 @@ public partial class HxListLayout<TFilterModel>
 	protected CardSettings CardSettingsEffective => CardSettings ?? GetSettings()?.CardSettings ?? GetDefaults().CardSettings ?? throw new InvalidOperationException(nameof(CardSettings) + " default for " + nameof(HxListLayout) + " has to be set.");
 
 	/// <summary>
+	/// Text for the button opening the filter drawer.
+	/// When not set, the button renders as an icon-only button (<c>btn-icon</c>).
+	/// </summary>
+	[Parameter] public string FilterButtonText { get; set; }
+
+	/// <summary>
 	/// Settings for the <see cref="HxButton"/> opening the filtering drawer.
 	/// </summary>
 	[Parameter] public ButtonSettings FilterOpenButtonSettings { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Layouts/HxListLayout.razor.css
@@ -14,8 +14,26 @@
 	overflow: hidden;
 }
 
-::deep .hx-chip-list {
-	margin-top: var(--hx-list-layout-header-gap);
+/* Bootstrap 6 makes .card-body a flex column with align-items: flex-start,
+   so block-level content no longer fills the width. Restore stretching
+   so the header grid and chip list span the full card width. */
+.hx-list-layout ::deep .card-body {
+	align-items: stretch;
+}
+
+/* The data (grid) renders in its own card-body so Bootstrap 6's section-based
+   border model (.card-body:last-child) gives the region its side + bottom
+   borders and bottom rounding. The header card-body directly above already
+   supplies the bottom padding, so the data body drops its top padding to avoid
+   doubling the space before the grid. */
+.hx-list-layout-data {
+	padding-top: 0;
+}
+
+/* The flush modifier (e.g. via CssClass) drops the data padding entirely so the
+   table sits edge to edge. */
+.hx-list-layout-flush .hx-list-layout-data {
+	padding: 0;
 }
 
 .hx-list-layout-header ::deep button {
@@ -41,20 +59,17 @@
     padding-right: 1rem;
 }
 
-.hx-list-layout:has(.hx-pager) ::deep .hx-grid {
-    margin-bottom: 0;
-}
-
-.hx-list-layout:not(:has(.hx-pager)) ::deep .hx-grid tr:last-of-type td:first-child {
-	border-bottom-left-radius: var(--bs-card-inner-border-radius);
-}
-
-.hx-list-layout:not(:has(.hx-pager)) ::deep .hx-grid tr:last-of-type td:last-child {
-	border-bottom-right-radius: var(--bs-card-inner-border-radius);
-}
-
+/* Spacing between card-body sections (header / chip list / grid / pager) is
+   managed by the card-body gap + padding, so these elements carry no margins.
+   The flush variant removes the data-body padding, so the pager takes a side and
+   bottom margin to stay inset from the card edges (aligned with the table cell
+   inset). The top spacing is left to the card-body gap to avoid doubling it. */
 ::deep .hx-pager {
-	margin: 1rem;
+	margin: 0;
+}
+
+.hx-list-layout-flush ::deep .hx-pager {
+	margin: 0 1rem 1rem;
 }
 
 .hx-list-layout-menu-link:hover {
@@ -76,11 +91,24 @@
 .hx-list-layout-header {
 	display: grid;
 	grid-template-columns: 1fr auto;
+	grid-template-areas: "title buttons";
+	align-items: center;
+	gap: var(--hx-list-layout-header-gap);
+}
+
+/* Vertically center every header item (title, search, buttons) in its row.
+   Without this the items stretch to the row height and their content (the
+   heading text, the search input) pins to the top. */
+.hx-list-layout-header > * {
+	align-self: center;
+}
+
+/* A search box stacks on its own full-width row below the title and buttons.
+   Without one, no extra row is reserved (avoids a trailing gap). */
+.hx-list-layout-header:has(.hx-list-layout-header-search) {
 	grid-template-areas:
 		"title buttons"
 		"search search";
-	align-items: center;
-	gap: var(--hx-list-layout-header-gap);
 }
 
 .hx-list-layout-header-buttons {
@@ -92,12 +120,19 @@
 }
 
 .hx-list-layout-named-view,
-.hx-list-layout-header-title {
+.hx-list-layout-title {
 	grid-area: title;
 }
 
 .hx-list-layout-header-search {
 	grid-area: search;
+}
+
+/* The search input lives in the toolbar row, so collapse the form-group's
+   validation-row gap. Otherwise the empty validation area makes the field
+   taller than the input, leaving the input pinned to the top of the row. */
+.hx-list-layout-header-search ::deep .hx-form-group {
+	gap: 0;
 }
 
 .hx-list-layout > ::deep .card:first-child {
@@ -106,7 +141,10 @@
 }
 
 @container hx-list-layout-card (min-width: 768px) {
-	.hx-list-layout-header {
+	/* With a search box, lay title / search / buttons out in one row. Without
+	   one, the base "title buttons" (1fr auto) layout is kept, so the title
+	   expands and no empty search column is reserved. */
+	.hx-list-layout-header:has(.hx-list-layout-header-search) {
 		grid-template-columns: 1fr 1fr 1fr;
 		grid-template-areas: "title search buttons";
 	}

--- a/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Demo_Flush.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Demo_Flush.razor
@@ -1,0 +1,91 @@
+@inject IDemoDataService DemoDataService
+
+<HxListLayout Title="Employees"
+			  CssClass="hx-list-layout-flush"
+			  TFilterModel="EmployeesFilterDto"
+			  @bind-FilterModel="filterModel"
+			  @bind-FilterModel:after="HandleFilterModelChanged">
+	<SearchTemplate>
+		<HxInputText Placeholder="Search by name"
+					 Type="InputType.Search"
+					 @bind-Value="filterModel.Name"
+					 @bind-Value:after="HandleFilterModelChanged" />
+	</SearchTemplate>
+	<CommandsTemplate>
+		<HxButton Text="Create employee" Color="ThemeColor.Primary" Icon="BootstrapIcon.PlusLg" OnClick="HandleNewItemClicked" />
+	</CommandsTemplate>
+	<FilterTemplate Context="filterContext">
+		<HxInputText Label="Phone" @bind-Value="filterContext.Phone" />
+		<HxInputNumber Label="Minimum salary" @bind-Value="filterContext.SalaryMin" Decimals="0" InputGroupStartText="$" />
+		<HxInputNumber Label="Maximum salary" @bind-Value="filterContext.SalaryMax" Decimals="0" InputGroupStartText="$" />
+		<HxInputText Label="Position" @bind-Value="filterContext.Position" />
+		<HxInputText Label="Location" @bind-Value="filterContext.Location" />
+	</FilterTemplate>
+	<DataTemplate>
+		<HxGrid @ref="gridComponent"
+				TItem="EmployeeDto"
+				DataProvider="GetGridData"
+				@bind-SelectedDataItem="currentEmployee"
+				@bind-SelectedDataItem:after="HandleSelectedDataItemChanged"
+				PageSize="5"
+				Responsive="true">
+			<Columns>
+				<HxGridColumn HeaderText="Name" ItemTextSelector="employee => employee.Name" />
+				<HxGridColumn HeaderText="Phone" ItemTextSelector="employee => employee.Phone" />
+				<HxGridColumn HeaderText="Salary" ItemTextSelector="@(employee => employee.Salary.ToString("c0"))" />
+				<HxGridColumn HeaderText="Position" ItemTextSelector="employee => employee.Position" />
+				<HxGridColumn HeaderText="Location" ItemTextSelector="employee => employee.Location" />
+				<HxContextMenuGridColumn Context="employee">
+					<HxContextMenu>
+						<HxContextMenuItem Text="Delete" Icon="BootstrapIcon.Trash" OnClick="async () => await HandleDeleteClick(employee)" ConfirmationQuestion="@($"Are you sure you want to delete {employee.Name}?")" />
+					</HxContextMenu>
+				</HxContextMenuGridColumn>
+			</Columns>
+		</HxGrid>
+	</DataTemplate>
+	<DetailTemplate>
+		dataItemEditComponent: {currentEmployee.Id: @currentEmployee?.Id}
+	</DetailTemplate>
+</HxListLayout>
+
+@code {
+	private EmployeeDto currentEmployee;
+	private EmployeesFilterDto filterModel = new() { SalaryMax = 20000 };
+	private HxGrid<EmployeeDto> gridComponent;
+
+	private async Task<GridDataProviderResult<EmployeeDto>> GetGridData(GridDataProviderRequest<EmployeeDto> request)
+	{
+		var response = await DemoDataService.GetEmployeesDataFragmentAsync(filterModel, request.StartIndex, request.Count, request.CancellationToken);
+		return new GridDataProviderResult<EmployeeDto>()
+			{
+				Data = response.Data,
+				TotalCount = response.TotalCount
+			};
+	}
+
+	private async Task HandleFilterModelChanged()
+	{
+		await gridComponent.RefreshDataAsync(GridStateResetOptions.ResetPosition);
+	}
+
+	private async Task HandleDeleteClick(EmployeeDto employee)
+	{
+		await DemoDataService.DeleteEmployeeAsync(employee.Id);
+		await gridComponent.RefreshDataAsync();
+	}
+
+	private Task HandleSelectedDataItemChanged()
+	{
+		// open or navigate to employee detail here (currentEmployee is set)
+		// await dataItemEditComponent.ShowAsync();
+		return Task.CompletedTask;
+	}
+
+	private Task HandleNewItemClicked()
+	{
+		currentEmployee = new();
+		// open or navigate to employee detail here
+		// await dataItemEditComponent.ShowAsync();
+		return Task.CompletedTask;
+	}
+}

--- a/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListLayoutDoc/HxListLayout_Documentation.razor
@@ -40,6 +40,14 @@
 		</p>
 		<Demo Type="typeof(HxListLayout_Demo_NamedViews)" />
 
+		<DocHeading Title="Flush (edge-to-edge content)" Id="flush" />
+		<p>
+			By default the data area keeps the card padding. Add the <code>hx-list-layout-flush</code> CSS class
+			(through the <code>CssClass</code> parameter) to remove that padding so the grid sits edge to edge with
+			the card. This works with all the other features &ndash; search, commands, filter chips, and the pager.
+		</p>
+		<Demo Type="typeof(HxListLayout_Demo_Flush)" />
+
 	</MainContent>
 	<CssVariables>
 		<ApiDocCssVariable Name="--hx-list-layout-table-font-size" Default=".875rem">

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -32,7 +32,7 @@ else
 @code {
 	private void RenderDemo(RenderTreeBuilder __builder)
 	{
-		<div class="@CssClassHelper.Combine("demo-content p-3 align-self-stretch vstack gap-3", DemoCardCssClass)">
+		<div class="@CssClassHelper.Combine("demo-content not-prose p-3 align-self-stretch vstack gap-3", DemoCardCssClass)">
 			@if (Resizable)
 			{
 				<div class="demo-resizable">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -10336,6 +10336,12 @@
             Settings for the wrapping <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxCard"/>.
             </summary>
         </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxListLayout`1.FilterButtonText">
+            <summary>
+            Text for the button opening the filter drawer.
+            When not set, the button renders as an icon-only button (<c>btn-icon</c>).
+            </summary>
+        </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxListLayout`1.FilterOpenButtonSettings">
             <summary>
             Settings for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxButton"/> opening the filtering drawer.


### PR DESCRIPTION
## What

Fixes the HxListLayout demo/layout under Bootstrap 6 and adds a few related improvements.

### Bootstrap 6 card layout fixes
Bootstrap 6 made `.card-body` a `flex-start` column and moved the card border onto the sections (`.card-body` carries the side borders; `:first-child`/`:last-child` add the top/bottom edges + rounding). HxListLayout rendered the grid + pager as raw `.card` children (outside `.card-body`), so the content shrink-wrapped and the table/pager region lost its border.

- Render the data (grid) in its **own `.card-body`** so the BS6 section-border model gives it side + bottom borders and bottom rounding — no `.card` override needed.
- `align-items: stretch` on the card-bodies so the header grid and chip list fill the width again (BS6 `flex-start` was shrink-wrapping them).
- The data body drops its **top padding** so the gap before the grid isn't doubled with the header body's bottom padding.
- Section spacing is driven by the **card-body gap** (legacy element margins on the chip list / pager / table removed); the pager keeps a side+bottom inset only in the flush variant where there is no body padding.
- Removed now-redundant table rules (table `margin-bottom: 0` and the no-pager last-row corner rounding) — the card-body handles rounding now.

### Header
- Smart header grid via `:has(.hx-list-layout-header-search)`: the search column/row is reserved **only when a search box is present** (no empty middle column / trailing row otherwise).
- Title rendered as **`h4`** and every header item is vertically centered (`align-self: center`) — items were stretching and pinning their content (heading text, search input) to the top.
- Collapse the search field's validation-row gap so the input matches the row height and centers properly.
- Fixed a latent class mismatch: the `grid-area: title` rule targeted `.hx-list-layout-header-title` but the element is `.hx-list-layout-title`, so the title was auto-placed instead of assigned to its cell.

### Filter button
- Rendered as a Bootstrap 6 **icon button** (`btn-icon`).
- Added a **`FilterButtonText`** parameter to optionally show text (when set, the button is a normal text+icon button and drops `btn-icon`/`AriaLabel` so the visible text is the accessible name).

### Flush variant
- Added the **`hx-list-layout-flush`** modifier (via `CssClass`) that removes the data padding so the grid sits edge to edge.

### Docs
- Added a complex **Flush** demo (search + commands + filter chips + pager + context menu).
- Added `not-prose` to the demo container so the documentation prose styles no longer bleed into demos.

## Why

The HxListLayout demo was visibly broken on the v6 branch (truncated title, missing card border, shrink-wrapped content) due to the Bootstrap 6 card changes. These changes restore the production layout under BS6 and add the requested flush/title/filter-button capabilities.

## Reviewer notes

- All changes are scoped to `HxListLayout` (component + scoped CSS) and the documentation project — no changes to `HxCard` or other shared components.
- Verified in the docs site across desktop / narrow viewport / dark mode: full card border, full-width header, centered title + search, edge-to-edge flush table, and the icon vs text filter button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)