### PR TITLE
HxInputText/HxInputTextArea/HxInputNumber: add form-adorn support (Adorns)

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputTextAdornTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputTextAdornTests.cs
@@ -1,0 +1,65 @@
+using Bunit;
+namespace Havit.Blazor.Components.Web.Bootstrap.Tests.Forms;
+
+public class HxInputTextAdornTests : BunitTestBase
+{
+	[Fact]
+	public void HxInputText_NoAdorn_RendersPlainFormControl()
+	{
+		// Act
+		var cut = RenderComponent<HxInputText>(parameters => parameters
+			.Bind(p => p.Value, "initial", _ => { }));
+
+		// Assert
+		Assert.DoesNotContain("form-adorn", cut.Markup);
+		var input = cut.Find("input");
+		Assert.Contains("form-control", input.GetAttribute("class"));
+		Assert.DoesNotContain("form-ghost", input.GetAttribute("class"));
+	}
+
+	[Fact]
+	public void HxInputText_AdornStartText_RendersFormAdornWrapperWithGhostInput()
+	{
+		// Act
+		var cut = RenderComponent<HxInputText>(parameters => parameters
+			.Bind(p => p.Value, "initial", _ => { })
+			.Add(p => p.AdornStartText, "€"));
+
+		// Assert
+		var wrapper = cut.Find("div.form-adorn");
+		Assert.Contains("form-control", wrapper.GetAttribute("class"));
+
+		var adornText = wrapper.QuerySelector(".form-adorn-text");
+		Assert.NotNull(adornText);
+		Assert.Equal("€", adornText.TextContent);
+
+		var input = cut.Find("input");
+		Assert.Contains("form-ghost", input.GetAttribute("class"));
+		Assert.DoesNotContain("form-control", input.GetAttribute("class"));
+	}
+
+	[Fact]
+	public void HxInputText_AdornEndTemplate_RendersFormAdornIconAfterInput()
+	{
+		// Act
+		var cut = RenderComponent<HxInputText>(parameters => parameters
+			.Bind(p => p.Value, "initial", _ => { })
+			.Add(p => p.AdornEndTemplate, (builder) => builder.AddMarkupContent(0, "<span class=\"my-icon\"></span>")));
+
+		// Assert
+		var wrapper = cut.Find("div.form-adorn");
+		var icon = wrapper.QuerySelector(".form-adorn-icon .my-icon");
+		Assert.NotNull(icon);
+	}
+
+	[Fact]
+	public void HxInputText_AdornWithFloatingLabel_Throws()
+	{
+		// Act & Assert
+		Assert.Throws<InvalidOperationException>(() => RenderComponent<HxInputText>(parameters => parameters
+			.Bind(p => p.Value, "initial", _ => { })
+			.Add(p => p.LabelType, LabelType.Floating)
+			.Add(p => p.Label, "Name")
+			.Add(p => p.AdornStartText, "€")));
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBase.cs
@@ -463,6 +463,14 @@ public abstract class HxInputBase<TValue> : InputBase<TValue>, ICascadeEnabledCo
 	protected virtual string GetInputCssClassToRender()
 	{
 		string validationCssClass = IsValueInvalid() ? InvalidCssClass : null;
+
+		if (this.ShouldRenderAdorn())
+		{
+			// The form-adorn wrapper (rendered by HxFormValueComponentRenderer) owns the form-control/size chrome,
+			// the input itself becomes an unstyled form-ghost.
+			return CssClassHelper.Combine("form-ghost", InputCssClass, validationCssClass);
+		}
+
 		return CssClassHelper.Combine(CoreInputCssClass, InputCssClass, validationCssClass, (this is IInputWithSize inputWithSize) ? inputWithSize.GetInputSizeCssClass() : null);
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBaseWithAdorns.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBaseWithAdorns.cs
@@ -1,0 +1,52 @@
+using Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+namespace Havit.Blazor.Components.Web.Bootstrap;
+
+/// <summary>
+/// A base class for form input components. This base class automatically integrates
+/// with a Microsoft.AspNetCore.Components.Forms.EditContext, which must be supplied
+/// as a cascading parameter.
+/// Extends the <seealso cref="HxInputBaseWithInputGroups{TValue}" /> class.
+/// Adds support for adorns (icons/text rendered inside the field chrome),
+/// see <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/forms/form-adorn/">form-adorn</see>.
+/// </summary>
+public abstract class HxInputBaseWithAdorns<TValue> : HxInputBaseWithInputGroups<TValue>, IFormValueComponentWithAdorns
+{
+	/// <summary>
+	/// Custom CSS class to be rendered with the <c>form-adorn</c> wrapper.
+	/// </summary>
+	[Parameter] public string AdornCssClass { get; set; }
+
+	/// <summary>
+	/// Text adornment at the beginning of the input.
+	/// </summary>
+	[Parameter] public string AdornStartText { get; set; }
+
+	/// <summary>
+	/// Adornment (typically an icon) at the beginning of the input.
+	/// </summary>
+	[Parameter] public RenderFragment AdornStartTemplate { get; set; }
+
+	/// <summary>
+	/// Text adornment at the end of the input.
+	/// </summary>
+	[Parameter] public string AdornEndText { get; set; }
+
+	/// <summary>
+	/// Adornment (typically an icon) at the end of the input.
+	/// </summary>
+	[Parameter] public RenderFragment AdornEndTemplate { get; set; }
+
+	/// <inheritdoc />
+	protected override void OnParametersSet()
+	{
+		base.OnParametersSet();
+
+		if ((this is IInputWithLabelType inputWithLabelType)
+			&& (inputWithLabelType.LabelTypeEffective == LabelType.Floating)
+			&& this.ShouldRenderAdorn())
+		{
+			throw new InvalidOperationException($"[{GetType().Name}] LabelType.Floating cannot be combined with adorns (AdornStartText/AdornStartTemplate/AdornEndText/AdornEndTemplate) — the form-adorn wrapper owns the visual chrome and cannot host a floating label. Use LabelType.Regular.");
+		}
+	}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
@@ -12,7 +12,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap;
 /// Defaults located in separate non-generic type <see cref="HxInputNumber"/>.
 /// </remarks>
 /// <typeparam name="TValue">Supported values: <c>byte (Byte), sbyte (SByte), short (Int16), ushort(UInt16), int (Int32), uint(UInt32), long (Int64), ulong(UInt64), float (Single), double (Double) and decimal (Decimal)</c>.</typeparam>
-public class HxInputNumber<TValue> : HxInputBaseWithInputGroups<TValue>, IInputWithSize, IInputWithPlaceholder, IInputWithLabelType
+public class HxInputNumber<TValue> : HxInputBaseWithAdorns<TValue>, IInputWithSize, IInputWithPlaceholder, IInputWithLabelType
 {
 	// DO NOT FORGET TO MAINTAIN DOCUMENTATION! (documentation comment of this class)
 	private static HashSet<Type> s_supportedTypes = new HashSet<Type>

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputTextBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputTextBase.cs
@@ -6,7 +6,7 @@ namespace Havit.Blazor.Components.Web.Bootstrap;
 /// <summary>
 /// Text-based (string) input base class.
 /// </summary>
-public abstract class HxInputTextBase : HxInputBaseWithInputGroups<string>, IInputWithSize, IInputWithPlaceholder, IInputWithLabelType
+public abstract class HxInputTextBase : HxInputBaseWithAdorns<string>, IInputWithSize, IInputWithPlaceholder, IInputWithLabelType
 {
 	/// <summary>
 	/// Return <see cref="HxInputText"/> defaults.

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/FormValueComponentExtensions.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/FormValueComponentExtensions.cs
@@ -16,4 +16,16 @@ public static class FormValueComponentExtensions
 				|| !String.IsNullOrEmpty(formValueComponentWithInputGroups.InputGroupEndText)
 				|| (formValueComponentWithInputGroups.InputGroupEndTemplate != null));
 	}
+
+	/// <summary>
+	/// Returns <c>true</c> if <see cref="IFormValueComponent" /> should render the <c>form-adorn</c> wrapper (at least one adornment).
+	/// </summary>
+	public static bool ShouldRenderAdorn(this IFormValueComponent formValueComponent)
+	{
+		return (formValueComponent is IFormValueComponentWithAdorns formValueComponentWithAdorns)
+			&& (!String.IsNullOrEmpty(formValueComponentWithAdorns.AdornStartText)
+				|| (formValueComponentWithAdorns.AdornStartTemplate != null)
+				|| !String.IsNullOrEmpty(formValueComponentWithAdorns.AdornEndText)
+				|| (formValueComponentWithAdorns.AdornEndTemplate != null));
+	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxFormValueComponentRenderer.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxFormValueComponentRenderer.cs
@@ -146,7 +146,7 @@ public class HxFormValueComponentRenderer : ComponentBase
 		}
 
 		builder.OpenRegion(400);
-		content(builder);
+		BuildRenderAdorn(builder, content);
 		builder.CloseRegion();
 
 		if (shouldRenderInputGroups)
@@ -164,6 +164,68 @@ public class HxFormValueComponentRenderer : ComponentBase
 			}
 
 			builder.CloseElement(); // span.input-group
+		}
+	}
+
+	/// <summary>
+	/// Renders the form-adorn wrapper (with content) when the component has at least one adornment.
+	/// </summary>
+	protected virtual void BuildRenderAdorn(RenderTreeBuilder builder, RenderFragment content)
+	{
+		IFormValueComponentWithAdorns formValueComponentWithAdorns = FormValueComponent as IFormValueComponentWithAdorns;
+		IInputWithSize formValueComponentWithSize = FormValueComponent as IInputWithSize;
+
+		bool shouldRenderAdorn = FormValueComponent.ShouldRenderAdorn();
+
+		if (shouldRenderAdorn)
+		{
+			builder.OpenElement(800, "div");
+			builder.AddAttribute(801, "class", CssClassHelper.Combine(
+				"form-control",
+				"form-adorn",
+				formValueComponentWithSize is not null ? formValueComponentWithSize.GetInputSizeCssClass() : null,
+				formValueComponentWithAdorns.AdornCssClass));
+
+			if (formValueComponentWithAdorns.AdornStartTemplate is not null)
+			{
+				builder.OpenElement(810, "div");
+				builder.AddAttribute(811, "class", "form-adorn-icon");
+				builder.AddContent(812, formValueComponentWithAdorns.AdornStartTemplate);
+				builder.CloseElement(); // div.form-adorn-icon
+			}
+
+			if (!String.IsNullOrEmpty(formValueComponentWithAdorns.AdornStartText))
+			{
+				builder.OpenElement(820, "span");
+				builder.AddAttribute(821, "class", "form-adorn-text");
+				builder.AddContent(822, formValueComponentWithAdorns.AdornStartText);
+				builder.CloseElement(); // span.form-adorn-text
+			}
+		}
+
+		builder.OpenRegion(830);
+		content(builder);
+		builder.CloseRegion();
+
+		if (shouldRenderAdorn)
+		{
+			if (!String.IsNullOrEmpty(formValueComponentWithAdorns.AdornEndText))
+			{
+				builder.OpenElement(840, "span");
+				builder.AddAttribute(841, "class", "form-adorn-text");
+				builder.AddContent(842, formValueComponentWithAdorns.AdornEndText);
+				builder.CloseElement(); // span.form-adorn-text
+			}
+
+			if (formValueComponentWithAdorns.AdornEndTemplate is not null)
+			{
+				builder.OpenElement(850, "div");
+				builder.AddAttribute(851, "class", "form-adorn-icon");
+				builder.AddContent(852, formValueComponentWithAdorns.AdornEndTemplate);
+				builder.CloseElement(); // div.form-adorn-icon
+			}
+
+			builder.CloseElement(); // div.form-adorn
 		}
 	}
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/IFormValueComponentWithAdorns.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/IFormValueComponentWithAdorns.cs
@@ -1,0 +1,33 @@
+namespace Havit.Blazor.Components.Web.Bootstrap.Internal;
+
+/// <summary>
+/// Extends <see cref="IFormValueComponent"/> with properties for rendering the <c>form-adorn</c> wrapper
+/// (icon/text decorations rendered inside the field chrome, as opposed to input groups which render outside it).
+/// </summary>
+public interface IFormValueComponentWithAdorns : IFormValueComponent
+{
+	/// <summary>
+	/// Custom CSS class to be rendered with the <c>form-adorn</c> wrapper.
+	/// </summary>
+	string AdornCssClass => null;
+
+	/// <summary>
+	/// Text adornment at the beginning of the input, rendered as <c>.form-adorn-text</c>.
+	/// </summary>
+	string AdornStartText => null;
+
+	/// <summary>
+	/// Adornment (typically an icon) at the beginning of the input, rendered as <c>.form-adorn-icon</c>.
+	/// </summary>
+	RenderFragment AdornStartTemplate => null;
+
+	/// <summary>
+	/// Text adornment at the end of the input, rendered as <c>.form-adorn-text</c>.
+	/// </summary>
+	string AdornEndText => null;
+
+	/// <summary>
+	/// Adornment (typically an icon) at the end of the input, rendered as <c>.form-adorn-icon</c>.
+	/// </summary>
+	RenderFragment AdornEndTemplate => null;
+}

--- a/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Demo_Adorns.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Demo_Adorns.razor
@@ -1,0 +1,21 @@
+<HxInputText Label="Adorn (icon)" @bind-Value="@value" Placeholder="Search...">
+	<AdornStartTemplate>
+		<HxIcon Icon="BootstrapIcon.Search" />
+	</AdornStartTemplate>
+</HxInputText>
+
+<HxInputText Label="Adorn (text)" @bind-Value="@value" Placeholder="username" AdornEndText="@@example.com" />
+
+<HxInputNumber @bind-Value="@valueDecimal" Label="Adorn (currency)" AdornStartText="€" />
+
+<HxInputText Label="Adorn (icon, end)" @bind-Value="@value" Placeholder="you@example.com">
+	<AdornEndTemplate>
+		<HxIcon Icon="BootstrapIcon.EnvelopeFill" />
+	</AdornEndTemplate>
+</HxInputText>
+
+@code
+{
+	private string value;
+	private decimal valueDecimal;
+}

--- a/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Documentation.razor
@@ -33,6 +33,18 @@
 </p>
 <Demo Type="@typeof(FormInputs_Demo_InputGroups)" />
 
+<DocHeading Title="Adorns" Id="adorns" />
+<p>
+	<code>@nameof(HxInputBaseWithAdorns<object>.AdornStartText), @nameof(HxInputBaseWithAdorns<object>.AdornEndText), @nameof(HxInputBaseWithAdorns<object>.AdornStartTemplate), @nameof(HxInputBaseWithAdorns<object>.AdornEndTemplate)</code>
+	render an icon or text inside the field's own chrome (border, background, focus ring) rather than in a separate box next to it, as with input groups.
+	Available on <code>HxInputText</code>, <code>HxInputTextArea</code>, and <code>HxInputNumber</code>.
+	See <a href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/forms/form-adorn/">form-adorn in the Bootstrap documentation</a>.
+</p>
+<DocAlert Type="DocAlertType.Warning">
+	Adorns cannot be combined with <code>LabelType.Floating</code> — the <code>form-adorn</code> wrapper owns the visual chrome and cannot host a floating label.
+</DocAlert>
+<Demo Type="@typeof(FormInputs_Demo_Adorns)" />
+
 <DocHeading Title="Floating labels" Id="floating-labels" />
 <p>
 	Floating labels provide a sleek and simple design, floating elegantly over your input fields.

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -3835,6 +3835,11 @@
             Returns <c>true</c> if <see cref="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent" /> should render input groups (at least one input group).
             </summary>
         </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.FormValueComponentExtensions.ShouldRenderAdorn(Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent)">
+            <summary>
+            Returns <c>true</c> if <see cref="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent" /> should render the <c>form-adorn</c> wrapper (at least one adornment).
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.FormValueRenderer">
             <summary>
             Renders <see cref="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent" />.
@@ -3872,6 +3877,11 @@
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxFormValueComponentRenderer.BuildRenderInputGroups(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder,Microsoft.AspNetCore.Components.RenderFragment)">
             <summary>
             Renders the input groups (with content).
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxFormValueComponentRenderer.BuildRenderAdorn(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder,Microsoft.AspNetCore.Components.RenderFragment)">
+            <summary>
+            Renders the form-adorn wrapper (with content) when the component has at least one adornment.
             </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.Internal.HxFormValueComponentRenderer.BuildRenderValue(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
@@ -4055,6 +4065,37 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent.RenderOrder">
             <summary>
             Render order LabelValue or ValueLabel.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithAdorns">
+            <summary>
+            Extends <see cref="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponent"/> with properties for rendering the <c>form-adorn</c> wrapper
+            (icon/text decorations rendered inside the field chrome, as opposed to input groups which render outside it).
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithAdorns.AdornCssClass">
+            <summary>
+            Custom CSS class to be rendered with the <c>form-adorn</c> wrapper.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithAdorns.AdornStartText">
+            <summary>
+            Text adornment at the beginning of the input, rendered as <c>.form-adorn-text</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithAdorns.AdornStartTemplate">
+            <summary>
+            Adornment (typically an icon) at the beginning of the input, rendered as <c>.form-adorn-icon</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithAdorns.AdornEndText">
+            <summary>
+            Text adornment at the end of the input, rendered as <c>.form-adorn-text</c>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithAdorns.AdornEndTemplate">
+            <summary>
+            Adornment (typically an icon) at the end of the input, rendered as <c>.form-adorn-icon</c>.
             </summary>
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.Internal.IFormValueComponentWithInputGroups">
@@ -5510,6 +5551,44 @@
             <summary>
             Application-wide defaults for the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxInputBase`1"/> and derived components.
             </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1">
+            <summary>
+            A base class for form input components. This base class automatically integrates
+            with a Microsoft.AspNetCore.Components.Forms.EditContext, which must be supplied
+            as a cascading parameter.
+            Extends the <seealso cref="T:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithInputGroups`1" /> class.
+            Adds support for adorns (icons/text rendered inside the field chrome),
+            see <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/forms/form-adorn/">form-adorn</see>.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1.AdornCssClass">
+            <summary>
+            Custom CSS class to be rendered with the <c>form-adorn</c> wrapper.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1.AdornStartText">
+            <summary>
+            Text adornment at the beginning of the input.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1.AdornStartTemplate">
+            <summary>
+            Adornment (typically an icon) at the beginning of the input.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1.AdornEndText">
+            <summary>
+            Text adornment at the end of the input.
+            </summary>
+        </member>
+        <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1.AdornEndTemplate">
+            <summary>
+            Adornment (typically an icon) at the end of the input.
+            </summary>
+        </member>
+        <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithAdorns`1.OnParametersSet">
+            <inheritdoc />
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxInputBaseWithInputGroups`1">
             <summary>


### PR DESCRIPTION
## Summary
- Adds `AdornStartText`/`AdornEndText`/`AdornStartTemplate`/`AdornEndTemplate` on a new `HxInputBaseWithAdorns<TValue>` base class (between `HxInputBaseWithInputGroups<TValue>` and `HxInputText`/`HxInputTextArea`/`HxInputNumber`), mirroring the existing `InputGroups` mechanism.
- When an adorn is set, `HxFormValueComponentRenderer` wraps the input in the Bootstrap 6 `form-adorn` pattern (`div.form-control.form-adorn` owning the border/background/focus chrome, `.form-adorn-icon`/`.form-adorn-text` for the decoration, the actual input becoming `.form-ghost`) instead of a separate `.input-group` box outside the field. Input groups and adorns can be combined (input-group wraps the adorn-wrapped field).
- Throws if combined with `LabelType.Floating`, matching the existing guard pattern used by `HxAutosuggest`/`HxInputDate`/`HxSearchBox`.
- Deliberately **not** added to `HxSelectBase` (`HxSelect`/`HxMultiSelect`) — native `<select>` relies on `.form-control`'s own caret background image, which `.form-ghost` strips, so adorn-wrapping a select would silently lose its dropdown arrow without extra caret handling.
- Adds a documentation section/demo and bUnit tests.

## Test plan
- [x] `dotnet build` for `Havit.Blazor.Components.Web.Bootstrap` and `Havit.Blazor.Documentation` — clean, 0 warnings/errors.
- [x] Full `Havit.Blazor.Components.Web.Bootstrap.Tests` suite — 580/580 passing (including 4 new adorn tests: no-adorn baseline, start-text wrapper, end-template icon, floating-label guard).
- [x] Verified rendered DOM/computed styles in-browser match Bootstrap's `form-adorn` reference markup for text/icon, start/end variants.