### PR TITLE
Fix inline demo elements (buttons, badges) stretching full-width in docs

### DIFF
--- a/Havit.Blazor.Documentation/Shared/Components/Demo.razor
+++ b/Havit.Blazor.Documentation/Shared/Components/Demo.razor
@@ -32,7 +32,7 @@ else
 @code {
 	private void RenderDemo(RenderTreeBuilder __builder)
 	{
-		<div class="@CssClassHelper.Combine("demo-content not-prose p-3 align-self-stretch vstack gap-3", DemoCardCssClass)">
+		<div class="@CssClassHelper.Combine("demo-content not-prose p-3 align-self-stretch", DemoCardCssClass)">
 			@if (Resizable)
 			{
 				<div class="demo-resizable">

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -8,11 +8,7 @@
 	--hx-sidebar-body-padding: 				0 1rem 0 0;
 }
 
-/* Demo content flows as normal block/inline content (not flex), so block-level demo
-   elements (e.g. alerts, cards) stay full-width by default while inline elements
-   (buttons, badges, avatars, ...) keep their natural width instead of being stretched.
-   Only multiple block-level root children need spacing between them. */
-.demo-content > * + * {
+:where(.demo-content) > * + :not(.btn, .btn-group, .badge, .avatar, .avatar-stack, .hx-context-menu) {
 	margin-top: 1rem;
 }
 

--- a/Havit.Blazor.Documentation/wwwroot/css/site.css
+++ b/Havit.Blazor.Documentation/wwwroot/css/site.css
@@ -8,11 +8,12 @@
 	--hx-sidebar-body-padding: 				0 1rem 0 0;
 }
 
-/* Demo content uses vstack to stack and space items; block-level elements (e.g. alerts)
-   stretch full-width by design. Buttons and button groups should keep their natural width. */
-.demo-content > .btn,
-.demo-content > .btn-group {
-	align-self: flex-start;
+/* Demo content flows as normal block/inline content (not flex), so block-level demo
+   elements (e.g. alerts, cards) stay full-width by default while inline elements
+   (buttons, badges, avatars, ...) keep their natural width instead of being stretched.
+   Only multiple block-level root children need spacing between them. */
+.demo-content > * + * {
+	margin-top: 1rem;
 }
 
 /* In the tabbed demo variant the tab content is a flex child of the (flex-column) card body;


### PR DESCRIPTION
## Summary
- `Demo.razor` wrapped every demo in a `vstack` (`flex-direction: column`, `align-items: stretch`), which stretched inline components — badges, avatars, the `HxContextMenu` trigger, etc. — to the full card width and stacked them vertically even when they were meant to flow inline.
- The existing CSS exception only covered `.btn`/`.btn-group` as direct children, so it missed badges, avatars, and anything nested one level deep (e.g. the `HxContextMenu` toggle button, which lives inside a `.hx-context-menu` wrapper div).
- Dropped the forced `vstack` in favor of normal block/inline flow: block-level demos (Alert, Carousel, Card, ListLayout) still stretch full-width via ordinary CSS block layout, while inline elements keep their natural size and flow side by side. Spacing between multiple root-level block children is now handled with a plain `margin-top` rule instead of flex `gap`.

## Test plan
- [x] `HxBadge` "Background colors" demo: badges now render at natural widths and flow on one row (verified via computed styles).
- [x] `HxContextMenu` "Basic usage" demo: trigger button is a small icon button instead of a full-width stretched bar.
- [x] `HxButton` demos: multiple buttons keep natural width and flow inline.
- [x] `HxAlert` and `HxCarousel` demos: block-level content still spans the full demo width.
- [x] `HxListLayout` resizable demo: fixed-width resizable panel unaffected.
- [x] `Havit.Blazor.Documentation` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)