### PR TITLE
Improve vague/missing component lead descriptions for docs SEO

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Alerts/HxAlert.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Alerts/HxAlert.razor.cs
@@ -1,7 +1,8 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/">Bootstrap alert</see> component.<br />
+/// Contextual feedback message (success, warning, danger, info, and more) with an optional icon, links, and a dismiss button.<br />
+/// Renders the <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/">Bootstrap alert</see> markup.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAlert">https://havit.blazor.eu/components/HxAlert</see>
 /// </summary>
 public partial class HxAlert

--- a/Havit.Blazor.Components.Web.Bootstrap/Badges/HxBadge.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Badges/HxBadge.razor.cs
@@ -1,7 +1,8 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap Badge</see> component.<br />
+/// Small <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap badge</see> for counts and labels.<br />
+/// Attach it to headings, buttons, or icons; position it as a notification dot; and style it with any theme color or pill shape.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxBadge">https://havit.blazor.eu/components/HxBadge</see>
 /// </summary>
 public partial class HxBadge

--- a/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButtonGroup.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Buttons/HxButtonGroup.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/button-group/">Button groups</see>.<br />
+/// Groups related <see cref="HxButton"/> controls into a single visual block, with support for sizing, nesting, and vertical stacking (<see href="https://getbootstrap.com/docs/5.3/components/button-group/">Bootstrap Button groups</see>).<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxButtonGroup">https://havit.blazor.eu/components/HxButtonGroup</see>
 /// </summary>
 public partial class HxButtonGroup

--- a/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Calendar/HxCalendar.razor.cs
@@ -3,7 +3,7 @@
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Basic calendar building block. Used for <see cref="HxInputDate{TValue}"/> and <see cref="HxInputDateRange"/> implementation.<br />
+/// Standalone month calendar for picking a single date or a date range — the same calendar used inside <see cref="HxInputDate{TValue}"/> and <see cref="HxInputDateRange"/>, available on its own for building custom date pickers.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxCalendar">https://havit.blazor.eu/components/HxCalendar</see>
 /// </summary>
 public partial class HxCalendar

--- a/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCard.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCard.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/card/">Bootstrap card</see> component.<br />
+/// Flexible content container — a <see href="https://getbootstrap.com/docs/5.3/components/card/">Bootstrap card</see> — for grouping a title, text, image, and actions into a single bordered panel.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxCard">https://havit.blazor.eu/components/HxCard</see>
 /// </summary>
 public partial class HxCard

