### PR TITLE
Fix on-this-page nav item color after Bootstrap 6 fg-* rename

### DIFF
--- a/Havit.Blazor.Documentation/Shared/Components/OnThisPageNavigation.razor.cs
+++ b/Havit.Blazor.Documentation/Shared/Components/OnThisPageNavigation.razor.cs
@@ -86,7 +86,7 @@ public partial class OnThisPageNavigation(
 
 			builder.OpenElement(86, "a");
 			builder.AddAttribute(87, "href", item.GetItemUrl(_currentUriWithoutFragment)); // TODO direct usage of HxAnchorFragmentNavigation.ScrollToAnchorAsync() ?
-			builder.AddAttribute(88, "class", "text-secondary mb-1 text-truncate");
+			builder.AddAttribute(88, "class", "fg-secondary mb-1 text-truncate");
 			builder.AddContent(89, item.Title);
 			builder.CloseElement();
 


### PR DESCRIPTION
## Summary
- `text-secondary` on the "on this page" nav links (`OnThisPageNavigation.razor.cs`) stopped applying color because the Bootstrap 6 vendoring rework (#1472) renamed the `text-*` color utility family to `fg-*`.
- Updated the class to `fg-secondary` to match the new utility naming.

## Test plan
- [ ] Open any doc page with a table of contents and confirm the on-this-page nav item text renders in the muted secondary color in both light and dark theme.