### PR TITLE
Document rounded-* / --bs-border-radius* rename in v6 migration skill

### DIFF
--- a/skills/havit-blazor-v6-migration/SKILL.md
+++ b/skills/havit-blazor-v6-migration/SKILL.md
@@ -218,6 +218,12 @@ Bootstrap 6 utilities no longer use `!important`; everything Bootstrap ships is 
 
 Audit `*.razor.css` files for rules setting properties that utility classes on the same elements also set (`display`, `margin`, `padding`, `position`, ...) and move them into `@layer custom`.
 
+### 4.12 `rounded-*` classes are unchanged; `--bs-border-radius*` variables are renamed
+
+`rounded-0`…`rounded-5`, `rounded-circle`, `rounded-pill`, and the side-scoped variants (`rounded-top-*`/`rounded-end-*`/`rounded-bottom-*`/`rounded-start-*`) are **not** renamed — v6 only extends the scale additively (new `rounded-6`…`rounded-9`, new standalone `rounded-size-*` family). Don't spend time sweeping `rounded-*` class usage.
+
+The CSS variables ARE renamed, though: `--bs-border-radius` and its `-sm`/`-lg`/`-xl`/`-xxl`/`-2xl`/`-pill` siblings become a numbered `--bs-radius-0`…`--bs-radius-9` scale plus `--bs-radius-pill`. Apply the mapping in `references/class-renames.md` § 10 to any consumer CSS overriding `--bs-border-radius*` directly.
+
 ## Step 5 — Verification loop
 
 1. `dotnet build` — iterate until clean. Compile errors name the removed types from Step 4; do not suppress with `#pragma`/aliases.
@@ -226,6 +232,7 @@ Audit `*.razor.css` files for rules setting properties that utility classes on t
    rg -n 'HxModal|HxOffcanvas|HxDropdown|HxNavbarCollapse' -g '*.razor' -g '*.cs' -g '!{bin,obj}'
    rg -n 'form-select|text-bg-|btn-outline-[a-z]+|\bbtn-(primary|secondary|success|danger|warning|info|light|dark)\b' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
    rg -on '\b[a-z][a-z0-9-]*-(sm|md|lg|xl|xxl)-[a-z0-9-]+\b' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
+   rg -n -- '--bs-border-radius' -g '*.css' -g '*.razor' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'
    ```
 3. Run the application and visually check:
    - **Forms**: labels/validation render; selects styled (no bare native select); checkboxes/radios/switches; any toggle-button groups respond to clicks.

--- a/skills/havit-blazor-v6-migration/references/class-renames.md
+++ b/skills/havit-blazor-v6-migration/references/class-renames.md
@@ -120,3 +120,20 @@ Rule: `{utility}-{bp}-{value}` → `{bp}:{utility}-{value}`; breakpoint name `xx
 | `navbar-collapse` | — (responsive content is a `dialog.drawer`, flattened inline at/above the expand breakpoint) |
 | `navbar-expand-{bp}` | `{bp}:navbar-expand` |
 | `navbar-dark` / `navbar-light` | — (toggler icon uses `mask-image` + `currentcolor`; use `data-bs-theme` / theme classes) |
+
+## 10. Border radius (`rounded-*`)
+
+**The classes are NOT renamed** — this is an additive change, not a breaking one. `rounded-0`…`rounded-5`, `rounded-circle`, `rounded-pill`, and the side-scoped variants (`rounded-top-*`, `rounded-end-*`, `rounded-bottom-*`, `rounded-start-*`, each with their own `-0`…`-5`/`-circle`/`-pill`) all still exist verbatim in v6 — nothing to sweep here. v6 extends the scale with `rounded-6` through `rounded-9` (larger radii) and adds a new `rounded-size-{0-9|circle|pill}` utility family (a standalone radius token not tied to border sides).
+
+**The underlying CSS variable IS renamed**, though — same pattern as `--bs-secondary-color` → `--bs-secondary-fg`. `--bs-border-radius` and its `-sm`/`-lg`/`-xl`/`-xxl`/`-2xl`/`-pill` siblings are replaced by a numbered `--bs-radius-0`…`--bs-radius-9` scale plus `--bs-radius-pill`. Any consumer CSS overriding `--bs-border-radius*` directly (a common BS5 theming technique) needs to target the numbered variable instead. Mapping (verified against this repo's actual pre-migration BS5 defaults vs. the v6 bundle, not the stock Bootstrap 5.3 defaults — re-verify the pre-migration values for any other project before reusing this table):
+
+| v5 (removed) | value | v6 | value |
+|---|---|---|---|
+| `--bs-border-radius-sm` | 0.375rem | `--bs-radius-4` | 0.375rem (exact) |
+| `--bs-border-radius` | 0.5rem | `--bs-radius-5` | 0.5rem (exact) |
+| `--bs-border-radius-lg` | 0.625rem | `--bs-radius-6` | 0.625rem (exact) |
+| `--bs-border-radius-xl` | 1rem | `--bs-radius-8` | 1rem (exact) |
+| `--bs-border-radius-xxl` / `-2xl` | 2rem | `--bs-radius-9` | 1.5rem (**not exact** — v6's largest step tops out lower; flag for human review if the visual size matters) |
+| `--bs-border-radius-pill` | 50rem | `--bs-radius-pill` | 50rem (exact) |
+
+Search: `rg -n -- '--bs-border-radius' -g '*.css' -g '*.razor' -g '!{bin,obj}' -g '!**/wwwroot/lib/**'`.


### PR DESCRIPTION
## Summary
Follow-up to #1716/#1718: while investigating a `rounded-3` → `rounded-5` icon tweak, checked whether the `havit-blazor-v6-migration` skill covers `rounded-*` utility classes — it didn't mention them at all.

Turns out there's nothing to migrate on the class side: `rounded-0`…`rounded-5`, `rounded-circle`, `rounded-pill`, and the side-scoped variants all still exist unchanged in v6 (it's purely additive — new `rounded-6`…`rounded-9` and a new `rounded-size-*` family). But the underlying CSS variable **is** renamed the same way `--bs-secondary-color` was: `--bs-border-radius`(`-sm`/`-lg`/`-xl`/`-xxl`/`-2xl`/`-pill`) → a numbered `--bs-radius-0`…`--bs-radius-9` scale + `--bs-radius-pill`. That gap wasn't documented anywhere.

Adds:
- `references/class-renames.md` § 10 with the mapping table, verified against this repo's actual pre-migration BS5 CSS values (not assumed stock Bootstrap 5.3 defaults) vs. the current v6 bundle — most map exactly, one (`-xxl`/`-2xl` → `--bs-radius-9`) is flagged as not an exact value match.
- `SKILL.md` § 4.12 explaining the class-vs-variable distinction, plus a Step 5 leftover-scan search command.

This directly caught a live bug, fixed separately in #1718: `Demo.razor.css` was still using the removed `--bs-border-radius` (and `--bs-body-bg`), so the demo box on every component doc page was rendering with square corners and a transparent background.

## Test plan
- [x] N/A — documentation-only change, no code affected