### PR TITLE
[HxEChart] Avoid re-serializing/retaining full Options JSON on every unrelated parent render

### DIFF
--- a/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
+++ b/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.JSInterop;
@@ -19,6 +21,7 @@ public partial class HxEChart : IAsyncDisposable
 
 	/// <summary>
 	/// Options for the chart. See <a href="https://echarts.apache.org/en/option.html">ECharts Option</a> for more details.
+	/// The chart is updated only when a new instance is provided (in-place mutations of the previously passed instance are not detected).
 	/// </summary>
 	[Parameter, EditorRequired] public object Options { get; set; }
 
@@ -46,7 +49,9 @@ public partial class HxEChart : IAsyncDisposable
 
 	private IJSObjectReference _jsModule;
 	private DotNetObjectReference<HxEChart> _dotNetObjectReference;
-	private string _currentOptions;
+	private object _lastOptionsReference;
+	private byte[] _currentOptionsHash;
+	private string _optionsToApply;
 	private bool _shouldSetupChartOnAfterRender;
 	private bool _disposed;
 
@@ -71,13 +76,18 @@ public partial class HxEChart : IAsyncDisposable
 
 	protected override void OnParametersSet()
 	{
-		if (Options is not null)
+		if ((Options is not null) && !ReferenceEquals(Options, _lastOptionsReference))
 		{
-			var newOptions = JsonSerializer.Serialize(Options, s_JsonSerializerOptions);
-			if (!string.Equals(_currentOptions, newOptions, StringComparison.Ordinal))
+			_lastOptionsReference = Options;
+
+			var newOptions = JsonSerializer.SerializeToUtf8Bytes(Options, s_JsonSerializerOptions);
+			var newOptionsHash = SHA256.HashData(newOptions);
+
+			if ((_currentOptionsHash is null) || !newOptionsHash.AsSpan().SequenceEqual(_currentOptionsHash))
 			{
 				_shouldSetupChartOnAfterRender = true;
-				_currentOptions = newOptions;
+				_currentOptionsHash = newOptionsHash;
+				_optionsToApply = Encoding.UTF8.GetString(newOptions);
 			}
 		}
 	}
@@ -92,7 +102,8 @@ public partial class HxEChart : IAsyncDisposable
 				return;
 			}
 
-			await _jsModule.InvokeVoidAsync("setupChart", ChartId, _dotNetObjectReference, _currentOptions, AutoResize, OnAxisPointerUpdated.HasDelegate);
+			await _jsModule.InvokeVoidAsync("setupChart", ChartId, _dotNetObjectReference, _optionsToApply, AutoResize, OnAxisPointerUpdated.HasDelegate);
+			_optionsToApply = null; // release the serialized JSON, only the hash is kept for change detection
 		}
 
 		_shouldSetupChartOnAfterRender = false;

--- a/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
+++ b/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
@@ -77,12 +77,13 @@ public partial class HxEChart : IAsyncDisposable
 		if (Options is not null)
 		{
 			var newOptions = JsonSerializer.SerializeToUtf8Bytes(Options, s_JsonSerializerOptions);
-			var newOptionsHash = SHA256.HashData(newOptions);
+			Span<byte> newOptionsHash = stackalloc byte[SHA256.HashSizeInBytes];
+			SHA256.HashData(newOptions, newOptionsHash);
 
-			if ((_currentOptionsHash is null) || !newOptionsHash.AsSpan().SequenceEqual(_currentOptionsHash))
+			if ((_currentOptionsHash is null) || !newOptionsHash.SequenceEqual(_currentOptionsHash))
 			{
 				_shouldSetupChartOnAfterRender = true;
-				_currentOptionsHash = newOptionsHash;
+				_currentOptionsHash = newOptionsHash.ToArray();
 				_optionsToApply = Encoding.UTF8.GetString(newOptions);
 			}
 		}

