### PR TITLE
Fix remaining stale Bootstrap 5 utility classes and CSS vars after v6 rework

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor
@@ -235,7 +235,7 @@
 										}
 										else
 										{
-											<div class="text-center text-secondary my-5">
+											<div class="text-center fg-secondary my-5">
 												<div class="fs-3"><HxIcon Icon="@BootstrapIcon.InboxFill" /></div>
 												<div>@HxGridLocalizer["LoadingData"]</div>
 											</div>

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridEmptyDataTemplateDefaultContent.razor
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridEmptyDataTemplateDefaultContent.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Havit.Blazor.Components.Web.Bootstrap
 
-<div class="text-center text-secondary my-5">
+<div class="text-center fg-secondary my-5">
     <div class="fs-3"><HxIcon Icon="@BootstrapIcon.Inbox" /></div>
     <div>@HxGridLocalizer["NoData"]</div>
 

--- a/Havit.Blazor.Documentation.Server/Error.razor
+++ b/Havit.Blazor.Documentation.Server/Error.razor
@@ -3,8 +3,8 @@
 
 <PageTitle>Error</PageTitle>
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 class="fg-danger">Error.</h1>
+<h2 class="fg-danger">An error occurred while processing your request.</h2>
 
 @if (!string.IsNullOrEmpty(_requestId))
 {

--- a/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_HeaderFooter.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_HeaderFooter.razor
@@ -1,4 +1,4 @@
-﻿<HxCard CssClass="text-center" FooterCssClass="text-muted">
+﻿<HxCard CssClass="text-center" FooterCssClass="fg-secondary">
     <HeaderTemplate>Featured</HeaderTemplate>
     <BodyTemplate>
         <HxCardTitle>Special title treatment</HxCardTitle>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageBottom.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageBottom.razor
@@ -9,7 +9,7 @@
 			This content is a little bit longer.
 		</HxCardText>
 		<HxCardText>
-			<small class="text-muted">Last updated 3 mins ago</small>
+			<small class="fg-secondary">Last updated 3 mins ago</small>
 		</HxCardText>
 	</BodyTemplate>
 </HxCard>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageOverlay.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageOverlay.razor
@@ -2,7 +2,7 @@
 		ImageSrc="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=="
 		ImagePlacement="CardImagePlacement.Overlay"
 		ImageHeight="200"
-		CssClass="bg-inverse text-white">
+		CssClass="bg-inverse fg-white">
 	<BodyTemplate>
 		<HxCardTitle>Card title</HxCardTitle>
 		<HxCardText>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageOverlay.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageOverlay.razor
@@ -2,7 +2,7 @@
 		ImageSrc="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=="
 		ImagePlacement="CardImagePlacement.Overlay"
 		ImageHeight="200"
-		CssClass="bg-dark text-white">
+		CssClass="bg-inverse text-white">
 	<BodyTemplate>
 		<HxCardTitle>Card title</HxCardTitle>
 		<HxCardText>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageTop.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_ImageTop.razor
@@ -8,7 +8,7 @@
 			This content is a little bit longer.
 		</HxCardText>
 		<HxCardText>
-			<small class="text-muted">Last updated 3 mins ago</small>
+			<small class="fg-secondary">Last updated 3 mins ago</small>
 		</HxCardText>
 	</BodyTemplate>
 </HxCard>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_TitlesTextLinks.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCardDoc/HxCard_Demo_TitlesTextLinks.razor
@@ -1,7 +1,7 @@
 ﻿<HxCard style="width: 18rem;">
     <BodyTemplate>
         <HxCardTitle>Card title</HxCardTitle>
-        <HxCardSubtitle CssClass="mb-2 text-muted">Card subtitle</HxCardSubtitle>
+        <HxCardSubtitle CssClass="mb-2 fg-secondary">Card subtitle</HxCardSubtitle>
         <HxCardText>Some quick example text to build on the card title and make up the bulk of the card's content.</HxCardText>
         <a href="#" class="card-link">Card link</a>
         <a href="#" class="card-link">Another link</a>

--- a/Havit.Blazor.Documentation/Pages/Components/HxCollapseDoc/HxCollapse_Demo_CustomToggleElement.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxCollapseDoc/HxCollapse_Demo_CustomToggleElement.razor
@@ -1,4 +1,4 @@
-﻿<HxCollapseToggleElement ElementName="div" CollapseTarget="#myCollapse5" CssClass="bg-primary p-3 text-white" role="button">
+﻿<HxCollapseToggleElement ElementName="div" CollapseTarget="#myCollapse5" CssClass="bg-primary p-3 fg-white" role="button">
 	Custom toggle element
 	<HxIcon Icon="BootstrapIcon.ArrowDown" />
 </HxCollapseToggleElement>

--- a/Havit.Blazor.Documentation/Pages/Components/HxInputDateDoc/HxInputDate_Demo_CalendarDateCustomization.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxInputDateDoc/HxInputDate_Demo_CalendarDateCustomization.razor
@@ -10,7 +10,7 @@
 			return new CalendarDateCustomizationResult()
 			{
 				Enabled = false,
-				CssClass = "text-danger"
+				CssClass = "fg-danger"
 			};
 		}
 		return null;

--- a/Havit.Blazor.Documentation/Pages/Components/HxInputDateRangeDoc/HxInputDateRange_Demo_CalendarDateCustomization.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxInputDateRangeDoc/HxInputDateRange_Demo_CalendarDateCustomization.razor
@@ -12,7 +12,7 @@
 				return new CalendarDateCustomizationResult()
 				{
 					Enabled = false,
-					CssClass = "text-danger"
+					CssClass = "fg-danger"
 				};
 			}
 		}
