### PR TITLE
Docs: move rounded-4 to card body on Upgrade to Premium page

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Premium/GetPremium.razor
+++ b/Havit.Blazor.Documentation/Pages/Premium/GetPremium.razor
@@ -16,7 +16,7 @@
 	<div class="mb-5">
 		<div class="row g-4">
 			<div class="col-12 lg:col-4" data-bs-theme="dark">
-				<HxCard CssClass="h-100 rounded-4" BodyCssClass="p-4 d-flex flex-column">
+				<HxCard CssClass="h-100" BodyCssClass="rounded-4 p-4 d-flex flex-column">
 					<BodyTemplate>
 						<h5 class="fw-bold text-white">Free forever</h5>
 						<p class="fw-medium text-white">$0 Free for everyone</p>
@@ -33,7 +33,7 @@
 				</HxCard>
 			</div>
 			<div class="col-12 lg:col-4">
-				<HxCard CssClass="h-100 rounded-4 bg-body-secondary border-0" BodyCssClass="p-4 d-flex flex-column">
+				<HxCard CssClass="h-100 bg-body-secondary border-0" BodyCssClass="rounded-4 p-4 d-flex flex-column">
 					<BodyTemplate>
 						<h5 class="fw-bold">Premium</h5>
 						<p class="fw-medium">$19 per user/month</p>
@@ -52,7 +52,7 @@
 				</HxCard>
 			</div>
 			<div class="col-12 lg:col-4">
-				<HxCard CssClass="h-100 rounded-4" BodyCssClass="p-4 d-flex flex-column">
+				<HxCard CssClass="h-100" BodyCssClass="rounded-4 p-4 d-flex flex-column">
 					<BodyTemplate>
 						<h5 class="fw-bold">Custom</h5>
 						<p class="fw-medium">Contact sales</p>


### PR DESCRIPTION
## Summary
- On the Upgrade to Premium page, `rounded-4` was applied to `HxCard`'s `CssClass` (outer `.card` wrapper). Moved it to `BodyCssClass` (`.card-body`) instead, per request.

## Test plan
- [x] Verified `HxCard.razor` markup to confirm `CssClass` targets the outer `.card` div and `BodyCssClass` targets `.card-body`.
- [ ] Visual check of `/premium` page not run in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)