### PR TITLE
Docs: restyle demo content wrapper, fix HxCloseButton dark demo layout

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxCloseButtonDoc/HxCloseButton_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCloseButtonDoc/HxCloseButton_Documentation.razor
@@ -8,5 +8,5 @@
     <Demo Type="typeof(HxCloseButton_Demo_DisabledState)" />
 
     <DocHeading Title="White variant" />
-    <Demo Type="typeof(HxCloseButton_Demo_White)" DemoCardCssClass="bg-dark p-0" />
+    <Demo Type="typeof(HxCloseButton_Demo_White)" DemoCardCssClass="bg-dark p-0 flex-row" />
 </ApiDoc>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCloseButtonDoc/HxCloseButton_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCloseButtonDoc/HxCloseButton_Documentation.razor
@@ -8,5 +8,5 @@
     <Demo Type="typeof(HxCloseButton_Demo_DisabledState)" />
 
     <DocHeading Title="White variant" />
-    <Demo Type="typeof(HxCloseButton_Demo_White)" DemoCardCssClass="bg-dark p-0 flex-row" />
+    <Demo Type="typeof(HxCloseButton_Demo_White)" DemoCardCssClass="bg-dark p-0 d-flex" />
 </ApiDoc>

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -32,7 +32,7 @@ else
 @code {
 	private void RenderDemo(RenderTreeBuilder __builder)
 	{
-		<div class="@CssClassHelper.Combine("p-3", DemoCardCssClass)">
+		<div class="@CssClassHelper.Combine("demo-content not-prose p-3 d-flex flex-column gap-3", DemoCardCssClass)">
 			<DynamicComponent Type="Type" />
 		</div>
 	}

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -32,7 +32,7 @@ else
 @code {
 	private void RenderDemo(RenderTreeBuilder __builder)
 	{
-		<div class="@CssClassHelper.Combine("demo-content not-prose p-3 d-flex flex-column gap-3", DemoCardCssClass)">
+		<div class="@CssClassHelper.Combine("demo-content not-prose p-3 d-grid gap-3", DemoCardCssClass)">
 			<DynamicComponent Type="Type" />
 		</div>
 	}


### PR DESCRIPTION
## Summary
- `Demo.razor`'s demo content wrapper now uses `demo-content not-prose p-3 d-flex flex-column gap-3` instead of just `p-3`, giving consistent vertical spacing between multiple elements in a single demo.
- `HxCloseButton_Documentation.razor`'s white-variant demo now adds `flex-row` to `DemoCardCssClass` to override the new `flex-column` default — otherwise its two close buttons would stack vertically instead of sitting side by side on the dark background.

## Notes for reviewer
- The pre-existing `p-0` in that same `DemoCardCssClass` doesn't actually zero out the padding — Bootstrap's `.p-3` utility is declared after `.p-0` in the vendored stylesheet, so it wins the cascade tie despite `!important` on both. This is a pre-existing issue, left as-is since it's out of scope here.
- Considered Bootstrap 6's upcoming `space-y-*` utilities (margin-based, no forced `display:flex`) as a longer-term alternative to `gap` for this wrapper, but the vendored Bootstrap here is still pinned to 5.3.8 and doesn't include them.

## Test plan
- [ ] Visually verify the `HxCloseButton` "White variant" demo still shows both buttons side by side on the dark background
- [ ] Spot-check a few other component docs pages to confirm multi-element demos get sensible vertical spacing from `gap-3`