@@ -23,7 +23,7 @@
 				return new CalendarDateCustomizationResult()
 				{
 					Enabled = false,
-					CssClass = "text-warning"
+					CssClass = "fg-warning"
 				};
 			}
 		}

--- a/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Demo_CustomContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxListGroupDoc/HxListGroup_Demo_CustomContent.razor
@@ -10,17 +10,17 @@
     <HxListGroupItem>
         <div class="d-flex w-100 justify-content-between">
             <h5 class="mb-1">List group item heading</h5>
-            <small class="text-muted">3 days ago</small>
+            <small class="fg-secondary">3 days ago</small>
         </div>
         <p class="mb-1">Some placeholder content in a paragraph.</p>
-        <small class="text-muted">And some muted small print.</small>
+        <small class="fg-secondary">And some muted small print.</small>
     </HxListGroupItem>
     <HxListGroupItem>
         <div class="d-flex w-100 justify-content-between">
             <h5 class="mb-1">List group item heading</h5>
-            <small class="text-muted">3 days ago</small>
+            <small class="fg-secondary">3 days ago</small>
         </div>
         <p class="mb-1">Some placeholder content in a paragraph.</p>
-        <small class="text-muted">And some muted small print.</small>
+        <small class="fg-secondary">And some muted small print.</small>
     </HxListGroupItem>
 </HxListGroup>

--- a/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Wrapper.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMarkdownDoc/HxMarkdown_Demo_Wrapper.razor
@@ -2,7 +2,7 @@
 <HxMarkdown Content="@_markdown" />
 
 <p class="mt-3"><strong>With wrapper (CssClass set):</strong></p>
