### PR TITLE
Fix Bootstrap 6 floating labels not floating

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputTextTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputTextTests.cs
@@ -202,6 +202,37 @@ public class HxInputTextTests : BunitTestBase
 		Assert.Equal("Enter your name", cut.Find("input").GetAttribute("placeholder"));
 	}
 
+	[Fact]
+	public void HxInputText_FloatingLabel_LabelPrecedesInputInDom()
+	{
+		// Arrange — regression: Bootstrap 6 floats the label via ":has(~ .form-control...)", a relational
+		// selector that only matches a *following* sibling, so the label must be the first child of
+		// .form-floating, immediately before the control (the reverse of Bootstrap 5's control-then-label order).
+		string currentValue = "";
+
+		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>
+		{
+			builder.OpenComponent<HxInputText>(0);
+			builder.AddAttribute(1, "Value", currentValue);
+			builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, (value) => { currentValue = value; }));
+			builder.AddAttribute(3, "ValueExpression", (Expression<Func<string>>)(() => currentValue));
+			builder.AddAttribute(4, "LabelType", (LabelType?)LabelType.Floating);
+			builder.AddAttribute(5, "Label", "Your name");
+			builder.CloseComponent();
+		};
+
+		// Act
+		var cut = Render(componentRenderer);
+
+		// Assert
+		var formFloating = cut.Find(".form-floating");
+		var children = formFloating.Children;
+		Assert.Equal(2, children.Length);
+		Assert.Equal("LABEL", children[0].TagName);
+		Assert.Equal("INPUT", children[1].TagName);
+		Assert.Equal(children[1].GetAttribute("id"), children[0].GetAttribute("for"));
+	}
+
 	private record FormData
 	{
 		[MaxLength(100)]

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSelectFilteringTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSelectFilteringTests.cs
@@ -193,4 +193,59 @@ public class HxSelectFilteringTests : BunitTestBase
 		cut.Find("select");
 		Assert.Empty(cut.FindAll(".combobox-toggle"));
 	}
+
+	[Fact]
+	public void HxSelect_AllowFilteringNotSet_FloatingLabel_LabelPrecedesSelectInDom()
+	{
+		// Arrange — regression: Bootstrap 6 floats the label via ":has(~ .form-control...)", a relational
+		// selector that only matches a *following* sibling, so the label must precede the native <select>.
+		string selectedValue = null;
+		Expression<Func<string>> valueExpression = () => selectedValue;
+
+		// Act
+		var cut = RenderComponent<HxSelect<string, string>>(parameters => parameters
+			.Add(p => p.Data, new List<string> { "Apple", "Banana" })
+			.Add(p => p.Value, selectedValue)
+			.Add(p => p.ValueChanged, value => selectedValue = value)
+			.Add(p => p.ValueExpression, valueExpression)
+			.Add(p => p.Nullable, true)
+			.Add(p => p.LabelType, LabelType.Floating)
+			.Add(p => p.Label, "Employee")
+		);
+
+		// Assert
+		var formFloating = cut.Find(".form-floating");
+		var children = formFloating.Children;
+		Assert.Equal(2, children.Length);
+		Assert.Equal("LABEL", children[0].TagName);
+		Assert.Equal("SELECT", children[1].TagName);
+		Assert.Equal(children[1].GetAttribute("id"), children[0].GetAttribute("for"));
+	}
+
+	[Fact]
+	public void HxSelect_AllowFiltering_FloatingLabel_LabelPrecedesToggleButtonInDom()
+	{
+		// Arrange — regression: with AllowFiltering, the floating label is rendered by HxSelectInternal
+		// itself (not the shared HxFormValueComponentRenderer), which must also put the label before the
+		// toggle button (not after it, and not after the menu) for the same ":has(~ ...)" reason.
+		string selectedValue = null;
+		Expression<Func<string>> valueExpression = () => selectedValue;
+
+		var cut = RenderComponent<HxSelect<string, string>>(parameters => parameters
+			.Add(p => p.Data, new List<string> { "Apple", "Banana" })
+			.Add(p => p.Value, selectedValue)
+			.Add(p => p.ValueChanged, value => selectedValue = value)
+			.Add(p => p.ValueExpression, valueExpression)
+			.Add(p => p.AllowFiltering, true)
+			.Add(p => p.LabelType, LabelType.Floating)
+			.Add(p => p.Label, "Employee")
+		);
+
+		// Assert — the label is the first child of .form-floating, preceding both the toggle button and the menu
+		var formFloating = cut.Find(".form-floating");
+		var children = formFloating.Children;
+		Assert.Equal("LABEL", children[0].TagName);
+		Assert.Equal("BUTTON", children[1].TagName);
+		Assert.Equal(children[1].GetAttribute("id"), children[0].GetAttribute("for"));
+	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMultiSelectTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMultiSelectTests.cs
@@ -149,6 +149,40 @@ public class HxMultiSelectTests : BunitTestBase
 	}
 
 	[Fact]