--- a/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
+++ b/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
@@ -21,7 +21,6 @@ public partial class HxEChart : IAsyncDisposable
 
 	/// <summary>
 	/// Options for the chart. See <a href="https://echarts.apache.org/en/option.html">ECharts Option</a> for more details.
-	/// The chart is updated only when a new instance is provided (in-place mutations of the previously passed instance are not detected).
 	/// </summary>
 	[Parameter, EditorRequired] public object Options { get; set; }
 
@@ -49,7 +48,6 @@ public partial class HxEChart : IAsyncDisposable
 
 	private IJSObjectReference _jsModule;
 	private DotNetObjectReference<HxEChart> _dotNetObjectReference;
-	private object _lastOptionsReference;
 	private byte[] _currentOptionsHash;
 	private string _optionsToApply;
 	private bool _shouldSetupChartOnAfterRender;
@@ -76,10 +74,8 @@ public partial class HxEChart : IAsyncDisposable
 
 	protected override void OnParametersSet()
 	{
-		if ((Options is not null) && !ReferenceEquals(Options, _lastOptionsReference))
+		if (Options is not null)
 		{
-			_lastOptionsReference = Options;
-
 			var newOptions = JsonSerializer.SerializeToUtf8Bytes(Options, s_JsonSerializerOptions);
 			var newOptionsHash = SHA256.HashData(newOptions);
 

--- a/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
+++ b/Havit.Blazor.Components.Web.ECharts/HxEChart.razor.cs
@@ -95,6 +95,8 @@ public partial class HxEChart : IAsyncDisposable
 			await EnsureJsModuleAsync();
 			if (_disposed)
 			{
+				_shouldSetupChartOnAfterRender = false;
+				_optionsToApply = null;
 				return;
 			}
 

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.ECharts.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.ECharts.xml
@@ -112,7 +112,6 @@
         <member name="P:Havit.Blazor.Components.Web.ECharts.HxEChart.Options">
             <summary>
             Options for the chart. See <a href="https://echarts.apache.org/en/option.html">ECharts Option</a> for more details.
-            The chart is updated only when a new instance is provided (in-place mutations of the previously passed instance are not detected).
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.ECharts.HxEChart.Height">

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.ECharts.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.ECharts.xml
@@ -112,6 +112,7 @@
         <member name="P:Havit.Blazor.Components.Web.ECharts.HxEChart.Options">
             <summary>
             Options for the chart. See <a href="https://echarts.apache.org/en/option.html">ECharts Option</a> for more details.
+            The chart is updated only when a new instance is provided (in-place mutations of the previously passed instance are not detected).
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.ECharts.HxEChart.Height">


### PR DESCRIPTION
Fixes #1734

## Changes

- **Hash instead of full JSON**: only a SHA-256 hash of the serialized options is kept for the lifetime of the component for change detection. The full serialized JSON (`_optionsToApply`) is retained only transiently — from `OnParametersSet` until it is handed to `setupChart` in `OnAfterRenderAsync`, then the reference is dropped.
- Serialization goes through `SerializeToUtf8Bytes`, so on the "same content" path no JSON string is allocated at all (bytes are hashed and discarded).

## Deliberate deviation from the issue

The suggested `ReferenceEquals` guard (skip serialization when the same `Options` instance is passed again) is **intentionally not implemented** — it would silently break callers that mutate the same options instance in place and rely on the change being picked up on the next render. Serialization therefore still runs on every parent render (as today), but the redundant `setupChart` JS interop and the long-term retention of the full JSON string are eliminated.

## Acceptance criteria (from the issue)

- ✅ Different instance serializing to the same JSON → `setupChart` not invoked again (hash comparison).
- ✅ Options actually change → chart updates exactly as before (same `setupChart` interop call and arguments).
- ✅ Once options stabilize, only the 32-byte hash is retained, not the full JSON string.
- ❌ (by design) Same instance → serialization still runs; skipping it would change semantics for in-place mutations.
- `Options` becoming `null` after being non-null keeps the previous behavior (chart keeps showing the last options).

Build passes with `-warnaserror` on net8.0/net9.0/net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)