### PR TITLE
[v6] Fix HxMultiSelect summary-text E2E test (button, not input)

### DIFF
--- a/Havit.Blazor.E2ETests/HxMultiSelectTests/HxMultiSelectTests.cs
+++ b/Havit.Blazor.E2ETests/HxMultiSelectTests/HxMultiSelectTests.cs
@@ -68,7 +68,7 @@ public class HxMultiSelectTests : TestAppTestBase
 		var toggle = Page.Locator("[data-testid='toggle']");
 
 		// Assert initial empty state shows EmptyText
-		await Expect(toggle).ToHaveValueAsync("-select items-");
+		await Expect(toggle).ToHaveTextAsync("-select items-");
 
 		// Act - open menu and select Gamma
 		await toggle.ClickAsync();
@@ -77,8 +77,8 @@ public class HxMultiSelectTests : TestAppTestBase
 		// Close by clicking outside
 		await Page.Locator("[data-testid='outside-click-target']").ClickAsync();
 
-		// Assert - the input reflects the selected item
-		await Expect(toggle).ToHaveValueAsync("Gamma");
+		// Assert - the toggle reflects the selected item
+		await Expect(toggle).ToHaveTextAsync("Gamma");
 	}
 
 	[Fact]


### PR DESCRIPTION
## What

Fixes the failing `HxMultiSelectTests.HxMultiSelect_SelectedItems_ShownAsSummaryText` E2E test by switching its two assertions from `ToHaveValueAsync` to `ToHaveTextAsync`.

## Why

The test asserted the selected/empty summary via `ToHaveValueAsync`, which Playwright only supports on `<input>` elements. The `[data-testid='toggle']` for `HxMultiSelect` renders as a `<button>` with the summary text inside a `<span class="combobox-value">` (see `HxMultiSelectInternal.razor`), so the assertion failed:

```
Microsoft.Playwright.PlaywrightException : Locator expected to have value
Error: Not an input element '-select items-'
But was: 'null'
```

## How

`ToHaveTextAsync` reads the button's text content, which is exactly the summary text (the caret SVG contributes no text). This matches how the sibling tests in the same file already assert on the selected value.

No component/production code changed — test-only fix.