### PR TITLE
Docs: fix HxGrid custom paging demo layout and sizing

### DIFF
--- a/Havit.Blazor.Documentation/Pages/Components/HxGridDoc/HxGrid_Demo_CustomPagination.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxGridDoc/HxGrid_Demo_CustomPagination.razor
@@ -14,18 +14,18 @@
 			int firstItemPosition = pagination.CurrentUserState.PageIndex * pagination.PageSize + 1;
 			int lastItemPosition = Math.Min(firstItemPosition + pagination.PageSize - 1, pagination.TotalCount);
 		}
-		<div class="row">
-			<div class="col d-flex gap-2 align-items-center">
-				Rows per page: <HxSelect @bind-Value="@_pageSize" Data="_pageSizes" Nullable="false" AutoSort="false" InputSize="InputSize.Small" />
+		<div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+			<div class="d-flex align-items-center gap-2">
+				Page size: <HxSelect @bind-Value="@_pageSize" Data="_pageSizes" Nullable="false" AutoSort="false" InputSize="InputSize.Small" ValidationMessageMode="ValidationMessageMode.None" />
 			</div>
-			<div class="col d-flex justify-content-center align-items-center">
+			<div class="text-nowrap">
 				Showing @firstItemPosition to @lastItemPosition of @pagination.TotalCount entries
 			</div>
-			<div class="col d-flex align-items-center justify-content-end">
-				<HxButton Icon="BootstrapIcon.ChevronBarLeft" Enabled="pagination.CurrentUserState.PageIndex > 0" OnClick="() => pagination.ChangeCurrentPageIndexAsync(0)" Color="ThemeColor.Link" />
-				<HxButton Icon="BootstrapIcon.ChevronLeft" Enabled="pagination.CurrentUserState.PageIndex > 0" OnClick="() => pagination.ChangeCurrentPageIndexAsync(pagination.CurrentUserState.PageIndex - 1)" Color="ThemeColor.Link" />
-				<HxButton Icon="BootstrapIcon.ChevronRight" Enabled="pagination.CurrentUserState.PageIndex + 1 < totalPages" OnClick="() => pagination.ChangeCurrentPageIndexAsync(pagination.CurrentUserState.PageIndex + 1)" Color="ThemeColor.Link" />
-				<HxButton Icon="BootstrapIcon.ChevronBarRight" Enabled="pagination.CurrentUserState.PageIndex + 1 < totalPages" OnClick="() => pagination.ChangeCurrentPageIndexAsync(totalPages - 1)" Color="ThemeColor.Link" />
+			<div class="d-flex align-items-center gap-1">
+				<HxButton Icon="BootstrapIcon.ChevronBarLeft" Enabled="pagination.CurrentUserState.PageIndex > 0" OnClick="() => pagination.ChangeCurrentPageIndexAsync(0)" Color="ThemeColor.Link" Size="ButtonSize.Small" CssClass="btn-icon" AriaLabel="First page" />
+				<HxButton Icon="BootstrapIcon.ChevronLeft" Enabled="pagination.CurrentUserState.PageIndex > 0" OnClick="() => pagination.ChangeCurrentPageIndexAsync(pagination.CurrentUserState.PageIndex - 1)" Color="ThemeColor.Link" Size="ButtonSize.Small" CssClass="btn-icon" AriaLabel="Previous page" />
+				<HxButton Icon="BootstrapIcon.ChevronRight" Enabled="pagination.CurrentUserState.PageIndex + 1 < totalPages" OnClick="() => pagination.ChangeCurrentPageIndexAsync(pagination.CurrentUserState.PageIndex + 1)" Color="ThemeColor.Link" Size="ButtonSize.Small" CssClass="btn-icon" AriaLabel="Next page" />
+				<HxButton Icon="BootstrapIcon.ChevronBarRight" Enabled="pagination.CurrentUserState.PageIndex + 1 < totalPages" OnClick="() => pagination.ChangeCurrentPageIndexAsync(totalPages - 1)" Color="ThemeColor.Link" Size="ButtonSize.Small" CssClass="btn-icon" AriaLabel="Last page" />
 			</div>
 		</div>
 	</PaginationTemplate>


### PR DESCRIPTION
## Summary
- Replaced the 3-column Bootstrap grid layout in the custom paging demo with a flex layout, fixing text wrapping and vertical alignment.
- Made the page-size select and pager buttons small, and rendered the pager buttons as proper icon buttons (`btn-icon`) with `AriaLabel`s.
- Relabeled "Rows per page:" to "Page size:".

## Test plan
- [x] Verified in the browser that the toolbar no longer wraps to two lines at typical widths.
- [x] Verified text, select, and buttons are all vertically centered (measured via computed styles).
- [x] Verified pager buttons render as 32×32 square icon buttons matching the select's small size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)