+	public void HxMultiSelect_FloatingLabel_LabelPrecedesToggleButtonInDom()
+	{
+		// Arrange — regression: Bootstrap 6 floats the label via ":has(~ .form-control...)", a relational
+		// selector that only matches a *following* sibling, so the label must be the first child of
+		// .form-floating, before the toggle button (not after it, and not after the menu).
+		var items = new[] { "Apple", "Banana" };
+		var selectedValues = new List<string>();
+
+		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>
+		{
+			builder.OpenComponent<HxMultiSelect<string, string>>(0);
+			builder.AddAttribute(1, "Data", (IEnumerable<string>)items);
+			builder.AddAttribute(2, "TextSelector", (Func<string, string>)(x => x));
+			builder.AddAttribute(3, "ValueSelector", (Func<string, string>)(x => x));
+			builder.AddAttribute(4, "Value", selectedValues);
+			builder.AddAttribute(5, "ValueChanged", EventCallback.Factory.Create<List<string>>(this, v => { }));
+			builder.AddAttribute(6, "ValueExpression", (Expression<Func<List<string>>>)(() => selectedValues));
+			builder.AddAttribute(7, "LabelType", (LabelType?)LabelType.Floating);
+			builder.AddAttribute(8, "Label", "Employees");
+			builder.CloseComponent();
+		};
+
+		// Act
+		var cut = Render(componentRenderer);
+
+		// Assert
+		var formFloating = cut.Find(".form-floating");
+		var children = formFloating.Children;
+		Assert.Equal("LABEL", children[0].TagName);
+		Assert.Equal("BUTTON", children[1].TagName);
+		Assert.Equal(children[1].GetAttribute("id"), children[0].GetAttribute("for"));
+	}
+
+	[Fact]
 	public void HxMultiSelect_Render_EmitsAccessibleListboxRoles()
 	{
 		// Arrange

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxFormValueComponentRenderer.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxFormValueComponentRenderer.cs
@@ -90,12 +90,14 @@ public class HxFormValueComponentRenderer : ComponentBase
 		builder.OpenElement(1, "div");
 		builder.AddAttribute(2, "class", "form-floating");
 
+		// Bootstrap 6 floats the label via ":has(~ .form-control...)", a relational selector that only matches
+		// a *following* sibling, so the label must precede the control in the DOM (unlike Bootstrap 5).
 		builder.OpenRegion(3);
-		BuildRenderValue(builder);
+		BuildRenderLabel(builder);
 		builder.CloseRegion();
 
 		builder.OpenRegion(4);
-		BuildRenderLabel(builder);
+		BuildRenderValue(builder);
 		builder.CloseRegion();
 
 		builder.CloseElement(); // div.form-floating

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor
@@ -19,6 +19,13 @@
 	@InputGroupStartTemplate
 	<div class="@CssClassHelper.Combine("hx-multi-select-toggle", (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null)">
 
+		@if (LabelTypeEffective == LabelType.Floating)
+		{
+			@* Bootstrap 6 floats the label via ":has(~ .form-control...)", a relational selector that only matches
+				a *following* sibling, so the label must precede the toggle button in the DOM. *@
+			<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
+		}
+
 		<button @ref="_toggleElementReference"
 				type="button"
 				id="@InputId"
@@ -112,11 +119,6 @@
 				}
 			}
 		</div>
-
-		@if (LabelTypeEffective == LabelType.Floating)
-		{
-			<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
-		}
 	</div>
 	@InputGroupEndTemplate
 

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxMultiSelectInternal.razor.css
@@ -41,3 +41,13 @@
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 }
+
+/* A floating label always makes the toggle button match ":not(:placeholder-shown)" (buttons never show a
+   placeholder), so Bootstrap 6 permanently shifts its padding down to clear the shrunk label. That shift is
+   meant for the value text's baseline, not the caret icon, so undo it here to keep the caret centered. */
+.form-floating .combobox-caret {
+	/* Flexbox align-items:center only shifts an item by half of any single-sided margin applied to it
+	   (the other half is absorbed back into the centering split), so the full padding delta is needed here,
+	   not half of it. */
+	margin-top: calc(var(--bs-form-floating-input-padding-b) - var(--bs-form-floating-input-padding-t));
+}

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor
@@ -4,6 +4,13 @@
 
 <div class="@CssClassHelper.Combine("hx-select", (LabelTypeEffective == LabelType.Floating) ? "form-floating" : null)">
 
+	@if (LabelTypeEffective == LabelType.Floating)
+	{
+		@* Bootstrap 6 floats the label via ":has(~ .form-control...)", a relational selector that only matches
+			a *following* sibling, so the label must precede the toggle button in the DOM. *@
+		<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
+	}
+
 	<button @ref="_toggleElementReference"
 			type="button"
 			id="@InputId"
@@ -96,9 +103,4 @@
 			}
 		}
 	</div>
-
-	@if (LabelTypeEffective == LabelType.Floating)
-	{
-		<HxFormValueComponentRenderer_Label FormValueComponent="@FormValueComponent" />
-	}
 </div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor.css
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/Internal/HxSelectInternal.razor.css
@@ -20,3 +20,13 @@
 .hx-select-filter-input-icon div[role="button"]:not(:hover) ::deep .hx-icon {
 	opacity: var(--hx-select-filter-input-icon-opacity, .25);
 }