-<HxMarkdown Content="@_markdown" CssClass="p-3 bg-body-secondary border rounded" />
+<HxMarkdown Content="@_markdown" CssClass="p-3 bg-2 border rounded" />
 
 @code {
 	private string _markdown = "A simple **paragraph** rendered from Markdown.";

--- a/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_CustomToggle.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxMenuDoc/HxMenu_Demo_CustomToggle.razor
@@ -1,6 +1,6 @@
 ﻿<HxMenu>
 	<Toggle>
-		<HxMenuToggleElement ElementName="div" CssClass="bg-success p-3 text-white" role="button">
+		<HxMenuToggleElement ElementName="div" CssClass="bg-success p-3 fg-white" role="button">
 			Custom menu toggle element
 			<HxIcon Icon="BootstrapIcon.Trash" />
 		</HxMenuToggleElement>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Demo.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Demo.razor
@@ -10,4 +10,4 @@
 		<HxNavLink Href="#" Text="Help" />
 	</HxNavOverflow>
 </div>
-<p class="mt-2 mb-0 small text-secondary">Drag the right edge of the container to see the items move to the "More" menu.</p>
+<p class="mt-2 mb-0 small fg-secondary">Drag the right edge of the container to see the items move to the "More" menu.</p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Demo_DisabledItems.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxNavOverflowDoc/HxNavOverflow_Demo_DisabledItems.razor
@@ -10,4 +10,4 @@
 		<HxNavLink Href="#" Text="Help" />
 	</HxNavOverflow>
 </div>
-<p class="mt-2 mb-0 small text-secondary">Disabled items keep their disabled state when moved to the "More" menu.</p>
+<p class="mt-2 mb-0 small fg-secondary">Disabled items keep their disabled state when moved to the "More" menu.</p>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_Dismissible.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_Dismissible.razor
@@ -1,3 +1,3 @@
 ﻿<HxPopover Trigger="PopoverTrigger.Focus" Title="Dismissible popover" Content="And here's some amazing content. It's very engaging. Right?">
-	<a tabindex="0" class="btn btn-primary">Dismissible popover</a>
+	<a tabindex="0" class="btn btn-solid theme-primary">Dismissible popover</a>
 </HxPopover>

--- a/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_HtmlContent_Sanitize.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxPopoverDoc/HxPopover_Demo_HtmlContent_Sanitize.razor
@@ -1,3 +1,3 @@
-﻿<HxPopover Title="<strong>Popover</strong> with button" Content="@("<button onclick='confirm()' class='btn btn-primary'>Button</button>")" Html="true" Sanitize="false">
+﻿<HxPopover Title="<strong>Popover</strong> with button" Content="@("<button onclick='confirm()' class='btn btn-solid theme-primary'>Button</button>")" Html="true" Sanitize="false">
 	<HxButton Color="ThemeColor.Primary">Click to toggle popover</HxButton>
 </HxPopover>

--- a/Havit.Blazor.Documentation/Pages/Components/HxSearchBoxDoc/HxSearchBox_Demo.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSearchBoxDoc/HxSearchBox_Demo.razor
@@ -10,10 +10,10 @@
 			 OnItemSelected="OnItemSelected"
 			 OnTextQueryTriggered="OnTextQueryTriggered">
 	<DefaultContentTemplate>
-		<div class="p-2 text-muted">Search for employees by name...</div>
+		<div class="p-2 fg-secondary">Search for employees by name...</div>
 	</DefaultContentTemplate>
 	<NotFoundTemplate>
-		<div class="small py-2 px-3 text-muted"><HxIcon CssClass="me-2" Icon="BootstrapIcon.EmojiFrown" />Sorry, I did not find that...</div>
+		<div class="small py-2 px-3 fg-secondary"><HxIcon CssClass="me-2" Icon="BootstrapIcon.EmojiFrown" />Sorry, I did not find that...</div>
 	</NotFoundTemplate>
 </HxSearchBox>
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxSearchBoxDoc/HxSearchBox_Demo_DisableTextQuery.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSearchBoxDoc/HxSearchBox_Demo_DisableTextQuery.razor
@@ -10,10 +10,10 @@
 			 AllowTextQuery="false"
 			 OnItemSelected="OnItemSelected">
 	<DefaultContentTemplate>
-		<div class="p-2 text-muted">Search for employees by name...</div>
+		<div class="p-2 fg-secondary">Search for employees by name...</div>
 	</DefaultContentTemplate>
 	<NotFoundTemplate>
-		<div class="small py-2 px-3 text-muted"><HxIcon CssClass="me-2" Icon="BootstrapIcon.EmojiFrown" />Sorry, I did not find that...</div>
+		<div class="small py-2 px-3 fg-secondary"><HxIcon CssClass="me-2" Icon="BootstrapIcon.EmojiFrown" />Sorry, I did not find that...</div>
 	</NotFoundTemplate>
 </HxSearchBox>
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxSearchBoxDoc/HxSearchBox_Demo_TextQueryOnly.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSearchBoxDoc/HxSearchBox_Demo_TextQueryOnly.razor
@@ -8,10 +8,10 @@
 			 Delay="0"
 			 OnTextQueryTriggered="OnTextQueryTriggered">
 	<DefaultContentTemplate>
-		<div class="p-2 text-muted">Type company registration number and hit Enter...</div>
+		<div class="p-2 fg-secondary">Type company registration number and hit Enter...</div>
 	</DefaultContentTemplate>
 	<NotFoundTemplate>
-		<div class="small py-2 px-3 text-muted"><HxIcon CssClass="me-2" Icon="BootstrapIcon.Lightbulb" />Hit Enter or click the search icon to initiate search in public register...</div>
+		<div class="small py-2 px-3 fg-secondary"><HxIcon CssClass="me-2" Icon="BootstrapIcon.Lightbulb" />Hit Enter or click the search icon to initiate search in public register...</div>
 	</NotFoundTemplate>
 </HxSearchBox>
 

--- a/Havit.Blazor.Documentation/Pages/Components/HxSidebarDoc/HxSidebar_Demo_Colors.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSidebarDoc/HxSidebar_Demo_Colors.razor
@@ -1,16 +1,16 @@
 ﻿<style>
 	/* Demonstration purposes only. Put this CSS into your application's CSS file or into the component's CSS file. */
 	.my-sidebar {
-		--hx-sidebar-item-hover-background-color: var(--bs-emphasis-color-rgb);
-		--hx-sidebar-item-active-background-color: var(--bs-emphasis-color-rgb);
-		--hx-sidebar-item-active-color: var(--bs-emphasis-color);
-		--hx-sidebar-item-hover-color: var(--bs-emphasis-color);
-		--hx-sidebar-item-icon-color: var(--bs-secondary-color);
-		--hx-sidebar-parent-item-active-icon-color: var(--bs-secondary-color);
+		--hx-sidebar-item-hover-background-color: var(--bs-fg-body);
+		--hx-sidebar-item-active-background-color: var(--bs-fg-body);
+		--hx-sidebar-item-active-color: var(--bs-fg-body);
+		--hx-sidebar-item-hover-color: var(--bs-fg-body);
+		--hx-sidebar-item-icon-color: var(--bs-secondary-fg);
+		--hx-sidebar-parent-item-active-icon-color: var(--bs-secondary-fg);
 	}
 </style>
 <div class="my-sidebar d-flex border rounded-3 overflow-hidden">
-	<HxSidebar CssClass="bg-body-secondary">
+	<HxSidebar CssClass="bg-2">
 		<HeaderTemplate>
 			<HxSidebarBrand BrandName="Brand name" BrandNameShort="BN" />
 		</HeaderTemplate>

--- a/Havit.Blazor.Documentation/Pages/Components/HxSidebarDoc/HxSidebar_Documentation.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSidebarDoc/HxSidebar_Documentation.razor
@@ -22,7 +22,7 @@
 		<Demo Type="typeof(HxSidebar_Demo_Dark)" />
 
 		<DocHeading Title="Colors" />
-		<p>Similarly to Bootstrap Navbar, you can use utility classes to create any color variation eg. <code>bg-body-secondary</code>. Colors of the items and active/hover states need to be fine-tuned via CSS vars.</p>
+		<p>Similarly to Bootstrap Navbar, you can use utility classes to create any color variation eg. <code>bg-2</code>. Colors of the items and active/hover states need to be fine-tuned via CSS vars.</p>
 		<Demo Type="typeof(HxSidebar_Demo_Colors)" />
 
 		<DocHeading Title="Logo" />

--- a/Havit.Blazor.Documentation/Pages/Components/HxSidebarDoc/HxSidebar_Layout.CodeSnippet.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxSidebarDoc/HxSidebar_Layout.CodeSnippet.razor
@@ -3,7 +3,7 @@
 <HxMessenger Position="ToastContainerPosition.MiddleCenter" />
 <HxMessageBoxHost />
 
-@* Add .container-xxl or similar, if you want to limit page width as this documentation does. *@
+@* Add .2xl:container or similar, if you want to limit page width as this documentation does. *@
 <div class="md:d-flex min-vh-100">
 
 	@* The sidebar does not implement mobile navigation - hide it below your breakpoint of choice

--- a/Havit.Blazor.Documentation/Pages/Components/HxTreeViewDoc/HxTreeView_Demo_CustomContent.razor
+++ b/Havit.Blazor.Documentation/Pages/Components/HxTreeViewDoc/HxTreeView_Demo_CustomContent.razor
@@ -5,7 +5,7 @@
                     Items="@fileSystem"
                     CssClass="border rounded p-2"
                     ItemCssClass="fst-italic"
-                    ItemCssClassSelector="@(p => p.Name.Equals("Users") ? "text-primary" : String.Empty)"
+                    ItemCssClassSelector="@(p => p.Name.Equals("Users") ? "fg-primary" : String.Empty)"
                     ItemInitialExpandedSelector="@(p => p.Name == "C:\\")"
                     ItemChildrenSelector="@(p => p.Subdirectories)"
                     ItemIconSelector="@(p => p.Icon)">

--- a/Havit.Blazor.Documentation/Pages/Premium/GatewayToPremium.razor
+++ b/Havit.Blazor.Documentation/Pages/Premium/GatewayToPremium.razor
@@ -5,7 +5,7 @@
 <DocHeadContent CanonicalRelativeUrl="/premium/access-content" />
 
 <div class="d-flex w-100 h-100 justify-content-center align-items-center my-5">
-	<HxCard CssClass="rounded-4 border-0 bg-body-secondary" BodyCssClass="d-flex flex-column align-items-center p-4">
+	<HxCard CssClass="rounded-4 border-0 bg-2" BodyCssClass="d-flex flex-column align-items-center p-4">
 		<BodyTemplate>
 			<h4 class="fw-bold">HAVIT Blazor Premium</h4>
 			<p class="opacity-75 text-center my-4">

--- a/Havit.Blazor.Documentation/Pages/Premium/GetPremium.razor
+++ b/Havit.Blazor.Documentation/Pages/Premium/GetPremium.razor
@@ -33,7 +33,7 @@
 				</HxCard>
 			</div>
 			<div class="col-12 lg:col-4">
-				<HxCard CssClass="h-100 bg-body-secondary border-0" BodyCssClass="rounded-4 p-4 d-flex flex-column">
+				<HxCard CssClass="h-100 bg-2 border-0" BodyCssClass="rounded-4 p-4 d-flex flex-column">
 					<BodyTemplate>
 						<h5 class="fw-bold">Premium</h5>
 						<p class="fw-medium">$19 per user/month</p>

--- a/Havit.Blazor.Documentation/Pages/Premium/GetPremium.razor
+++ b/Havit.Blazor.Documentation/Pages/Premium/GetPremium.razor
@@ -18,8 +18,8 @@
 			<div class="col-12 lg:col-4" data-bs-theme="dark">
 				<HxCard CssClass="h-100" BodyCssClass="rounded-4 p-4 d-flex flex-column">
 					<BodyTemplate>
-						<h5 class="fw-bold text-white">Free forever</h5>
-						<p class="fw-medium text-white">$0 Free for everyone</p>
+						<h5 class="fw-bold fg-white">Free forever</h5>
+						<p class="fw-medium fg-white">$0 Free for everyone</p>
 						<div class="d-flex flex-column gap-2 opacity-75 mb-5 mt-2 small">
 							<PlanItem Text="Full component library" />
 							<PlanItem Text="Documentation" />

--- a/Havit.Blazor.Documentation/Pages/Premium/PremiumWelcome.razor
+++ b/Havit.Blazor.Documentation/Pages/Premium/PremiumWelcome.razor
@@ -40,7 +40,7 @@
 						<p class="opacity-75 mt-2">
 							Add the following configuration to your MCP settings:
 						</p>
-						<pre class="bg-dark text-light p-3 rounded-3"><code>"HAVIT Blazor Documentation": {
+						<pre class="bg-inverse fg-secondary p-3 rounded-3"><code>"HAVIT Blazor Documentation": {
 	"type": "http",
 	"url": "https://mcp.havit.blazor.eu"
 }</code></pre>

--- a/Havit.Blazor.Documentation/Pages/Premium/Subscribe.razor
+++ b/Havit.Blazor.Documentation/Pages/Premium/Subscribe.razor
@@ -14,7 +14,7 @@
 <div class="container">
 	<div class="row g-4 justify-content-center mb-5">
 		<div class="col-12 md:col-6 lg:col-5">
-			<HxCard CssClass="h-100 rounded-4 bg-body-secondary border-0" BodyCssClass="p-4 d-flex flex-column">
+			<HxCard CssClass="h-100 rounded-4 bg-2 border-0" BodyCssClass="p-4 d-flex flex-column">
 				<BodyTemplate>
 					<div class="d-flex align-items-center gap-2 mb-2">
 						<HxIcon Icon="BootstrapIcon.CreditCard2Front" CssClass="fs-4" />
@@ -47,7 +47,7 @@
 						<PlanItem Text="Manage subscription in GitHub settings" />
 					<PlanItem Text="Instant access to private repository" />
 					</div>
-					<a href="https://github.com/sponsors/havit/sponsorships?tier_id=437336" class="btn btn-outline-dark w-100 rounded-pill mt-auto">
+					<a href="https://github.com/sponsors/havit/sponsorships?tier_id=437336" class="btn btn-outline theme-inverse w-100 rounded-pill mt-auto">
 						Sponsor on GitHub
 					</a>
 				</BodyTemplate>
@@ -55,7 +55,7 @@
 		</div>
 	</div>
 	<div class="text-center mb-5 pb-5">
-		<a href="/premium" class="text-muted text-decoration-none">
+		<a href="/premium" class="fg-secondary text-decoration-none">
 			<HxIcon Icon="BootstrapIcon.ArrowLeft" />
 			Back to Premium overview
 		</a>

--- a/Havit.Blazor.Documentation/Pages/Showcase/ShowcaseDetail.razor
+++ b/Havit.Blazor.Documentation/Pages/Showcase/ShowcaseDetail.razor
@@ -12,7 +12,7 @@
                             Href="@($"showcase/{_previousShowcase.Id}")" />
 
     <div class="current text-center order-last md:order-0 py-4 md:py-0">
-        <div class="small text-primary">@_showcase.Description</div>
+        <div class="small fg-primary">@_showcase.Description</div>
         <h1 class="fw-bold">@_showcase.Title</h1>
     </div>
 
@@ -23,7 +23,7 @@
                             CssClass="text-end" />
 </div>
 
-<div class="showcase-detail bg-body-tertiary">
+<div class="showcase-detail bg-3">
     <div class="container d-flex gap-3 flex-wrap justify-content-center">
         <img src="@_showcase.ImageUrl" class="rounded-3 border shadow-lg mw-100" alt="@_showcase.Title" style="max-height: 750px">
     </div>

--- a/Havit.Blazor.Documentation/Pages/Showcase/ShowcaseListItem.razor
+++ b/Havit.Blazor.Documentation/Pages/Showcase/ShowcaseListItem.razor
@@ -1,10 +1,10 @@
 <div class="@CssClassHelper.Combine("showcase-item-container", Showcase.IsMobileApp ? "mobile-app" : string.Empty)">
     <HxNavLink Href="@($"showcase/{Showcase.Id}")">
-        <div class="showcase-item p-4 bg-body-tertiary rounded-3 d-flex flex-column align-items-center gap-3">
+        <div class="showcase-item p-4 bg-3 rounded-3 d-flex flex-column align-items-center gap-3">
             <img src="@Showcase.ImageUrl" class="rounded-2 shadow" alt="@Showcase.Title" />
             <div class="d-flex flex-column align-items-center gap-1">
                 <div class="title fw-medium">@Showcase.Title</div>
-                <div class="description text-secondary small">@Showcase.Description</div>
+                <div class="description fg-secondary small">@Showcase.Description</div>
             </div>
         </div>
     </HxNavLink>

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -38,7 +38,7 @@ else
 				<div class="demo-resizable">
 					<DynamicComponent Type="Type" />
 				</div>
-				<p class="demo-resizable-hint text-body-secondary small mb-0">
+				<p class="demo-resizable-hint fg-secondary small mb-0">
 					Use the lower-right corner grip to resize and preview the responsive behavior.
 				</p>
 			}

--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor.css
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor.css
@@ -4,9 +4,9 @@
 	padding: 1rem;
 	overflow: auto;
 	resize: horizontal;
-	background-color: var(--bs-body-bg);
+	background-color: var(--bs-bg-body);
 	border: 1px dashed var(--bs-border-color);
-	border-radius: var(--bs-border-radius);
+	border-radius: var(--bs-radius-5);
 	/* Establish a query container so components whose container queries rely on an ancestor
 	   (e.g. list-group-horizontal) respond to the box width. Components that set their own
 	   container-type (navbar, HxListLayout's card) still resolve to their nearer container. */

--- a/Havit.Blazor.Documentation/Shared/MainLayout.razor.css
+++ b/Havit.Blazor.Documentation/Shared/MainLayout.razor.css
@@ -11,7 +11,7 @@
 }
 
 /* Offset headings by Navbar height on desktop */