--- a/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCardSubtitle.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCardSubtitle.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-subtitle</see> component.
+/// Secondary heading placed under a <see cref="HxCardTitle"/>, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-subtitle</see>.
 /// </summary>
 public class HxCardSubtitle : ComponentBase
 {

--- a/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCardText.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCardText.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-text</see> component.
+/// Paragraph of body text for a <see cref="HxCard"/>, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-text</see>.
 /// </summary>
 public partial class HxCardText
 {

--- a/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCardTitle.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Cards/HxCardTitle.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-title</see> component.
+/// Heading for a <see cref="HxCard"/>'s content, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-title</see>.
 /// </summary>
 public class HxCardTitle : ComponentBase
 {

--- a/Havit.Blazor.Components.Web.Bootstrap/Collapse/HxCollapse.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Collapse/HxCollapse.razor.cs
@@ -3,7 +3,7 @@
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/collapse/">Bootstrap 5 Collapse</see> component.<br />
+/// <see href="https://getbootstrap.com/docs/5.3/components/collapse/">Bootstrap 5 Collapse</see> for toggling the visibility of content — accordions, expandable panels, collapsible sidebars — with a smooth height animation.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxCollapse">https://havit.blazor.eu/components/HxCollapse</see>
 /// </summary>
 public partial class HxCollapse : IAsyncDisposable

--- a/Havit.Blazor.Components.Web.Bootstrap/ContextMenus/HxContextMenuItem.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/ContextMenus/HxContextMenuItem.razor.cs
@@ -5,6 +5,9 @@ using Microsoft.JSInterop;
 
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
+/// <summary>
+/// Single item for <see cref="HxContextMenu"/>, with an optional confirmation message shown before its action runs.
+/// </summary>
 public partial class HxContextMenuItem : ComponentBase, ICascadeEnabledComponent
 {
 	/// <summary>

--- a/Havit.Blazor.Components.Web.Bootstrap/Drawers/HxDrawer.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Drawers/HxDrawer.razor.cs
@@ -3,7 +3,7 @@
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/drawer/">Bootstrap Drawer</see> component (aka Drawer).<br />
+/// Off-canvas <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/drawer/">Bootstrap Drawer</see> panel that slides in from any edge of the screen — ideal for navigation, filters, or supplementary content.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxDrawer">https://havit.blazor.eu/components/HxDrawer</see>
 /// </summary>
 public partial class HxDrawer : IAsyncDisposable

--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputNumber.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Localization;
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Numeric input.<br />
+/// Numeric input field for whole numbers or decimals, with configurable input mode, HTML input type, and select-on-focus behavior.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputNumber">https://havit.blazor.eu/components/HxInputNumber</see>
 /// </summary>
 /// <remarks>

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridColumn.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridColumn.cs
@@ -4,7 +4,7 @@ using Havit.Collections;
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Grid column.
+/// Defines a single column of a <see cref="HxGrid{TItem}"/> — its header, cell template, sorting, and width.
 /// </summary>
 /// <typeparam name="TItem">Grid row data type.</typeparam>
 public class HxGridColumn<TItem> : HxGridColumnBase<TItem>

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridEmptyDataTemplateDefaultContent.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridEmptyDataTemplateDefaultContent.razor.cs
@@ -2,6 +2,9 @@
 
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
+/// <summary>
+/// Default placeholder shown by <see cref="HxGrid{TItem}"/> when there is no data to display.
+/// </summary>
 public partial class HxGridEmptyDataTemplateDefaultContent
 {
 	[Parameter] public RenderFragment ChildContent { get; set; }

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxPager.razor.cs
@@ -3,7 +3,7 @@
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Pager.<br />
+/// Pagination control for navigating pages of data, typically used alongside <see cref="HxGrid{TItem}"/>, with configurable sizes and a customizable button template.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxPager">https://havit.blazor.eu/components/HxPager</see>
 /// </summary>
 public partial class HxPager : ComponentBase

--- a/Havit.Blazor.Components.Web.Bootstrap/ListGroups/HxListGroupItemNavLink.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/ListGroups/HxListGroupItemNavLink.razor.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Components.Routing;
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/list-group/#links-and-buttons">Bootstrap 5 List group link item</see> component.
+/// Clickable, linkable item for <see cref="HxListGroup"/>, rendered as an anchor styled as a <see href="https://getbootstrap.com/docs/5.3/components/list-group/#links-and-buttons">Bootstrap list-group item</see>.
 /// </summary>
 public partial class HxListGroupItemNavLink : ICascadeEnabledComponent
 {

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxAnchorFragmentNavigation.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxAnchorFragmentNavigation.cs
@@ -4,8 +4,7 @@ using Microsoft.JSInterop;
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Temporarily (?) compensates for a Blazor deficiency in anchor fragments (scrolling to <c>page#id</c> URLs). Supports navigation with the <see cref="HxScrollspy"/> component.
-/// <see href="https://github.com/dotnet/aspnetcore/issues/8393">GitHub Issue: Blazor 0.8.0: hash routing to named element #8393</see>.<br />
+/// Enables navigation to in-page anchors (<c>page#id</c> URLs) by scrolling to the target element — Blazor routing does not do this on its own (<see href="https://github.com/dotnet/aspnetcore/issues/8393">tracking issue</see>). Pairs with <see cref="HxScrollspy"/>.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAnchorFragmentNavigation">https://havit.blazor.eu/components/HxAnchorFragmentNavigation</see>
 /// </summary>
 public class HxAnchorFragmentNavigation : ComponentBase, IAsyncDisposable

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNav.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNav.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/navs-tabs/">Bootstrap Nav</see> component.<br />
+/// <see href="https://getbootstrap.com/docs/5.3/components/navs-tabs/">Bootstrap Nav</see> component for building tabs, pills, and vertical or underline navigation from a list of links.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxNav">https://havit.blazor.eu/components/HxNav</see>
 /// </summary>
 public partial class HxNav

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNavbarBrand.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxNavbarBrand.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/navbar/#brand">navbar-brand</see> component.
+/// Brand/logo slot for <see cref="HxNavbar"/>, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/navbar/#brand">navbar-brand</see>.
 /// </summary>
 public partial class HxNavbarBrand
 {

--- a/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxScrollspy.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Navigation/HxScrollspy.razor.cs
@@ -3,7 +3,7 @@
 namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// <see href="https://getbootstrap.com/docs/5.3/components/scrollspy/">Bootstrap Scrollspy</see> component.<br />
+/// <see href="https://getbootstrap.com/docs/5.3/components/scrollspy/">Bootstrap Scrollspy</see> that automatically highlights the navigation link matching the section currently scrolled into view.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxScrollspy">https://havit.blazor.eu/components/HxScrollspy</see>
 /// </summary>
 public partial class HxScrollspy : IAsyncDisposable

--- a/Havit.Blazor.Components.Web.Bootstrap/Progress/HxProgressIndicator.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Progress/HxProgressIndicator.razor.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
 /// <summary>
-/// Displays the content of the component as "in progress".<br />
+/// Wraps content and shows a spinner overlay while an operation is in progress, with a configurable delay to avoid flicker on fast operations.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxProgressIndicator">https://havit.blazor.eu/components/HxProgressIndicator</see>
 /// </summary>
 public partial class HxProgressIndicator : IDisposable

--- a/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToastContainer.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Toasts/HxToastContainer.razor.cs
@@ -1,5 +1,8 @@
 ﻿namespace Havit.Blazor.Components.Web.Bootstrap;
 
+/// <summary>
+/// Positions and stacks the <see cref="HxToast"/> messages on the screen; rendered automatically by <see cref="HxMessenger"/>.
+/// </summary>
 public partial class HxToastContainer : ComponentBase
 {
 	/// <summary>

--- a/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
+++ b/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
@@ -6,7 +6,8 @@ using Microsoft.JSInterop;
 namespace Havit.Blazor.Components.Web.ECharts;
 
 /// <summary>
-/// Component for convenient rendering of Apache ECharts.
+/// Blazor wrapper for <see href="https://echarts.apache.org/">Apache ECharts</see> — render rich, interactive charts (line, bar, pie, and more) from .NET without writing JavaScript.<br />
+/// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxEChart">https://havit.blazor.eu/components/HxEChart</see>
 /// </summary>
 public partial class HxEChart : IAsyncDisposable
 {

--- a/Havit.Blazor.Components.Web/HxDynamicElement.cs
+++ b/Havit.Blazor.Components.Web/HxDynamicElement.cs
@@ -1,7 +1,7 @@
 ﻿namespace Havit.Blazor.Components.Web;
 
 /// <summary>
-/// Renders an element with the specified name, attributes, and child content.<br />
+/// Renders an HTML element whose tag name is chosen at runtime — pass any tag (e.g., <c>h1</c>..<c>h6</c>, <c>div</c>, <c>span</c>) along with attributes and content as parameters.<br />
 /// Full documentation and demos: <see href="https://havit.blazor.eu/components/HxDynamicElement">https://havit.blazor.eu/components/HxDynamicElement</see>
 /// </summary>
 public class HxDynamicElement : ComponentBase

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -130,7 +130,8 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAlert">
             <summary>
-            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/">Bootstrap alert</see> component.<br />
+            Contextual feedback message (success, warning, danger, info, and more) with an optional icon, links, and a dismiss button.<br />
+            Renders the <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/alert/">Bootstrap alert</see> markup.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAlert">https://havit.blazor.eu/components/HxAlert</see>
             </summary>
         </member>
@@ -451,7 +452,8 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxBadge">
             <summary>
-            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap Badge</see> component.<br />
+            Small <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/badge/">Bootstrap badge</see> for counts and labels.<br />
+            Attach it to headings, buttons, or icons; position it as a notification dot; and style it with any theme color or pill shape.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxBadge">https://havit.blazor.eu/components/HxBadge</see>
             </summary>
         </member>
@@ -812,7 +814,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxButtonGroup">
             <summary>
-            Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/button-group/">Button groups</see>.<br />
+            Groups related <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxButton"/> controls into a single visual block, with support for sizing, nesting, and vertical stacking (<see href="https://getbootstrap.com/docs/5.3/components/button-group/">Bootstrap Button groups</see>).<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxButtonGroup">https://havit.blazor.eu/components/HxButtonGroup</see>
             </summary>
         </member>
@@ -964,7 +966,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxCalendar">
             <summary>
-            Basic calendar building block. Used for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxInputDate`1"/> and <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxInputDateRange"/> implementation.<br />
+            Standalone month calendar for picking a single date or a date range — the same calendar used inside <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxInputDate`1"/> and <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxInputDateRange"/>, available on its own for building custom date pickers.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxCalendar">https://havit.blazor.eu/components/HxCalendar</see>
             </summary>
         </member>
@@ -1138,7 +1140,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxCard">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/card/">Bootstrap card</see> component.<br />
+            Flexible content container — a <see href="https://getbootstrap.com/docs/5.3/components/card/">Bootstrap card</see> — for grouping a title, text, image, and actions into a single bordered panel.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxCard">https://havit.blazor.eu/components/HxCard</see>
             </summary>
         </member>
@@ -1259,7 +1261,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxCardSubtitle">
             <summary>
-            Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-subtitle</see> component.
+            Secondary heading placed under a <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxCardTitle"/>, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-subtitle</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCardSubtitle.ChildContent">
@@ -1284,7 +1286,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxCardText">
             <summary>
-            Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-text</see> component.
+            Paragraph of body text for a <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxCard"/>, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-text</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCardText.ChildContent">
@@ -1299,7 +1301,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxCardTitle">
             <summary>
-            Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-title</see> component.
+            Heading for a <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxCard"/>'s content, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/card/#titles-text-and-links">card-title</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxCardTitle.ChildContent">
@@ -1738,7 +1740,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxCollapse">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/collapse/">Bootstrap 5 Collapse</see> component.<br />
+            <see href="https://getbootstrap.com/docs/5.3/components/collapse/">Bootstrap 5 Collapse</see> for toggling the visibility of content — accordions, expandable panels, collapsible sidebars — with a smooth height animation.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxCollapse">https://havit.blazor.eu/components/HxCollapse</see>
             </summary>
         </member>
@@ -1989,6 +1991,11 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxContextMenu.FloatingStrategy">
             <summary>
             Floating UI positioning strategy. Default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.FloatingStrategy.Absolute"/>.
+            </summary>
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxContextMenuItem">
+            <summary>
+            Single item for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxContextMenu"/>, with an optional confirmation message shown before its action runs.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxContextMenuItem.Text">
@@ -2943,7 +2950,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxDrawer">
             <summary>
-            <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/drawer/">Bootstrap Drawer</see> component (aka Drawer).<br />
+            Off-canvas <see href="https://v6-dev--twbs-bootstrap.netlify.app/docs/6.0/components/drawer/">Bootstrap Drawer</see> panel that slides in from any edge of the screen — ideal for navigation, filters, or supplementary content.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxDrawer">https://havit.blazor.eu/components/HxDrawer</see>
             </summary>
         </member>
@@ -5919,7 +5926,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxInputNumber`1">
             <summary>
-            Numeric input.<br />
+            Numeric input field for whole numbers or decimals, with configurable input mode, HTML input type, and select-on-focus behavior.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxInputNumber">https://havit.blazor.eu/components/HxInputNumber</see>
             </summary>
             <remarks>
@@ -9638,7 +9645,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxGridColumn`1">
             <summary>
-            Grid column.
+            Defines a single column of a <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1"/> — its header, cell template, sorting, and width.
             </summary>
             <typeparam name="TItem">Grid row data type.</typeparam>
         </member>
@@ -9936,9 +9943,14 @@
             Defaults to <c>null</c>; override to make the sortable header focusable.
             </summary>
         </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxGridEmptyDataTemplateDefaultContent">
+            <summary>
+            Default placeholder shown by <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1"/> when there is no data to display.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxPager">
             <summary>
-            Pager.<br />
+            Pagination control for navigating pages of data, typically used alongside <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1"/>, with configurable sizes and a customizable button template.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxPager">https://havit.blazor.eu/components/HxPager</see>
             </summary>
         </member>
@@ -10630,7 +10642,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxListGroupItemNavLink">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/list-group/#links-and-buttons">Bootstrap 5 List group link item</see> component.
+            Clickable, linkable item for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxListGroup"/>, rendered as an anchor styled as a <see href="https://getbootstrap.com/docs/5.3/components/list-group/#links-and-buttons">Bootstrap list-group item</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxListGroupItemNavLink.Href">
@@ -11436,8 +11448,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxAnchorFragmentNavigation">
             <summary>
-            Temporarily (?) compensates for a Blazor deficiency in anchor fragments (scrolling to <c>page#id</c> URLs). Supports navigation with the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxScrollspy"/> component.
-            <see href="https://github.com/dotnet/aspnetcore/issues/8393">GitHub Issue: Blazor 0.8.0: hash routing to named element #8393</see>.<br />
+            Enables navigation to in-page anchors (<c>page#id</c> URLs) by scrolling to the target element — Blazor routing does not do this on its own (<see href="https://github.com/dotnet/aspnetcore/issues/8393">tracking issue</see>). Pairs with <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxScrollspy"/>.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxAnchorFragmentNavigation">https://havit.blazor.eu/components/HxAnchorFragmentNavigation</see>
             </summary>
         </member>
@@ -11498,7 +11509,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxNav">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/navs-tabs/">Bootstrap Nav</see> component.<br />
+            <see href="https://getbootstrap.com/docs/5.3/components/navs-tabs/">Bootstrap Nav</see> component for building tabs, pills, and vertical or underline navigation from a list of links.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxNav">https://havit.blazor.eu/components/HxNav</see>
             </summary>
         </member>
@@ -11582,7 +11593,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxNavbarBrand">
             <summary>
-            Bootstrap <see href="https://getbootstrap.com/docs/5.3/components/navbar/#brand">navbar-brand</see> component.
+            Brand/logo slot for <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxNavbar"/>, rendered as Bootstrap's <see href="https://getbootstrap.com/docs/5.3/components/navbar/#brand">navbar-brand</see>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxNavbarBrand.Href">
@@ -11878,7 +11889,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxScrollspy">
             <summary>
-            <see href="https://getbootstrap.com/docs/5.3/components/scrollspy/">Bootstrap Scrollspy</see> component.<br />
+            <see href="https://getbootstrap.com/docs/5.3/components/scrollspy/">Bootstrap Scrollspy</see> that automatically highlights the navigation link matching the section currently scrolled into view.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxScrollspy">https://havit.blazor.eu/components/HxScrollspy</see>
             </summary>
         </member>
@@ -12679,7 +12690,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxProgressIndicator">
             <summary>
-            Displays the content of the component as "in progress".<br />
+            Wraps content and shows a spinner overlay while an operation is in progress, with a configurable delay to avoid flicker on fast operations.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxProgressIndicator">https://havit.blazor.eu/components/HxProgressIndicator</see>
             </summary>
         </member>
@@ -13588,6 +13599,11 @@
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxToast.DisposeAsync">
             <inheritdoc />
+        </member>
+        <member name="T:Havit.Blazor.Components.Web.Bootstrap.HxToastContainer">
+            <summary>
+            Positions and stacks the <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxToast"/> messages on the screen; rendered automatically by <see cref="T:Havit.Blazor.Components.Web.Bootstrap.HxMessenger"/>.
+            </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxToastContainer.Position">
             <summary>

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.ECharts.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.ECharts.xml
@@ -101,7 +101,8 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.ECharts.HxEChart">
             <summary>
-            Component for convenient rendering of Apache ECharts.
+            Blazor wrapper for <see href="https://echarts.apache.org/">Apache ECharts</see> — render rich, interactive charts (line, bar, pie, and more) from .NET without writing JavaScript.<br />
+            Full documentation and demos: <see href="https://havit.blazor.eu/components/HxEChart">https://havit.blazor.eu/components/HxEChart</see>
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.ECharts.HxEChart.ChartId">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.xml
@@ -539,7 +539,7 @@
         </member>
         <member name="T:Havit.Blazor.Components.Web.HxDynamicElement">
             <summary>
-            Renders an element with the specified name, attributes, and child content.<br />
+            Renders an HTML element whose tag name is chosen at runtime — pass any tag (e.g., <c>h1</c>..<c>h6</c>, <c>div</c>, <c>span</c>) along with attributes and content as parameters.<br />
             Full documentation and demos: <see href="https://havit.blazor.eu/components/HxDynamicElement">https://havit.blazor.eu/components/HxDynamicElement</see>
             </summary>
         </member>

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.GoogleTagManager.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.GoogleTagManager.xml
@@ -54,6 +54,11 @@
             Name of the variabel to be used for URL when page-view is tracked.
             </summary>
         </member>
+        <member name="T:Havit.Blazor.GoogleTagManager.HxGoogleTagManagerPageViewTracker">
+            <summary>
+            Tracks Blazor route changes and pushes a page-view event to the Google Tag Manager data layer. Add it once alongside <see cref="P:Havit.Blazor.GoogleTagManager.HxGoogleTagManagerPageViewTracker.HxGoogleTagManager"/> to track SPA navigation as page views.
+            </summary>
+        </member>
         <member name="T:Havit.Blazor.GoogleTagManager.IHxGoogleTagManager">
             <summary>
             Support for <see href="https://developers.google.com/tag-manager/devguide">Google Tag Manager</see> - initialization and pushing data to data-layer.

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.GoogleTagManager.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.GoogleTagManager.xml
@@ -56,7 +56,7 @@
         </member>
         <member name="T:Havit.Blazor.GoogleTagManager.HxGoogleTagManagerPageViewTracker">
             <summary>
-            Tracks Blazor route changes and pushes a page-view event to the Google Tag Manager data layer. Add it once alongside <see cref="P:Havit.Blazor.GoogleTagManager.HxGoogleTagManagerPageViewTracker.HxGoogleTagManager"/> to track SPA navigation as page views.
+            Tracks Blazor route changes and pushes a page-view event to the Google Tag Manager data layer. Add it once alongside <see cref="T:Havit.Blazor.GoogleTagManager.HxGoogleTagManager"/> to track SPA navigation as page views.
             </summary>
         </member>
         <member name="T:Havit.Blazor.GoogleTagManager.IHxGoogleTagManager">

--- a/Havit.Blazor.GoogleTagManager/HxGoogleTagManagerPageViewTracker.cs
+++ b/Havit.Blazor.GoogleTagManager/HxGoogleTagManagerPageViewTracker.cs
@@ -3,6 +3,9 @@ using Microsoft.AspNetCore.Components.Routing;
 
 namespace Havit.Blazor.GoogleTagManager;
 
+/// <summary>
+/// Tracks Blazor route changes and pushes a page-view event to the Google Tag Manager data layer. Add it once alongside <see cref="HxGoogleTagManager"/> to track SPA navigation as page views.
+/// </summary>
 public class HxGoogleTagManagerPageViewTracker : ComponentBase, IDisposable
 {
 	[Inject] protected NavigationManager NavigationManager { get; set; }

--- a/Havit.Blazor.GoogleTagManager/HxGoogleTagManagerPageViewTracker.cs
+++ b/Havit.Blazor.GoogleTagManager/HxGoogleTagManagerPageViewTracker.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Components.Routing;
 namespace Havit.Blazor.GoogleTagManager;
 
 /// <summary>
-/// Tracks Blazor route changes and pushes a page-view event to the Google Tag Manager data layer. Add it once alongside <see cref="HxGoogleTagManager"/> to track SPA navigation as page views.
+/// Tracks Blazor route changes and pushes a page-view event to the Google Tag Manager data layer. Add it once alongside <see cref="T:Havit.Blazor.GoogleTagManager.HxGoogleTagManager"/> to track SPA navigation as page views.
 /// </summary>
 public class HxGoogleTagManagerPageViewTracker : ComponentBase, IDisposable
 {


### PR DESCRIPTION
## Summary
- Rewrites the XML doc `<summary>` comments that render as the lead paragraph on each component's docs page (`Havit.Blazor.Documentation/Shared/Components/ApiDoc.razor`), focused on the components with the vaguest or missing descriptions.
- Fixed patterns: generic "Bootstrap X component." boilerplate (HxAlert, HxBadge, HxCard, HxNav, HxScrollspy, HxCollapse, HxButtonGroup, HxDrawer), near-empty one-liners (HxPager, HxInputNumber, HxProgressIndicator, HxCalendar, HxEChart, HxDynamicElement), internal/implementation jargon (HxAnchorFragmentNavigation), and summaries that were missing entirely (HxContextMenuItem, HxToastContainer, HxGridEmptyDataTemplateDefaultContent, HxGoogleTagManagerPageViewTracker). Also touched a few secondary/child-component blurbs shown inline on their parent's page (HxCardTitle/Text/Subtitle, HxGridColumn, HxNavbarBrand, HxListGroupItemNavLink).
- Left already-descriptive summaries untouched (HxGrid, HxOtpInput, HxPasswordStrength, HxListLayout, HxNavOverflow, HxTreeView, etc.).
- Regenerated `Havit.Blazor.Documentation/XmlDoc/*.xml` to match.

## Test plan
- [x] `dotnet build` on `Havit.Blazor.Components.Web.Bootstrap`, `Havit.Blazor.Components.Web`, `Havit.Blazor.Components.Web.ECharts`, `Havit.Blazor.GoogleTagManager` — 0 warnings/errors (no broken `<see cref>`).
- [x] Verified in the running docs site that the new lead text renders correctly on both a top-level page (HxAlert) and a previously-blank section (HxToastContainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)