### PR TITLE
[v6] Fix hanging HxDrawer Escape E2E test (unblocks E2E CI)

### DIFF
--- a/Havit.Blazor.E2ETests/HxDrawerTests/HxDrawer_BasicTests.cs
+++ b/Havit.Blazor.E2ETests/HxDrawerTests/HxDrawer_BasicTests.cs
@@ -52,17 +52,23 @@ public class HxDrawer_BasicTests : TestAppTestBase
 		await NavigateToTestAppAsync("/HxDrawer_BasicTests");
 
 		var showButton = Page.Locator("[data-testid='show-button']");
-		await Page.EvaluateAsync("window.__hxDrawerShown = new Promise(resolve => document.addEventListener('shown.bs.drawer', resolve, { once: true }))");
 		await showButton.ClickAsync();
 
 		var drawerContent = Page.Locator("[data-testid='drawer-content']");
 		await Expect(drawerContent).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
-		// Wait for the entry transition to finish (shown.bs.drawer): Bootstrap 6 (alpha)
-		// silently swallows dismissals (incl. native Escape) while _isTransitioning is true.
-		await Page.EvaluateAsync("window.__hxDrawerShown");
+		// Move focus into the open drawer before pressing Escape. Playwright delivers key presses
+		// to the focused element; right after opening, focus is still on the trigger button in the
+		// now-inert page, so a bare Escape never reaches the dialog. (The previous implementation
+		// instead awaited a 'shown.bs.drawer' event that is never raised in a headless/CI
+		// environment - transitions emit no transitionend - which hung the whole E2E run forever.)
+		await drawerContent.ClickAsync();
 
-		// Act - press Escape
+		// Press Escape. Bootstrap 6 (alpha) silently swallows dismissals while the entry transition
+		// is still running, so the first keystroke can be ignored; a second press after a short
+		// settle reliably dismisses the drawer.
+		await Page.Keyboard.PressAsync("Escape");
+		await Page.WaitForTimeoutAsync(500);
 		await Page.Keyboard.PressAsync("Escape");
 
 		// Assert - drawer content should no longer be visible


### PR DESCRIPTION
## Problem

The E2E pipeline never finishes on the build server. Running the suite locally and bisecting with xunit's `-longRunning` detector pinned the culprit:

**`HxDrawerTests.HxDrawer_BasicTests.HxDrawer_PressEscape_ClosesPanel`** hangs **indefinitely** — it awaits `window.__hxDrawerShown` (a `shown.bs.drawer` event) with **no timeout**. In a headless/CI browser the drawer's entry transition emits no `transitionend`, so Bootstrap never raises `shown.bs.drawer`, and the unbounded `await Page.EvaluateAsync(...)` blocks the whole run forever (it was the only test in the suite using an unbounded promise-await; every other test uses bounded `Expect(...)` assertions that fail rather than hang).

## Fix

Drop the unreliable `shown.bs.drawer` wait entirely and fix the actual interaction:

- **Focus the dialog before pressing Escape.** Playwright delivers key presses to the focused element; right after opening, focus is still on the trigger button in the now-inert page, so a bare `Escape` never reached the dialog. Clicking inside the drawer first delivers it.
- **Press Escape twice with a short settle**, since Bootstrap 6 (alpha) swallows dismissals while the entry transition is still running.

## Verification

Locally, the test previously hung forever (>9 min). With this change the **HxDrawer suite is 5/5 green in ~8 s**, stable across repeated runs.

## Notes
- This is the sole infinite-hang in the suite; with it resolved the E2E run completes and any remaining issues surface as ordinary (bounded) failures rather than hangs.
- The underlying product observation — Bootstrap 6 (alpha) drawer not emitting `shown.bs.drawer` / not clearing its transitioning state when no `transitionend` fires — is worth a separate look, but is out of scope for unblocking CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)