-@media screen and (min-width: 992px) {
+@media screen and (min-width: 1024px) {
     .doc-content > ::deep h1, 
     .doc-content > ::deep h2, 
     .doc-content > ::deep h3, 

--- a/Havit.Blazor.Documentation/Shared/Navbar.razor
+++ b/Havit.Blazor.Documentation/Shared/Navbar.razor
@@ -10,7 +10,7 @@
 			</HxNavbarBrand>
 
 			@* Separator between the brand and the mobile section dropdown (Bootstrap docs style: "Brand / Docs"). *@
-			<span class="xl:d-none text-body-secondary mx-2" aria-hidden="true">/</span>
+			<span class="xl:d-none fg-secondary mx-2" aria-hidden="true">/</span>
 
 			@* Main navigation as a dropdown below xl; the inline nav in the drawer takes over at xl+.
 			   Wrap in an xl:d-none element because HxMenu's own CssClass applies to the menu panel, not the toggle. *@

--- a/Havit.Blazor.Documentation/Shared/Navbar.razor.css
+++ b/Havit.Blazor.Documentation/Shared/Navbar.razor.css
@@ -10,7 +10,7 @@
 
 .nav-container {
 	--bs-bg-opacity: .5;
-	background-color: rgba(var(--bs-body-bg-rgb),var(--bs-bg-opacity)) !important;
+	background-color: color-mix(in srgb, var(--bs-bg-body) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 	-webkit-backdrop-filter: saturate(120%) blur(20px);
 	backdrop-filter: saturate(120%) blur(20px);
 	z-index: 1030;

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -53,7 +53,7 @@
 code[class*=language-],
 pre[class*=language-] {
 	text-shadow: none;
-	color: var(--bs-secondary-color);
+	color: var(--bs-secondary-fg);
 }
 
 /* Inline code (not the Prism-highlighted source blocks) colored with a pink theme color. */
@@ -136,38 +136,38 @@ pre[class*="language-"] {
 /* Syntax highlighting override */
 
 [data-bs-theme=dark] .language-none {
-	color: var(--bs-secondary-text-emphasis);
+	color: var(--bs-secondary-fg-emphasis);
 }
 
 [data-bs-theme=dark] .token.namespace,
 [data-bs-theme=dark] .token.attr-name,
 [data-bs-theme=dark] .token.csharp.language-csharp,
 [data-bs-theme=dark] .language-csharp {
-	color: var(--bs-primary-text-emphasis);
+	color: var(--bs-primary-fg-emphasis);
 }
 
 [data-bs-theme=dark] .token.punctuation {
-	color: var(--bs-secondary-text-emphasis);
+	color: var(--bs-secondary-fg-emphasis);
 }
 
 [data-bs-theme=dark] .token.keyword,
 [data-bs-theme=dark] .token.string,
 [data-bs-theme=dark] .token.attr-value {
-	color: var(--bs-danger-text-emphasis);
+	color: var(--bs-danger-fg-emphasis);
 }
 
 [data-bs-theme=dark] .token.tag,
 [data-bs-theme=dark] .token.selector,
 [data-bs-theme=dark] .token.class-name {
-	color: var(--bs-success-text-emphasis);
+	color: var(--bs-success-fg-emphasis);
 }
 
 [data-bs-theme=dark] .token.function {
-	color: var(--bs-warning-text-emphasis);
+	color: var(--bs-warning-fg-emphasis);
 }
 
 [data-bs-theme=dark] .token.operator {
-	color: var(--bs-secondary-color);
+	color: var(--bs-secondary-fg);
 	background-color: transparent;
 }
 

--- a/skills/havit-blazor-v6-migration/SKILL.md
+++ b/skills/havit-blazor-v6-migration/SKILL.md
@@ -77,7 +77,11 @@ Run the searches in `references/class-renames.md` and apply the mappings: `form-
 
 ### 3c. Theme color utilities (Bootstrap 6 token system)
 
-Apply per `references/class-renames.md`: `text-{color}` → `fg-{color}`, `text-{color}-emphasis` → `fg-emphasis-{color}`, `bg-{color}-subtle` → `bg-subtle-{color}`, `border-{color}-subtle` → `border-subtle-{color}`, `text-bg-{color}` → `theme-{color}`. The `light`/`dark` theme colors are **removed** — map `light` → `secondary` and `dark` → `inverse` (new `accent` and `inverse` colors exist). Verify each result against the bundle as in 3a.
+Apply per `references/class-renames.md`: `text-{color}` → `fg-{color}`, `text-{color}-emphasis` → `fg-emphasis-{color}`, `bg-{color}-subtle` → `bg-subtle-{color}`, `border-{color}-subtle` → `border-subtle-{color}`, `text-bg-{color}` → `theme-{color}`. The `light`/`dark` theme colors are **removed** — map `light` → `secondary` and `dark` → `inverse` (new `accent` and `inverse` colors exist). Also apply the body-surface renames: `bg-body-secondary`/`bg-body-tertiary` → `bg-2`/`bg-3`, `text-body-secondary` → `fg-secondary`, `text-muted` → `fg-secondary`. Verify each result against the bundle as in 3a.
+
+**Don't stop at `class="..."` markup searches.** Classes are frequently built as C# string literals — a hardcoded `CssClass = "text-danger"` in a demo's `@code` block, a `RenderTreeBuilder.AddAttribute(..., "text-secondary mb-1 ...")` in a `.razor.cs` file, an `ItemCssClassSelector` lambda returning a literal string, or a class embedded inside an HTML string passed to a `Content`/`Html` parameter. A plain `rg 'class="..."' -g '*.razor'` search misses all of these. Grep `.cs`/`.razor.cs` files for the same old class names as plain quoted substrings, not just attribute syntax.
+
+**Also sweep CSS custom properties, not just utility classes.** Consumer `<style>` blocks, `.razor.css` files, and inline `style="--my-var: var(--bs-...)"` overrides that reference renamed Bootstrap variables (`--bs-secondary-color`, `--bs-emphasis-color`, `--bs-{color}-text-emphasis`, `--bs-body-bg`/`--bs-body-color`) break silently the same way a stale class does — see the CSS custom properties table in `references/class-renames.md`.
 
 ### 3d. Breakpoint VALUE changes
 
@@ -226,7 +230,10 @@ Audit `*.razor.css` files for rules setting properties that utility classes on t
    rg -n 'HxModal|HxOffcanvas|HxDropdown|HxNavbarCollapse' -g '*.razor' -g '*.cs' -g '!{bin,obj}'
    rg -n 'form-select|text-bg-|btn-outline-[a-z]+|\bbtn-(primary|secondary|success|danger|warning|info|light|dark)\b' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
    rg -on '\b[a-z][a-z0-9-]*-(sm|md|lg|xl|xxl)-[a-z0-9-]+\b' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
+   rg -n '\btext-(primary|secondary|success|danger|warning|info|light|dark|muted|body-secondary|body-tertiary)\b|\bbg-body-(secondary|tertiary)\b' -g '*.razor' -g '*.cs' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
+   rg -n -- '--bs-(secondary-color|emphasis-color|[a-z]+-text-emphasis|[a-z-]*-rgb\b)' -g '*.css' -g '*.razor' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
    ```
+   The third-to-last and second-to-last commands also need a `.cs` pass beyond `class="..."` markup — see the C# string-literal note in Step 3c.
 3. Run the application and visually check:
    - **Forms**: labels/validation render; selects styled (no bare native select); checkboxes/radios/switches; any toggle-button groups respond to clicks.
    - **Dialogs**: open/close (button, Escape, backdrop), sizes/fullscreen, message boxes.

--- a/skills/havit-blazor-v6-migration/references/class-renames.md
+++ b/skills/havit-blazor-v6-migration/references/class-renames.md
@@ -49,11 +49,27 @@ Rule: `{utility}-{bp}-{value}` → `{bp}:{utility}-{value}`; breakpoint name `xx
 | `bg-{color}-subtle` | `bg-subtle-{color}` |
 | `border-{color}-subtle` | `border-subtle-{color}` |
 | `text-bg-{color}` | `theme-{color}` (sets bg + contrast fg via theme tokens) |
-| `bg-light` / `bg-dark` | `bg-secondary` / `bg-inverse` (or semantic `bg-body-*`) |
+| `bg-light` / `bg-dark` | `bg-secondary` / `bg-inverse` |
 | `text-light` / `text-dark` | `fg-secondary` / `fg-inverse` |
 | `alert-{color}`, `badge` color via `text-bg-*`, `list-group-item-{color}` | component class + `theme-{color}` |
+| `bg-body-secondary` / `bg-body-tertiary` | `bg-2` / `bg-3` (numbered surfaces — see below) |
+| `text-body-secondary` | `fg-secondary` |
+| `text-muted` | `fg-secondary` (v6 has no muted-specific fg token; nearest match) |
 
-`bg-{color}` and `border-{color}` keep their names. The `--bs-{color}-rgb` CSS variables are removed (only `--bs-link-color-rgb` remains) — replace `rgba(var(--bs-primary-rgb), .25)` with `color-mix(in srgb, var(--bs-primary) 25%, transparent)`.
+`bg-{color}` and `border-{color}` keep their names. `bg-body` (unmodified) keeps its name too — it's only the `-secondary`/`-tertiary` body-surface variants that are renamed.
+
+**Numbered surfaces**: v6 replaces the body-surface ladder (`bg-body`, `bg-body-secondary`, `bg-body-tertiary`) with `bg-body`, `bg-1`, `bg-2`, `bg-3`, `bg-4` (increasingly distinct from the page background — `bg-1` subtlest, `bg-4` most). `bg-body-secondary` maps to `bg-2` and `bg-body-tertiary` maps to `bg-3` (confirmed by comparing computed gray-scale steps against the BS5 defaults — verify against the bundle same as other renames, and re-check against a real card/surface in the browser since the numbered scale isn't a strict 1:1 semantic match).
+
+**CSS custom properties** (not just classes — consumer CSS/`<style>` blocks and `.razor.css` files referencing Bootstrap variables directly need the same sweep): the `--bs-{color}-rgb` channel variables are removed (only `--bs-link-color-rgb` remains) — replace `rgba(var(--bs-primary-rgb), .25)` with `color-mix(in srgb, var(--bs-primary) 25%, transparent)` (and `rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity))` similarly becomes `color-mix(in srgb, var(--bs-bg-body) calc(var(--bs-bg-opacity) * 100%), transparent)`). Beyond the RGB drop, several variables were also renamed outright:
+
+| v5 (removed) | v6 |
+|---|---|
+| `--bs-secondary-color` | `--bs-secondary-fg` |
+| `--bs-emphasis-color` | `--bs-fg-body` |
+| `--bs-{color}-text-emphasis` (e.g. `--bs-primary-text-emphasis`) | `--bs-{color}-fg-emphasis` (e.g. `--bs-primary-fg-emphasis`) |
+| `--bs-body-bg` / `--bs-body-color` | `--bs-bg-body` / `--bs-fg-body` |
+
+Search: `rg -n -- '--bs-(secondary-color|emphasis-color|[a-z]+-text-emphasis|body-bg\b|body-color\b)' -g '*.css' -g '*.razor' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'`.
 
 ## 4. Buttons
 

--- a/skills/havit-blazor-v6-migration/references/class-renames.md
+++ b/skills/havit-blazor-v6-migration/references/class-renames.md
@@ -55,8 +55,9 @@ Rule: `{utility}-{bp}-{value}` → `{bp}:{utility}-{value}`; breakpoint name `xx
 | `bg-body-secondary` / `bg-body-tertiary` | `bg-2` / `bg-3` (numbered surfaces — see below) |
 | `text-body-secondary` | `fg-secondary` |
 | `text-muted` | `fg-secondary` (v6 has no muted-specific fg token; nearest match) |
+| `text-white` / `text-black` | `fg-white` / `fg-black` |
 
-`bg-{color}` and `border-{color}` keep their names. `bg-body` (unmodified) keeps its name too — it's only the `-secondary`/`-tertiary` body-surface variants that are renamed.
+`bg-{color}` and `border-{color}` keep their names — **including `bg-white`/`bg-black`/`bg-body`**, which are unaffected. Only the `text-*` family is renamed to `fg-*`; don't assume `text-white`/`text-black` survive just because their `bg-*` counterparts do (verify each one against the bundle, same as any other `text-*` class — this exact assumption caused a real miss in an earlier pass of this sweep).
 
 **Numbered surfaces**: v6 replaces the body-surface ladder (`bg-body`, `bg-body-secondary`, `bg-body-tertiary`) with `bg-body`, `bg-1`, `bg-2`, `bg-3`, `bg-4` (increasingly distinct from the page background — `bg-1` subtlest, `bg-4` most). `bg-body-secondary` maps to `bg-2` and `bg-body-tertiary` maps to `bg-3` (confirmed by comparing computed gray-scale steps against the BS5 defaults — verify against the bundle same as other renames, and re-check against a real card/surface in the browser since the numbered scale isn't a strict 1:1 semantic match).
 


### PR DESCRIPTION
## Summary
Follow-up repo-wide sweep after #1716, checking for other leftover Bootstrap 5 identifiers the v6 rework's `text-*` → `fg-*` rename left behind (per the class-rename table in the `havit-blazor-v6-migration` skill), plus a few adjacent gaps the sweep uncovered:

- **`text-{color}` → `fg-{color}`** across ~15 doc pages, and **two spots in the NuGet library itself** ([HxGrid.razor](Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor), [HxGridEmptyDataTemplateDefaultContent.razor](Havit.Blazor.Components.Web.Bootstrap/Grids/HxGridEmptyDataTemplateDefaultContent.razor) loading/empty states).
- **`btn-{color}`/`btn-outline-{color}` → `btn-solid theme-{color}`/`btn-outline theme-{color}`** (popover demos, Premium page).
- **`bg-body-secondary`/`bg-body-tertiary` → `bg-2`/`bg-3`** (numbered surfaces) — this rename wasn't in the skill's table at all; added it.
- **`text-muted` → `fg-secondary`** — also missing from the skill's table; v6 has no muted-specific fg token so this is the closest match.
- A stale **`992px` media query** in `MainLayout.razor.css` that was meant to mirror the navbar's `lg` expand breakpoint (now `1024px` in v6).
- Underlying **CSS custom-property renames** (`--bs-secondary-color` → `--bs-secondary-fg`, `--bs-emphasis-color` → `--bs-fg-body`, `--bs-{color}-text-emphasis` → `--bs-{color}-fg-emphasis`, and an `rgba(var(--bs-*-rgb), …)` → `color-mix()` conversion) in `site.css`, `Navbar.razor.css`, and the `HxSidebar` color-customization demo.

Also extends `skills/havit-blazor-v6-migration/` with what this sweep found missing: the body-surface → numbered-`bg-N` mapping, `text-muted`, a CSS custom-property rename table, and a note that classes built as C# string literals (`RenderTreeBuilder`, `CssClass="..."`, `ItemCssClassSelector` lambdas) need their own grep pass since markup-only `class="..."` searches miss them — that's exactly how the #1716 bug slipped through originally.

All affected projects (`Havit.Blazor.Components.Web.Bootstrap`, `Havit.Blazor.Documentation`, `Havit.Blazor.Documentation.Server`) build clean.

## Test plan
- [x] `dotnet build` clean on all three affected projects
- [x] Verified visually in-browser: Showcase list/detail pages (`bg-3`/`fg-primary`), on-this-page nav, HxSidebar colors demo
- [ ] Spot-check the remaining doc pages (Premium, Popover, Card, SearchBox, ListGroup demos) render with the expected muted/theme colors in both light and dark mode