### PR TITLE
Fix collapsed-sidebar flyout menu item/header sizing

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxSidebarItem.razor.css
@@ -26,6 +26,13 @@
 		display: flex;
 	}
 
+	/* Flyout menu items (collapsed sidebar) should default to the same size as HxMenu items, not the top-level sidebar item size. */
+	::deep .menu.hx-sidebar-subitems .nav-link {
+		padding: var(--bs-menu-item-padding-y) var(--bs-menu-item-padding-x);
+		font-size: var(--bs-menu-font-size);
+		line-height: var(--bs-body-line-height, 1.5);
+	}
+
 	::deep .hx-sidebar-collapsed-nav {
 		flex-direction: column;
 		padding-block: .25rem;
@@ -81,8 +88,4 @@
 		color: var(--hx-sidebar-item-hover-icon-color);
 	}
 
-	::deep .menu-header {
-		padding-bottom: 0;
-		padding-left: .75rem;
-	}
 }


### PR DESCRIPTION
## Summary
- Collapsed-sidebar flyout items (e.g. hovering a rail icon like "Data & Grid") rendered with the top-level sidebar item's size (`1rem` font, `.75rem` padding) instead of `HxMenu`'s default item size, because a generic `.nav-link` rule in `HxSidebarItem.razor.css` lived in a CSS layer declared after Bootstrap's `.menu-item` layer and won regardless of specificity.
- Also removes a `.menu-header` `padding-bottom: 0` override so the flyout's category heading (e.g. "Data & Grid") matches `HxMenu`'s default header spacing.

## Test plan
- [x] Ran `Havit.Blazor.Documentation.Server`, collapsed the desktop sidebar to icon-rail mode, hovered a category icon, and confirmed the flyout items/header now compute the same padding/font-size/line-height as `HxMenu`'s defaults (`4px 12px` padding, `14px` font, `21px` line-height for items; `4px 12px` uniform padding for the header).
- [x] Confirmed the expanded-rail accordion submenu and top-level sidebar items are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)