+
+/* A floating label always makes the toggle button match ":not(:placeholder-shown)" (buttons never show a
+   placeholder), so Bootstrap 6 permanently shifts its padding down to clear the shrunk label. That shift is
+   meant for the value text's baseline, not the caret icon, so undo it here to keep the caret centered. */
+.form-floating .combobox-caret {
+	/* Flexbox align-items:center only shifts an item by half of any single-sided margin applied to it
+	   (the other half is absorbed back into the centering split), so the full padding delta is needed here,
+	   not half of it. */
+	margin-top: calc(var(--bs-form-floating-input-padding-b) - var(--bs-form-floating-input-padding-t));
+}

--- a/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Demo_FloatingLabels.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/FormInputs/FormInputs_Demo_FloatingLabels.razor
@@ -1,10 +1,45 @@
-﻿<HxInputText LabelType="LabelType.Floating" Label="Your name" @bind-Value="@name" CssClass="my-3" />
+﻿@inject IDemoDataService DemoDataService
+
+<HxInputText LabelType="LabelType.Floating" Label="Your name" @bind-Value="@name" CssClass="my-3" />
 <HxInputTextArea LabelType="LabelType.Floating" Label="Comments" @bind-Value="@comments" style="height:80px" CssClass="my-3" />
 <HxInputNumber LabelType="LabelType.Floating" Label="Age" @bind-Value="@age" CssClass="my-3" />
+
+<HxSelect TItem="EmployeeDto"
+		  TValue="int?"
+		  LabelType="LabelType.Floating"
+		  Label="Employee"
+		  Data="employees"
+		  @bind-Value="employeeId"
+		  TextSelector="@(employee => employee.Name)"
+		  ValueSelector="@(employee => employee.Id)"
+		  Nullable="true"
+		  NullText="-select employee-"
+		  NullDataText="Loading employees..."
+		  CssClass="my-3" />
+
+<HxMultiSelect TItem="EmployeeDto"
+			   TValue="int"
+			   LabelType="LabelType.Floating"
+			   Label="Employees"
+			   Data="employees"
+			   @bind-Value="selectedEmployeeIds"
+			   TextSelector="@(employee => employee.Name)"
+			   ValueSelector="@(employee => employee.Id)"
+			   NullDataText="Loading employees..."
+			   EmptyText="-select employees-"
+			   CssClass="my-3" />
 
 @code
 {
 	private string name;
 	private string comments;
 	private int? age;
+	private IEnumerable<EmployeeDto> employees;
+	private int? employeeId;
+	private List<int> selectedEmployeeIds = new();
+
+	protected override async Task OnInitializedAsync()
+	{
+		employees = await DemoDataService.GetAllEmployeesAsync();
+	}
 }


### PR DESCRIPTION
## Summary

Floating labels (`LabelType.Floating`) were broken on `main` after the Bootstrap 6 migration — the label rendered on top of the value but never floated/shrank on focus or when the field had a value. Reported on the v6 docs stage build's [Inputs page](/components/Inputs#floating-labels).

**Root cause:** Bootstrap 6 changed the floating-label CSS selector from Bootstrap 5's `.form-control:focus ~ label` to `label:has(~ .form-control:focus)`. `:has(~ X)` is a relational selector that only matches *following* siblings, so the `<label>` now has to come **before** its control in the DOM — the reverse of Bootstrap 5. Our renderers still emitted control-then-label, so the selector never matched. No build error, no test failure — only visible by inspecting the live DOM/computed styles.

## Changes

- `HxFormValueComponentRenderer.BuildRenderValueWithFloatingLabel` — render the label before the value (affects `HxInputText`, `HxInputTextArea`, `HxInputNumber`).
- `HxSelectInternal.razor` / `HxMultiSelectInternal.razor` — render the label immediately before the toggle button (first attempt placed it right after the button, which still fails since `:has(~ ...)` only looks forward — caught this by checking computed styles before considering it done).
- Documentation: extended the "Floating labels" demo (`FormInputs_Demo_FloatingLabels.razor`) to also include `HxSelect` and `HxMultiSelect`, matching what the docs text already claimed was supported but wasn't demoed.

## Test plan

- [x] `dotnet test` on `Havit.Blazor.Components.Web.Bootstrap.Tests` — 1160 passed, 0 failed (net9.0/net10.0; net8.0 target skipped, missing runtime on this machine, unrelated).
- [x] `dotnet build -warnaserror` on the affected projects — 0 warnings, 0 errors.
- [x] Manually verified in a running docs site + the TestApp's `HxMultiSelect_FloatingLabel` test page: confirmed DOM order (`LABEL` before control) and that `getComputedStyle(label).transform` correctly switches to the floated matrix on focus/value for `HxInputText`, `HxInputTextArea`, `HxInputNumber`, `HxSelect`, and `HxMultiSelect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)