### PR TITLE
Bump dependencies to latest stable versions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Install gh-aw extension
-        uses: github/gh-aw-actions/setup-cli@3fac1cfa7a5a375a6a5eb9839178f6dad7adb60a # v0.82.2
+        uses: github/gh-aw-actions/setup-cli@e89c65e17eb281bbd5ff2ff9e9199a03e96654c7 # v0.83.4
         with:
           version: v0.79.6

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,9 @@
 	<PropertyGroup>
 <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-<AspNetCoreVersion8>8.0.28</AspNetCoreVersion8>
-<AspNetCoreVersion9>9.0.17</AspNetCoreVersion9>
-<AspNetCoreVersion10>10.0.9</AspNetCoreVersion10>
+<AspNetCoreVersion8>8.0.29</AspNetCoreVersion8>
+<AspNetCoreVersion9>9.0.18</AspNetCoreVersion9>
+<AspNetCoreVersion10>10.0.10</AspNetCoreVersion10>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
@@ -14,8 +14,8 @@
 		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.80.0" />
 		<PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
 		<PackageVersion Include="Grpc.Net.Client.Web" Version="2.80.0" />
-		<PackageVersion Include="Havit.Core" Version="2.0.38" />
-		<PackageVersion Include="Havit.AspNetCore" Version="2.0.31" />
+		<PackageVersion Include="Havit.Core" Version="2.0.39" />
+		<PackageVersion Include="Havit.AspNetCore" Version="2.0.32" />
 		<PackageVersion Include="LoxSmoke.DocXml" Version="3.9.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion10)" Condition="'$(TargetFramework)' == 'net10.0'" />
 		<PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' == 'net9.0'" />
@@ -29,8 +29,8 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion10)" />
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(AspNetCoreVersion10)" />
 		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion10)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis" Version="5.3.0" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis" Version="5.6.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion10)" Condition="'$(TargetFramework)' == 'net10.0'" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' != 'net10.0'" />
@@ -64,6 +64,13 @@
 		<PackageVersion Include="System.Text.Json" Version="$(AspNetCoreVersion10)" />
 		<!-- Transient vulnerabilities -->
 		<PackageVersion Include="System.Formats.Asn1" Version="$(AspNetCoreVersion10)" />
+	</ItemGroup>
+	<ItemGroup>
+		<!-- AngleSharp 1.2.0 (pulled in by bunit.web 1.40.0, the latest release) has a known moderate severity
+		     vulnerability. Later AngleSharp versions break binary compatibility with bunit.web's compiled
+		     assemblies (MissingMethodException on IHtmlCollection<T>.get_Item), so it can't be bumped yet;
+		     suppress the advisory until bunit.web ships a build against a patched AngleSharp. -->
+		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-pgww-w46g-26qg" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(ProjectName.EndsWith(`Tests`))' == 'False'">
 		<GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
 		<PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
-		<PackageVersion Include="bunit.web" Version="1.40.0" />
+		<PackageVersion Include="bunit" Version="2.8.6" />
 		<PackageVersion Include="Grpc.AspNetCore.Server" Version="2.80.0" />
 		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.80.0" />
 		<PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
@@ -64,13 +64,6 @@
 		<PackageVersion Include="System.Text.Json" Version="$(AspNetCoreVersion10)" />
 		<!-- Transient vulnerabilities -->
 		<PackageVersion Include="System.Formats.Asn1" Version="$(AspNetCoreVersion10)" />
-	</ItemGroup>
-	<ItemGroup>
-		<!-- AngleSharp 1.2.0 (pulled in by bunit.web 1.40.0, the latest release) has a known moderate severity
-		     vulnerability. Later AngleSharp versions break binary compatibility with bunit.web's compiled
-		     assemblies (MissingMethodException on IHtmlCollection<T>.get_Item), so it can't be bumped yet;
-		     suppress the advisory until bunit.web ships a build against a patched AngleSharp. -->
-		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-pgww-w46g-26qg" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(ProjectName.EndsWith(`Tests`))' == 'False'">
 		<GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/BunitTestBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/BunitTestBase.cs
@@ -3,11 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
 
-public abstract class BunitTestBase : TestContextWrapper, IDisposable
+public abstract class BunitTestBase : BunitContext
 {
 	protected BunitTestBase()
 	{
-		TestContext = new Bunit.TestContext();
 		Services.AddSingleton(TimeProvider.System);
 		Services.AddLocalization();
 		Services.AddLogging();
@@ -15,10 +14,5 @@ public abstract class BunitTestBase : TestContextWrapper, IDisposable
 		Services.AddHxMessenger();
 		Services.AddHxMessageBoxHost();
 		JSInterop.Mode = JSRuntimeMode.Loose;
-	}
-
-	public void Dispose()
-	{
-		TestContext?.Dispose();
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxButtonGroupTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxButtonGroupTests.cs
@@ -6,7 +6,7 @@ public class HxButtonGroupTests : BunitTestBase
 	public void HxButtonGroup_Render_GroupsButtonsHorizontally()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButtonGroup>(parameters => parameters
+		var cut = Render<HxButtonGroup>(parameters => parameters
 			.Add(p => p.AriaLabel, "Test group")
 			.AddChildContent<HxButton>(buttonParams => buttonParams.Add(p => p.Text, "First"))
 			.AddChildContent<HxButton>(buttonParams => buttonParams.Add(p => p.Text, "Second"))

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxButtonTests.Tooltip.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxButtonTests.Tooltip.cs
@@ -6,7 +6,7 @@ public partial class HxButtonTests : BunitTestBase
 	public void HxButton_TooltipSettings_Trigger_ShouldBeConfigurableViaParameter()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Tooltip, "Test Tooltip")
 			.Add(p => p.TooltipSettings, new TooltipSettings()
 			{
@@ -25,7 +25,7 @@ public partial class HxButtonTests : BunitTestBase
 	public void HxButton_TooltipSettings_Trigger_ShouldBeConfigurableViaSettings()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Tooltip, "Test Tooltip")
 			.Add(p => p.Settings, new ButtonSettings()
 			{
@@ -47,7 +47,7 @@ public partial class HxButtonTests : BunitTestBase
 	public void HxButton_TooltipSettings_DefaultTrigger_ShouldNotBeSet()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Tooltip, "Test Tooltip")
 		);
 
@@ -63,7 +63,7 @@ public partial class HxButtonTests : BunitTestBase
 	public void HxButton_TooltipSettings_Placement_ShouldBeConfigurableViaParameter()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Tooltip, "Test Tooltip")
 			.Add(p => p.TooltipSettings, new TooltipSettings()
 			{
@@ -82,7 +82,7 @@ public partial class HxButtonTests : BunitTestBase
 	public void HxButton_TooltipSettings_Placement_ShouldBeConfigurableViaSettings()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Tooltip, "Test Tooltip")
 			.Add(p => p.Settings, new ButtonSettings()
 			{
@@ -104,7 +104,7 @@ public partial class HxButtonTests : BunitTestBase
 	public void HxButton_TooltipSettings_DefaultPlacement_ShouldNotBeSet()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Tooltip, "Test Tooltip")
 		);
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxButtonTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxButtonTests.cs
@@ -10,7 +10,7 @@ public partial class HxButtonTests
 	{
 		// Arrange
 		var clicked = false;
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Text, "Click me")
 			.Add(p => p.OnClick, EventCallback.Factory.Create<MouseEventArgs>(this, () => clicked = true))
 		);
@@ -26,7 +26,7 @@ public partial class HxButtonTests
 	public void HxButton_Disabled_RendersDisabledAttribute()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Text, "Disabled")
 			.Add(p => p.Enabled, false)
 		);
@@ -41,7 +41,7 @@ public partial class HxButtonTests
 	{
 		// Arrange
 		var tcs = new TaskCompletionSource();
-		var cut = RenderComponent<HxButton>(parameters => parameters
+		var cut = Render<HxButton>(parameters => parameters
 			.Add(p => p.Text, "Async")
 			.Add(p => p.OnClick, EventCallback.Factory.Create<MouseEventArgs>(this, () => tcs.Task))
 		);

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxCloseButtonTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Buttons/HxCloseButtonTests.cs
@@ -6,7 +6,7 @@ public class HxCloseButtonTests : BunitTestBase
 	public void HxCloseButton_Render_OutputsButtonElement()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxCloseButton>();
+		var cut = Render<HxCloseButton>();
 
 		// Assert
 		var button = cut.Find("button");
@@ -19,7 +19,7 @@ public class HxCloseButtonTests : BunitTestBase
 	{
 		// Arrange
 		var clicked = false;
-		var cut = RenderComponent<HxCloseButton>(parameters => parameters
+		var cut = Render<HxCloseButton>(parameters => parameters
 			.Add(p => p.OnClick, () => clicked = true)
 		);
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Cards/HxCardTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Cards/HxCardTests.cs
@@ -6,7 +6,7 @@ public class HxCardTests : BunitTestBase
 	public void HxCard_Render_DisplaysBodyContent()
 	{
 		// Act
-		var cut = RenderComponent<HxCard>(parameters => parameters
+		var cut = Render<HxCard>(parameters => parameters
 			.Add(p => p.BodyTemplate, "Body content here")
 		);
 
@@ -20,7 +20,7 @@ public class HxCardTests : BunitTestBase
 	public void HxCard_HeaderAndFooter_RenderCorrectly()
 	{
 		// Act
-		var cut = RenderComponent<HxCard>(parameters => parameters
+		var cut = Render<HxCard>(parameters => parameters
 			.Add(p => p.HeaderTemplate, "Header text")
 			.Add(p => p.BodyTemplate, "Body text")
 			.Add(p => p.FooterTemplate, "Footer text")
@@ -38,7 +38,7 @@ public class HxCardTests : BunitTestBase
 	public void HxCard_ImageTop_RendersImageAboveBody()
 	{
 		// Act
-		var cut = RenderComponent<HxCard>(parameters => parameters
+		var cut = Render<HxCard>(parameters => parameters
 			.Add(p => p.ImageSrc, "test-image.png")
 			.Add(p => p.ImagePlacement, CardImagePlacement.Top)
 			.Add(p => p.BodyTemplate, "Body text")
@@ -63,7 +63,7 @@ public class HxCardTests : BunitTestBase
 	public void HxCardTitle_Render_OutputsH5WithText()
 	{
 		// Act
-		var cut = RenderComponent<HxCardTitle>(parameters => parameters
+		var cut = Render<HxCardTitle>(parameters => parameters
 			.AddChildContent("Card Title Text")
 		);
 
@@ -77,7 +77,7 @@ public class HxCardTests : BunitTestBase
 	public void HxCardSubtitle_Render_OutputsH6WithText()
 	{
 		// Act
-		var cut = RenderComponent<HxCardSubtitle>(parameters => parameters
+		var cut = Render<HxCardSubtitle>(parameters => parameters
 			.AddChildContent("Card Subtitle Text")
 		);
 
@@ -91,7 +91,7 @@ public class HxCardTests : BunitTestBase
 	public void HxCardText_Render_OutputsParagraphWithText()
 	{
 		// Act
-		var cut = RenderComponent<HxCardText>(parameters => parameters
+		var cut = Render<HxCardText>(parameters => parameters
 			.AddChildContent("Card text content")
 		);
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Chips/HxChipListTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Chips/HxChipListTests.cs
@@ -14,7 +14,7 @@ public class HxChipListTests : BunitTestBase
 		};
 
 		// Act
-		var cut = RenderComponent<HxChipList>(parameters => parameters
+		var cut = Render<HxChipList>(parameters => parameters
 			.Add(p => p.Chips, chips));
 
 		// Assert – three badge elements are rendered
@@ -33,7 +33,7 @@ public class HxChipListTests : BunitTestBase
 		};
 		ChipItem removedChip = null;
 
-		var cut = RenderComponent<HxChipList>(parameters => parameters
+		var cut = Render<HxChipList>(parameters => parameters
 			.Add(p => p.Chips, chips)
 			.Add(p => p.OnChipRemoveClick, (ChipItem chip) => { removedChip = chip; }));
 
@@ -48,7 +48,7 @@ public class HxChipListTests : BunitTestBase
 		Assert.Same(chips[1], removedChip);
 		// Simulate the parent updating the chips list in response to the callback
 		chips.Remove(removedChip);
-		cut.SetParametersAndRender(p => p.Add(x => x.Chips, chips));
+		cut.Render(p => p.Add(x => x.Chips, chips));
 
 		// Assert – one chip badge disappeared
 		Assert.Equal(2, cut.FindAll(".badge").Count());
@@ -66,7 +66,7 @@ public class HxChipListTests : BunitTestBase
 		};
 		ChipItem removedChip = null;
 
-		var cut = RenderComponent<HxChipList>(parameters => parameters
+		var cut = Render<HxChipList>(parameters => parameters
 			.Add(p => p.Chips, chips)
 			.Add(p => p.OnChipRemoveClick, (ChipItem chip) => { removedChip = chip; }));
 
@@ -79,7 +79,7 @@ public class HxChipListTests : BunitTestBase
 
 		// Simulate the parent updating the chips list in response to the callback
 		chips.Remove(removedChip);
-		cut.SetParametersAndRender(p => p.Add(x => x.Chips, chips));
+		cut.Render(p => p.Add(x => x.Chips, chips));
 
 		// Assert – remaining badges contain the expected content; "Name: Peter" is gone
 		var badgeTexts = cut.FindAll(".badge")

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Collapse/HxCollapse_Basic_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Collapse/HxCollapse_Basic_Tests.cs
@@ -6,7 +6,7 @@ public class HxCollapse_Basic_Tests : BunitTestBase
 	public void HxCollapse_Render_DoesNotSetAriaExpandedOnContentContainer()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxCollapse>(parameters => parameters
+		var cut = Render<HxCollapse>(parameters => parameters
 			.AddChildContent("Test content"));
 
 		// Assert

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxCheckboxListTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxCheckboxListTests.cs
@@ -10,7 +10,7 @@ public class HxCheckboxListTests : BunitTestBase
 		List<string> selectedValues = new();
 
 		// Act
-		var cut = RenderComponent<HxCheckboxList<string, string>>(parameters => parameters
+		var cut = Render<HxCheckboxList<string, string>>(parameters => parameters
 			.Add(p => p.Data, data)
 			.Add(p => p.ItemTextSelector, item => item)
 			.Add(p => p.ItemValueSelector, item => item)
@@ -36,7 +36,7 @@ public class HxCheckboxListTests : BunitTestBase
 		List<string> selectedValues = new() { "Alpha", "Beta", "Gamma" };
 
 		// Act
-		var cut = RenderComponent<HxCheckboxList<string, string>>(parameters => parameters
+		var cut = Render<HxCheckboxList<string, string>>(parameters => parameters
 			.Add(p => p.Data, data)
 			.Add(p => p.ItemTextSelector, item => item)
 			.Add(p => p.ItemValueSelector, item => item)
@@ -60,7 +60,7 @@ public class HxCheckboxListTests : BunitTestBase
 		var data = new List<string> { "Alpha", "Beta", "Gamma" };
 		List<string> selectedValues = new() { "Alpha", "Beta", "Gamma" };
 
-		var cut = RenderComponent<HxCheckboxList<string, string>>(parameters => parameters
+		var cut = Render<HxCheckboxList<string, string>>(parameters => parameters
 			.Add(p => p.Data, data)
 			.Add(p => p.ItemTextSelector, item => item)
 			.Add(p => p.ItemValueSelector, item => item)
@@ -86,7 +86,7 @@ public class HxCheckboxListTests : BunitTestBase
 		var data = new List<string> { "Alpha", "Beta", "Gamma" };
 		List<string> selectedValues = new();
 
-		var cut = RenderComponent<HxCheckboxList<string, string>>(parameters => parameters
+		var cut = Render<HxCheckboxList<string, string>>(parameters => parameters
 			.Add(p => p.Data, data)
 			.Add(p => p.ItemTextSelector, item => item)
 			.Add(p => p.ItemValueSelector, item => item)

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxFormValueTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxFormValueTests.cs
@@ -8,7 +8,7 @@ public class HxFormValueTests : BunitTestBase
 	public void HxFormValue_Render_DisplaysValueText()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxFormValue>(parameters => parameters
+		var cut = Render<HxFormValue>(parameters => parameters
 			.Add(p => p.Value, "TestValue"));
 
 		// Assert
@@ -20,7 +20,7 @@ public class HxFormValueTests : BunitTestBase
 	public void HxFormValue_Label_DisplaysLabelText()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxFormValue>(parameters => parameters
+		var cut = Render<HxFormValue>(parameters => parameters
 			.Add(p => p.Label, "TestLabel")
 			.Add(p => p.Value, "TestValue"));
 
@@ -34,7 +34,7 @@ public class HxFormValueTests : BunitTestBase
 	public void HxFormValue_ValueTemplate_OverridesValueText()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxFormValue>(parameters => parameters
+		var cut = Render<HxFormValue>(parameters => parameters
 			.Add(p => p.Value, "PlainValue")
 			.Add(p => p.ValueTemplate, (RenderTreeBuilder builder) =>
 			{
@@ -54,7 +54,7 @@ public class HxFormValueTests : BunitTestBase
 	public void HxFormValue_Hint_DisplaysHelpText()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxFormValue>(parameters => parameters
+		var cut = Render<HxFormValue>(parameters => parameters
 			.Add(p => p.Value, "TestValue")
 			.Add(p => p.Hint, "TestHint"));
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputBaseTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputBaseTests.cs
@@ -12,7 +12,7 @@ public class HxInputBaseTests
 	public void HxInputBase_Renders_WithoutEditContext()
 	{
 		// Arrange
-		var ctx = new Bunit.BunitContext();
+		using var ctx = new Bunit.BunitContext();
 		var formData = new FormData();
 
 		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputBaseTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputBaseTests.cs
@@ -12,7 +12,7 @@ public class HxInputBaseTests
 	public void HxInputBase_Renders_WithoutEditContext()
 	{
 		// Arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 		var formData = new FormData();
 
 		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>
@@ -52,7 +52,7 @@ public class HxInputBaseTests
 	public void HxInputBase_Renders_AriaDescribedBy_WhenHintProvided()
 	{
 		// Arrange — regression for #1110: input must have aria-describedby referencing hint
-		using var ctx = new Bunit.TestContext();
+		using var ctx = new Bunit.BunitContext();
 		ctx.Services.AddSingleton(TimeProvider.System);
 		ctx.Services.AddLocalization();
 		ctx.Services.AddLogging();

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputNumberTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputNumberTests.cs
@@ -28,7 +28,7 @@ public class HxInputNumberTests : BunitTestBase
 		CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
 
 		decimal? currentValue = null;
-		var cut = RenderComponent<HxInputNumber<decimal?>>(parameters =>
+		var cut = Render<HxInputNumber<decimal?>>(parameters =>
 			parameters.Bind(p =>
 				p.Value,
 				currentValue,
@@ -47,7 +47,7 @@ public class HxInputNumberTests : BunitTestBase
 	{
 		// Arrange
 		int currentValue = 0;
-		var cut = RenderComponent<HxInputNumber<int>>(parameters =>
+		var cut = Render<HxInputNumber<int>>(parameters =>
 			parameters.Bind(p =>
 				p.Value,
 				currentValue,

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputPercentTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputPercentTests.cs
@@ -10,7 +10,7 @@ public class HxInputPercentTests : BunitTestBase
 	{
 		// Arrange
 		decimal currentValue = 0m;
-		var cut = RenderComponent<HxInputPercent<decimal>>(parameters =>
+		var cut = Render<HxInputPercent<decimal>>(parameters =>
 			parameters.Bind(p =>
 				p.Value,
 				currentValue,
@@ -54,7 +54,7 @@ public class HxInputPercentTests : BunitTestBase
 	{
 		// Arrange
 		decimal currentValue = 0.75m;
-		var cut = RenderComponent<HxInputPercent<decimal>>(parameters =>
+		var cut = Render<HxInputPercent<decimal>>(parameters =>
 		{
 			parameters.Bind(p =>
 				p.Value,

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputRangeTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputRangeTests.cs
@@ -9,7 +9,7 @@ public class HxInputRangeTests : BunitTestBase
 		int currentValue = 50;
 
 		// Act
-		var cut = RenderComponent<HxInputRange<int>>(parameters => parameters
+		var cut = Render<HxInputRange<int>>(parameters => parameters
 			.Add(p => p.Min, 0)
 			.Add(p => p.Max, 100)
 			.Bind(p => p.Value, currentValue, newValue => currentValue = newValue));
@@ -26,7 +26,7 @@ public class HxInputRangeTests : BunitTestBase
 		// Arrange
 		int currentValue = 25;
 
-		var cut = RenderComponent<HxInputRange<int>>(parameters => parameters
+		var cut = Render<HxInputRange<int>>(parameters => parameters
 			.Add(p => p.Min, 0)
 			.Add(p => p.Max, 100)
 			.Bind(p => p.Value, currentValue, newValue => currentValue = newValue));
@@ -45,7 +45,7 @@ public class HxInputRangeTests : BunitTestBase
 		int currentValue = 42;
 
 		// Act
-		var cut = RenderComponent<HxInputRange<int>>(parameters => parameters
+		var cut = Render<HxInputRange<int>>(parameters => parameters
 			.Add(p => p.Min, 0)
 			.Add(p => p.Max, 100)
 			.Add(p => p.Label, "Volume")

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputTextAreaTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxInputTextAreaTests.cs
@@ -13,7 +13,7 @@ public class HxInputTextAreaTests : BunitTestBase
 	{
 		// Arrange
 		string currentValue = null;
-		var cut = RenderComponent<HxInputTextArea>(parameters =>
+		var cut = Render<HxInputTextArea>(parameters =>
 			parameters.Bind(p =>
 				p.Value,
 				currentValue,

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSelectTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSelectTests.cs
@@ -13,7 +13,7 @@ public class HxSelectTests : BunitTestBase
 		Expression<Func<string>> valueExpression = () => selectedValue;
 
 		// Act
-		var cut = RenderComponent<HxSelect<string, string>>(parameters => parameters
+		var cut = Render<HxSelect<string, string>>(parameters => parameters
 			.Add(p => p.Data, items)
 			.Add(p => p.Value, selectedValue)
 			.Add(p => p.ValueChanged, value => selectedValue = value)
@@ -37,7 +37,7 @@ public class HxSelectTests : BunitTestBase
 		string selectedValue = null;
 		Expression<Func<string>> valueExpression = () => selectedValue;
 
-		var cut = RenderComponent<HxSelect<string, string>>(parameters => parameters
+		var cut = Render<HxSelect<string, string>>(parameters => parameters
 			.Add(p => p.Data, items)
 			.Add(p => p.Value, selectedValue)
 			.Add(p => p.ValueChanged, value => selectedValue = value)
@@ -66,7 +66,7 @@ public class HxSelectTests : BunitTestBase
 		Expression<Func<string>> valueExpression = () => selectedValue;
 
 		// Act
-		var cut = RenderComponent<HxSelect<string, string>>(parameters => parameters
+		var cut = Render<HxSelect<string, string>>(parameters => parameters
 			.Add(p => p.Data, items)
 			.Add(p => p.Value, selectedValue)
 			.Add(p => p.ValueChanged, value => selectedValue = value)

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSwitchTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Forms/HxSwitchTests.cs
@@ -44,7 +44,7 @@ public class HxSwitchTests : BunitTestBase
 		Assert.False(cut.Find("input").HasAttribute("checked"));
 	}
 
-	private (IRenderedFragment cut, bool[] valueHolder) RenderSwitch(bool initialValue = false)
+	private (IRenderedComponent<HxSwitch> cut, bool[] valueHolder) RenderSwitch(bool initialValue = false)
 	{
 		var valueHolder = new bool[] { initialValue };
 
@@ -57,6 +57,6 @@ public class HxSwitchTests : BunitTestBase
 			builder.CloseComponent();
 		};
 
-		return (Render(componentRenderer), valueHolder);
+		return (Render<HxSwitch>(componentRenderer), valueHolder);
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Accessibility_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Accessibility_Tests.cs
@@ -16,7 +16,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 		var items = Enumerable.Range(1, 3).Select(i => new TestItem(i, $"Item {i}")).ToList();
 		Task<GridDataProviderResult<TestItem>> dataProvider(GridDataProviderRequest<TestItem> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -36,7 +36,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 		var items = Enumerable.Range(1, 3).Select(i => new TestItem(i, $"Item {i}")).ToList();
 		Task<GridDataProviderResult<TestItem>> dataProvider(GridDataProviderRequest<TestItem> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -63,7 +63,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 		var items = Enumerable.Range(1, 3).Select(i => new TestItem(i, $"Item {i}")).ToList();
 		Task<GridDataProviderResult<TestItem>> dataProvider(GridDataProviderRequest<TestItem> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -95,7 +95,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 
 		Expression<Func<TestItem, IComparable>> sortKeySelector = item => item.Name;
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -121,7 +121,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 
 		Expression<Func<TestItem, IComparable>> sortKeySelector = item => item.Name;
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -144,7 +144,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 		var items = Enumerable.Range(1, 3).Select(i => new TestItem(i, $"Item {i}")).ToList();
 		Task<GridDataProviderResult<TestItem>> dataProvider(GridDataProviderRequest<TestItem> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -177,7 +177,7 @@ public class HxGrid_Accessibility_Tests : BunitTestBase
 
 		Expression<Func<TestItem, IComparable>> sortKeySelector = item => item.Name;
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Basic_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Basic_Tests.cs
@@ -16,7 +16,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 
 		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -48,7 +48,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 
 		Expression<Func<TestItem, IComparable>> sortKeySelector = item => item.Name;
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -84,7 +84,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 
 		Expression<Func<TestItem, IComparable>> sortKeySelector = item => item.Name;
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -109,7 +109,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) =>
 			Task.FromResult(new GridDataProviderResult<TestItem> { Data = [], TotalCount = 0 });
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -129,7 +129,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) =>
 			Task.FromResult(new GridDataProviderResult<TestItem> { Data = [], TotalCount = 0 });
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.EmptyDataTemplate, (RenderFragment)(builder =>
 			{
@@ -158,7 +158,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) =>
 			Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")
@@ -182,7 +182,7 @@ public class HxGrid_Basic_Tests : BunitTestBase
 		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) =>
 			Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<TestItem>>(parameters => parameters
+		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add<HxGridColumn<TestItem>>(p => p.Columns, column => column
 				.Add(c => c.HeaderText, "Name")

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Cancellation_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Cancellation_Tests.cs
@@ -30,11 +30,11 @@ public class HxGrid_Cancellation_Tests : BunitTestBase
 			}
 		};
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider));
 
 		// Act
-		DisposeComponents();
+		await DisposeComponentsAsync();
 		disposedTCS.SetResult(); // signal that the component is disposed
 		var wasCancellationRequested = await dataProviderTCS.Task;
 
@@ -76,11 +76,11 @@ public class HxGrid_Cancellation_Tests : BunitTestBase
 			}
 		};
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider));
 
 		// Act
-		DisposeComponents();
+		await DisposeComponentsAsync();
 		disposedTCS.SetResult(); // signal that the component is disposed
 		var wasCancellationRequested = await dataProviderTCS.Task;
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_LoadMore_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_LoadMore_Tests.cs
@@ -22,7 +22,7 @@ public class HxGrid_LoadMore_Tests : BunitTestBase
 			return request.ApplyTo(items);
 		};
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.PageSize, 10)
 			.Add(p => p.ContentNavigationMode, GridContentNavigationMode.LoadMore)

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_PreserveSelection_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_PreserveSelection_Tests.cs
@@ -11,14 +11,14 @@ public class HxGrid_PreserveSelection_Tests : BunitTestBase
 
 		GridDataProviderDelegate<object> dataProvider = (GridDataProviderRequest<object> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.PageSize, 10) // selectedItem visible
 			.Bind(p => p.SelectedDataItem, selectedItem, newValue => selectedItem = newValue, () => selectedItem)
 			.Add(p => p.PreserveSelection, false));
 
 		// Act
-		cut.SetParametersAndRender(parameters => parameters
+		cut.Render(parameters => parameters
 			.Add(p => p.PageSize, 5)); // selectedItem no longer visible
 
 		// Assert
@@ -34,14 +34,14 @@ public class HxGrid_PreserveSelection_Tests : BunitTestBase
 
 		GridDataProviderDelegate<object> dataProvider = (GridDataProviderRequest<object> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.PageSize, 10) // selectedItem visible
 			.Bind(p => p.SelectedDataItems, selectedItems, newValue => selectedItems = newValue, () => selectedItems)
 			.Add(p => p.PreserveSelection, false));
 
 		// Act
-		cut.SetParametersAndRender(parameters => parameters
+		cut.Render(parameters => parameters
 			.Add(p => p.PageSize, 5)); // someItems no longer visible
 
 		// Assert
@@ -57,7 +57,7 @@ public class HxGrid_PreserveSelection_Tests : BunitTestBase
 
 		GridDataProviderDelegate<object> dataProvider = (GridDataProviderRequest<object> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.PageSize, 10) // selectedItem visible
 			.Bind(p => p.SelectedDataItem, selectedItem, newValue => selectedItem = newValue, () => selectedItem)
@@ -79,14 +79,14 @@ public class HxGrid_PreserveSelection_Tests : BunitTestBase
 
 		GridDataProviderDelegate<object> dataProvider = (GridDataProviderRequest<object> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.PageSize, 10) // selectedItem visible
 			.Bind(p => p.SelectedDataItem, selectedItem, newValue => selectedItem = newValue, () => selectedItem)
 			.Add(p => p.PreserveSelection, true));
 
 		// Act
-		cut.SetParametersAndRender(parameters => parameters
+		cut.Render(parameters => parameters
 			.Add(p => p.PageSize, 5)); // selectedItem no longer visible
 
 		// Assert
@@ -102,14 +102,14 @@ public class HxGrid_PreserveSelection_Tests : BunitTestBase
 
 		GridDataProviderDelegate<object> dataProvider = (GridDataProviderRequest<object> request) => Task.FromResult(request.ApplyTo(items));
 
-		var cut = RenderComponent<HxGrid<object>>(parameters => parameters
+		var cut = Render<HxGrid<object>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
 			.Add(p => p.PageSize, 10) // selectedItem visible
 			.Bind(p => p.SelectedDataItems, selectedItems, newValue => selectedItems = newValue, () => selectedItems)
 			.Add(p => p.PreserveSelection, true));
 
 		// Act
-		cut.SetParametersAndRender(parameters => parameters
+		cut.Render(parameters => parameters
 			.Add(p => p.PageSize, 5)); // someItems no longer visible
 
 		// Assert

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxPager_Basic_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxPager_Basic_Tests.cs
@@ -9,7 +9,7 @@ public class HxPager_Basic_Tests : BunitTestBase
 	public void HxPager_Render_ShowsCorrectPageCount()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxPager>(parameters => parameters
+		var cut = Render<HxPager>(parameters => parameters
 			.Add(p => p.TotalPages, 5)
 			.Add(p => p.CurrentPageIndex, 0));
 
@@ -30,7 +30,7 @@ public class HxPager_Basic_Tests : BunitTestBase
 	{
 		// Arrange
 		int currentPageIndex = 0;
-		var cut = RenderComponent<HxPager>(parameters => parameters
+		var cut = Render<HxPager>(parameters => parameters
 			.Add(p => p.TotalPages, 3)
 			.Add(p => p.CurrentPageIndex, currentPageIndex)
 			.Add(p => p.CurrentPageIndexChanged, (int newIndex) => currentPageIndex = newIndex));
@@ -50,7 +50,7 @@ public class HxPager_Basic_Tests : BunitTestBase
 		using (CultureInfoExt.EnterScope(CultureInfo.GetCultureInfo("en-US")))
 		{
 			// Arrange & Act
-			var cut = RenderComponent<HxPager>(parameters => parameters
+			var cut = Render<HxPager>(parameters => parameters
 				.Add(p => p.TotalPages, 5)
 				.Add(p => p.CurrentPageIndex, 0));
 
@@ -69,7 +69,7 @@ public class HxPager_Basic_Tests : BunitTestBase
 		using (CultureInfoExt.EnterScope(CultureInfo.GetCultureInfo("en-US")))
 		{
 			// Arrange & Act
-			var cut = RenderComponent<HxPager>(parameters => parameters
+			var cut = Render<HxPager>(parameters => parameters
 				.Add(p => p.TotalPages, 25)
 				.Add(p => p.CurrentPageIndex, 10));
 
@@ -91,7 +91,7 @@ public class HxPager_Basic_Tests : BunitTestBase
 		using (CultureInfoExt.EnterScope(CultureInfo.GetCultureInfo("en-US")))
 		{
 			// Arrange & Act
-			var cut = RenderComponent<HxPager>(parameters => parameters
+			var cut = Render<HxPager>(parameters => parameters
 				.Add(p => p.TotalPages, 5)
 				.Add(p => p.CurrentPageIndex, 0));
 
@@ -113,7 +113,7 @@ public class HxPager_Basic_Tests : BunitTestBase
 		using (CultureInfoExt.EnterScope(CultureInfo.GetCultureInfo("en-US")))
 		{
 			// Arrange & Act
-			var cut = RenderComponent<HxPager>(parameters => parameters
+			var cut = Render<HxPager>(parameters => parameters
 				.Add(p => p.TotalPages, 5)
 				.Add(p => p.CurrentPageIndex, 0));
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Havit.Blazor.Components.Web.Bootstrap.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Havit.Blazor.Components.Web.Bootstrap.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="bunit.web" />
+		<PackageReference Include="bunit" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAccordionTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAccordionTests.cs
@@ -8,7 +8,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordion_Render_HasAccordionStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.AddChildContent<HxAccordionItem>(item => item
 				.Add(i => i.Id, "item1")
 				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header 1")))
@@ -24,7 +24,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordion_MultipleItems_RendersAllItems()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.AddChildContent(builder =>
 			{
 				builder.OpenComponent<HxAccordionItem>(0);
@@ -55,7 +55,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordionItem_Render_HasCorrectStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.AddChildContent<HxAccordionItem>(item => item
 				.Add(i => i.Id, "item1")
 				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header Text")))
@@ -84,7 +84,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordionItem_DataBsTarget_MatchesCollapseId()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.AddChildContent<HxAccordionItem>(item => item
 				.Add(i => i.Id, "testitem")
 				.Add(i => i.HeaderTemplate, (RenderFragment)(b => b.AddContent(0, "Header")))
@@ -105,7 +105,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordion_StayOpenFalse_SetsDataBsParent()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.Add(a => a.StayOpen, false)
 			.AddChildContent<HxAccordionItem>(item => item
 				.Add(i => i.Id, "item1")
@@ -125,7 +125,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordion_StayOpenTrue_NoDataBsParent()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.Add(a => a.StayOpen, true)
 			.AddChildContent<HxAccordionItem>(item => item
 				.Add(i => i.Id, "item1")
@@ -142,7 +142,7 @@ public class HxAccordionTests : BunitTestBase
 	public void HxAccordion_CssClass_IsApplied()
 	{
 		// Act
-		var cut = RenderComponent<HxAccordion>(p => p
+		var cut = Render<HxAccordion>(p => p
 			.Add(a => a.CssClass, "custom-accordion")
 			.AddChildContent<HxAccordionItem>(item => item
 				.Add(i => i.Id, "item1")

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAlertTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxAlertTests.cs
@@ -6,7 +6,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_Color_RendersCorrectCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, ThemeColor.Primary)
 			.AddChildContent("Test alert"));
 
@@ -27,7 +27,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_Color_AllThemeColors(ThemeColor color, string expectedCss)
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, color)
 			.AddChildContent("Content"));
 
@@ -40,7 +40,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_ChildContent_IsRendered()
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, ThemeColor.Info)
 			.AddChildContent("<strong>Hello</strong> World"));
 
@@ -54,7 +54,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_Dismissible_AddsCloseButton()
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, ThemeColor.Warning)
 			.Add(a => a.Dismissible, true)
 			.AddChildContent("Dismissible alert"));
@@ -74,7 +74,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_NotDismissible_NoCloseButton()
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, ThemeColor.Success)
 			.Add(a => a.Dismissible, false)
 			.AddChildContent("Non-dismissible alert"));
@@ -89,7 +89,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_HasRoleAttribute()
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, ThemeColor.Primary)
 			.AddChildContent("Alert"));
 
@@ -102,7 +102,7 @@ public class HxAlertTests : BunitTestBase
 	public void HxAlert_CssClass_IsApplied()
 	{
 		// Act
-		var cut = RenderComponent<HxAlert>(p => p
+		var cut = Render<HxAlert>(p => p
 			.Add(a => a.Color, ThemeColor.Primary)
 			.Add(a => a.CssClass, "my-custom-class")
 			.AddChildContent("Alert"));

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxBadgeTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxBadgeTests.cs
@@ -6,7 +6,7 @@ public class HxBadgeTests : BunitTestBase
 	public void HxBadge_Render_DisplaysContent()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxBadge>(parameters => parameters
+		var cut = Render<HxBadge>(parameters => parameters
 			.Add(p => p.Color, ThemeColor.Primary)
 			.AddChildContent("New")
 		);
@@ -19,7 +19,7 @@ public class HxBadgeTests : BunitTestBase
 	public void HxBadge_Color_AppliesCorrectCssClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxBadge>(parameters => parameters
+		var cut = Render<HxBadge>(parameters => parameters
 			.Add(p => p.Color, ThemeColor.Primary)
 		);
 
@@ -31,7 +31,7 @@ public class HxBadgeTests : BunitTestBase
 	public void HxBadge_RoundedPill_AppliesPillClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxBadge>(parameters => parameters
+		var cut = Render<HxBadge>(parameters => parameters
 			.Add(p => p.Color, ThemeColor.Primary)
 			.Add(p => p.Type, BadgeType.RoundedPill)
 		);

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxBootstrapIconTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxBootstrapIconTests.cs
@@ -6,7 +6,7 @@ public class HxBootstrapIconTests : BunitTestBase
 	public void HxBootstrapIcon_Render_OutputsIconElement()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxIcon>(parameters => parameters
+		var cut = Render<HxIcon>(parameters => parameters
 			.Add(p => p.Icon, BootstrapIcon.Alarm)
 		);
 
@@ -19,7 +19,7 @@ public class HxBootstrapIconTests : BunitTestBase
 	public void HxBootstrapIcon_Icon_AppliesCorrectCssClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxIcon>(parameters => parameters
+		var cut = Render<HxIcon>(parameters => parameters
 			.Add(p => p.Icon, BootstrapIcon.Alarm)
 		);
 
@@ -32,7 +32,7 @@ public class HxBootstrapIconTests : BunitTestBase
 	public void HxBootstrapIcon_CssClass_IsApplied()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxIcon>(parameters => parameters
+		var cut = Render<HxIcon>(parameters => parameters
 			.Add(p => p.Icon, BootstrapIcon.Alarm)
 			.Add(p => p.CssClass, "my-custom-class")
 		);

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxBreadcrumbTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxBreadcrumbTests.cs
@@ -6,7 +6,7 @@ public class HxBreadcrumbTests : BunitTestBase
 	public void HxBreadcrumb_Render_DisplaysAllItems()
 	{
 		// Act
-		var cut = RenderComponent<HxBreadcrumb>(parameters => parameters
+		var cut = Render<HxBreadcrumb>(parameters => parameters
 			.AddChildContent<HxBreadcrumbItem>(item => item
 				.Add(i => i.Href, "/home")
 				.Add(i => i.Text, "Home"))
@@ -30,7 +30,7 @@ public class HxBreadcrumbTests : BunitTestBase
 	public void HxBreadcrumb_ActiveItem_HasNoLink()
 	{
 		// Act
-		var cut = RenderComponent<HxBreadcrumb>(parameters => parameters
+		var cut = Render<HxBreadcrumb>(parameters => parameters
 			.AddChildContent<HxBreadcrumbItem>(item => item
 				.Add(i => i.Href, "/home")
 				.Add(i => i.Text, "Home"))
@@ -51,7 +51,7 @@ public class HxBreadcrumbTests : BunitTestBase
 	public void HxBreadcrumb_NonActiveItems_RenderLinksWithHrefs()
 	{
 		// Act
-		var cut = RenderComponent<HxBreadcrumb>(parameters => parameters
+		var cut = Render<HxBreadcrumb>(parameters => parameters
 			.AddChildContent<HxBreadcrumbItem>(item => item
 				.Add(i => i.Href, "/home")
 				.Add(i => i.Text, "Home"))

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxCalendarTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxCalendarTests.cs
@@ -12,7 +12,7 @@ public class HxCalendarTests : BunitTestBase
 		var displayMonth = new DateTime(2025, 6, 1);
 
 		// Act
-		var cut = RenderComponent<HxCalendar>(parameters => parameters
+		var cut = Render<HxCalendar>(parameters => parameters
 			.Add(p => p.DisplayMonth, displayMonth)
 			.Add(p => p.DisplayMonthChanged, (DateTime _) => { })
 		);
@@ -33,7 +33,7 @@ public class HxCalendarTests : BunitTestBase
 		var displayMonth = new DateTime(2025, 3, 1);
 		DateTime? reportedMonth = null;
 
-		var cut = RenderComponent<HxCalendar>(parameters => parameters
+		var cut = Render<HxCalendar>(parameters => parameters
 			.Add(p => p.DisplayMonth, displayMonth)
 			.Add(p => p.DisplayMonthChanged, (DateTime newMonth) => { reportedMonth = newMonth; })
 		);
@@ -55,7 +55,7 @@ public class HxCalendarTests : BunitTestBase
 		var displayMonth = new DateTime(2025, 3, 1);
 		DateTime? reportedMonth = null;
 
-		var cut = RenderComponent<HxCalendar>(parameters => parameters
+		var cut = Render<HxCalendar>(parameters => parameters
 			.Add(p => p.DisplayMonth, displayMonth)
 			.Add(p => p.DisplayMonthChanged, (DateTime newMonth) => { reportedMonth = newMonth; })
 		);
@@ -79,7 +79,7 @@ public class HxCalendarTests : BunitTestBase
 			var displayMonth = new DateTime(2025, 3, 1);
 			DateTime? selectedValue = null;
 
-			var cut = RenderComponent<HxCalendar>(parameters => parameters
+			var cut = Render<HxCalendar>(parameters => parameters
 				.Add(p => p.DisplayMonth, displayMonth)
 				.Add(p => p.DisplayMonthChanged, (DateTime _) => { })
 				.Add(p => p.ValueChanged, (DateTime? newValue) => { selectedValue = newValue; })
@@ -105,7 +105,7 @@ public class HxCalendarTests : BunitTestBase
 			var selectedDate = new DateTime(2025, 3, 20);
 
 			// Act
-			var cut = RenderComponent<HxCalendar>(parameters => parameters
+			var cut = Render<HxCalendar>(parameters => parameters
 				.Add(p => p.Value, selectedDate)
 				.Add(p => p.ValueChanged, (DateTime? _) => { })
 				.Add(p => p.DisplayMonth, new DateTime(2025, 3, 1))
@@ -123,7 +123,7 @@ public class HxCalendarTests : BunitTestBase
 	public void HxCalendar_AllButtons_HaveTypeButton()
 	{
 		// Arrange & Act — regression for #1064: calendar buttons must not submit forms
-		var cut = RenderComponent<HxCalendar>(parameters => parameters
+		var cut = Render<HxCalendar>(parameters => parameters
 			.Add(p => p.DisplayMonth, new DateTime(2025, 3, 1))
 			.Add(p => p.DisplayMonthChanged, (DateTime _) => { }));
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxContextMenuTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxContextMenuTests.cs
@@ -6,7 +6,7 @@ public class HxContextMenuTests : BunitTestBase
 	public void HxContextMenu_Render_HasContextMenuStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxContextMenu>(p => p
+		var cut = Render<HxContextMenu>(p => p
 			.AddChildContent<HxContextMenuItem>(item => item
 				.Add(i => i.Text, "Action 1")));
 
@@ -27,7 +27,7 @@ public class HxContextMenuTests : BunitTestBase
 	public void HxContextMenu_RendersDropdownMenu()
 	{
 		// Act
-		var cut = RenderComponent<HxContextMenu>(p => p
+		var cut = Render<HxContextMenu>(p => p
 			.AddChildContent<HxContextMenuItem>(item => item
 				.Add(i => i.Text, "Action 1")));
 
@@ -40,7 +40,7 @@ public class HxContextMenuTests : BunitTestBase
 	public void HxContextMenuItem_RendersCorrectStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxContextMenu>(p => p
+		var cut = Render<HxContextMenu>(p => p
 			.AddChildContent<HxContextMenuItem>(item => item
 				.Add(i => i.Text, "Edit")));
 
@@ -57,7 +57,7 @@ public class HxContextMenuTests : BunitTestBase
 	public void HxContextMenuItem_Disabled_HasDisabledCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxContextMenu>(p => p
+		var cut = Render<HxContextMenu>(p => p
 			.AddChildContent<HxContextMenuItem>(item => item
 				.Add(i => i.Text, "Disabled action")
 				.Add(i => i.Enabled, false)));
@@ -71,7 +71,7 @@ public class HxContextMenuTests : BunitTestBase
 	public void HxContextMenuItem_Enabled_NoDisabledCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxContextMenu>(p => p
+		var cut = Render<HxContextMenu>(p => p
 			.AddChildContent<HxContextMenuItem>(item => item
 				.Add(i => i.Text, "Active action")
 				.Add(i => i.Enabled, true)));
@@ -85,7 +85,7 @@ public class HxContextMenuTests : BunitTestBase
 	public void HxContextMenu_MultipleItems_RendersAll()
 	{
 		// Act
-		var cut = RenderComponent<HxContextMenu>(p => p
+		var cut = Render<HxContextMenu>(p => p
 			.AddChildContent(builder =>
 			{
 				builder.OpenComponent<HxContextMenuItem>(0);

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxDropdownTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxDropdownTests.cs
@@ -6,7 +6,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdown_DefaultDirection_HasDropdownCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent("Content"));
 
 		// Assert
@@ -22,7 +22,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdown_Direction_CorrectCssClass(DropdownDirection direction, string expectedCss)
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.Add(d => d.Direction, direction)
 			.AddChildContent("Content"));
 
@@ -35,7 +35,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdown_CssClass_IsApplied()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.Add(d => d.CssClass, "my-dropdown")
 			.AddChildContent("Content"));
 
@@ -48,7 +48,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownToggleElement_RendersDataBsToggle()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent<HxDropdownToggleElement>(toggle => toggle
 				.AddChildContent("Toggle")));
 
@@ -62,7 +62,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownMenu_RendersDropdownMenuCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent<HxDropdownMenu>(menu => menu
 				.AddChildContent("Menu content")));
 
@@ -75,7 +75,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownItem_RendersCorrectStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent<HxDropdownMenu>(menu => menu
 				.AddChildContent<HxDropdownItem>(item => item
 					.AddChildContent("Item text"))));
@@ -94,7 +94,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownItem_DisabledFalse_HasDisabledCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent<HxDropdownMenu>(menu => menu
 				.AddChildContent<HxDropdownItem>(item => item
 					.Add(i => i.Enabled, false)
@@ -109,7 +109,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownDivider_RendersDividerStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent<HxDropdownMenu>(menu => menu
 				.AddChildContent<HxDropdownDivider>()));
 
@@ -122,7 +122,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownHeader_RendersHeaderStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdown>(p => p
+		var cut = Render<HxDropdown>(p => p
 			.AddChildContent<HxDropdownMenu>(menu => menu
 				.AddChildContent<HxDropdownHeader>(header => header
 					.AddChildContent("Section title"))));
@@ -137,7 +137,7 @@ public class HxDropdownTests : BunitTestBase
 	public void HxDropdownButtonGroup_HasBtnGroupClass()
 	{
 		// Act
-		var cut = RenderComponent<HxDropdownButtonGroup>(p => p
+		var cut = Render<HxDropdownButtonGroup>(p => p
 			.AddChildContent("Content"));
 
 		// Assert

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxFilterFormTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxFilterFormTests.cs
@@ -14,7 +14,7 @@ public class HxFilterFormTests : BunitTestBase
 		var model = new FilterModel { Name = "Test" };
 
 		// Act
-		var cut = RenderComponent<HxFilterForm<FilterModel>>(parameters => parameters
+		var cut = Render<HxFilterForm<FilterModel>>(parameters => parameters
 			.Add(p => p.Model, model)
 			.Add(p => p.ChildContent, (FilterModel m) => (RenderTreeBuilder builder) =>
 			{
@@ -40,7 +40,7 @@ public class HxFilterFormTests : BunitTestBase
 		var model = new FilterModel { Name = "Initial" };
 		FilterModel updatedModel = null;
 
-		var cut = RenderComponent<HxFilterForm<FilterModel>>(parameters => parameters
+		var cut = Render<HxFilterForm<FilterModel>>(parameters => parameters
 			.Add(p => p.Model, model)
 			.Add(p => p.ModelChanged, (FilterModel m) => updatedModel = m)
 			.Add(p => p.ChildContent, (FilterModel m) => (RenderTreeBuilder builder) =>
@@ -70,7 +70,7 @@ public class HxFilterFormTests : BunitTestBase
 		var initialModel = new FilterModel { Name = "ActiveFilter" };
 		var defaultModel = new FilterModel { Name = null };
 
-		var cut = RenderComponent<HxFilterForm<FilterModel>>(parameters => parameters
+		var cut = Render<HxFilterForm<FilterModel>>(parameters => parameters
 			.Add(p => p.Model, initialModel)
 			.Add(p => p.ChildContent, (FilterModel m) => (RenderTreeBuilder builder) =>
 			{
@@ -85,7 +85,7 @@ public class HxFilterFormTests : BunitTestBase
 		Assert.Equal("ActiveFilter", cut.Find("#filter-name").TextContent);
 
 		// Act — reset by providing a new default model from outside
-		cut.SetParametersAndRender(parameters => parameters
+		cut.Render(parameters => parameters
 			.Add(p => p.Model, defaultModel)
 		);
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxListGroupTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxListGroupTests.cs
@@ -6,7 +6,7 @@ public class HxListGroupTests : BunitTestBase
 	public void HxListGroup_Render_DisplaysAllItems()
 	{
 		// Act
-		var cut = RenderComponent<HxListGroup>(parameters => parameters
+		var cut = Render<HxListGroup>(parameters => parameters
 			.AddChildContent<HxListGroupItem>(item => item
 				.AddChildContent("First item"))
 			.AddChildContent<HxListGroupItem>(item => item
@@ -29,7 +29,7 @@ public class HxListGroupTests : BunitTestBase
 		// Arrange
 		int clickCount = 0;
 
-		var cut = RenderComponent<HxListGroup>(parameters => parameters
+		var cut = Render<HxListGroup>(parameters => parameters
 			.AddChildContent<HxListGroupItem>(item => item
 				.Add(i => i.OnClick, () => clickCount++)
 				.AddChildContent("Clickable item"))
@@ -46,7 +46,7 @@ public class HxListGroupTests : BunitTestBase
 	public void HxListGroup_ActiveItem_HasActiveClass()
 	{
 		// Act
-		var cut = RenderComponent<HxListGroup>(parameters => parameters
+		var cut = Render<HxListGroup>(parameters => parameters
 			.AddChildContent<HxListGroupItem>(item => item
 				.Add(i => i.Active, false)
 				.AddChildContent("Inactive item"))

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxListLayoutTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxListLayoutTests.cs
@@ -13,7 +13,7 @@ public class HxListLayoutTests : BunitTestBase
 	public void HxListLayout_Render_DisplaysGridAndFilterArea()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxListLayout<TestFilterModel>>(parameters => parameters
+		var cut = Render<HxListLayout<TestFilterModel>>(parameters => parameters
 			.Add(p => p.Title, "Test Title")
 			.Add(p => p.FilterModel, new TestFilterModel())
 			.Add(p => p.DataTemplate, (RenderFragment)(builder =>
@@ -51,7 +51,7 @@ public class HxListLayoutTests : BunitTestBase
 		var filterModel = new TestFilterModel { Name = "Initial" };
 		TestFilterModel appliedFilter = null;
 
-		var cut = RenderComponent<HxListLayout<TestFilterModel>>(parameters => parameters
+		var cut = Render<HxListLayout<TestFilterModel>>(parameters => parameters
 			.Add(p => p.FilterModel, filterModel)
 			.Add(p => p.FilterModelChanged, newFilter => appliedFilter = newFilter)
 			.Add(p => p.FilterTemplate, (RenderFragment<TestFilterModel>)(model => builder => { })));
@@ -70,7 +70,7 @@ public class HxListLayoutTests : BunitTestBase
 		// Arrange
 		var filterModel = new TestFilterModel { Name = "ActiveFilter" };
 
-		var cut = RenderComponent<HxListLayout<TestFilterModel>>(parameters => parameters
+		var cut = Render<HxListLayout<TestFilterModel>>(parameters => parameters
 			.Add(p => p.FilterModel, filterModel)
 			.Add(p => p.FilterTemplate, (RenderFragment<TestFilterModel>)(model => builder =>
 			{
@@ -95,7 +95,7 @@ public class HxListLayoutTests : BunitTestBase
 		var filterModel = new TestFilterModel { Name = "FilterToRemove" };
 		TestFilterModel updatedFilter = null;
 
-		var cut = RenderComponent<HxListLayout<TestFilterModel>>(parameters => parameters
+		var cut = Render<HxListLayout<TestFilterModel>>(parameters => parameters
 			.Add(p => p.FilterModel, filterModel)
 			.Add(p => p.FilterModelChanged, newFilter => updatedFilter = newFilter)
 			.Add(p => p.FilterTemplate, (RenderFragment<TestFilterModel>)(model => builder =>
@@ -129,7 +129,7 @@ public class HxListLayoutTests : BunitTestBase
 	public void HxListLayout_FilterButton_HasAriaLabel()
 	{
 		// Arrange — regression for #1190: filter button must have aria-label for accessibility
-		var cut = RenderComponent<HxListLayout<TestFilterModel>>(parameters => parameters
+		var cut = Render<HxListLayout<TestFilterModel>>(parameters => parameters
 			.Add(p => p.FilterModel, new TestFilterModel())
 			.Add(p => p.FilterTemplate, (RenderFragment<TestFilterModel>)(model => builder => { }))
 			.Add(p => p.DataTemplate, (RenderFragment)(builder => { })));

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMarkdownTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxMarkdownTests.cs
@@ -8,7 +8,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_NullContent_RendersNothing()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, null)
 		);
 
@@ -20,7 +20,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_EmptyContent_RendersNothing()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "")
 		);
 
@@ -32,7 +32,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_SimpleText_RendersParagraph()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "Hello world")
 		);
 
@@ -45,7 +45,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_Heading_RendersH1()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "# My Heading")
 		);
 
@@ -61,7 +61,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_NoWrapperByDefault()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "Text")
 		);
 
@@ -73,7 +73,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_CssClass_RendersWrapperDiv()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "Text")
 			.Add(p => p.CssClass, "my-class")
 		);
@@ -88,7 +88,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_AdditionalAttributes_RendersWrapperDiv()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "Text")
 			.AddUnmatched("id", "my-md")
 		);
@@ -106,7 +106,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_SanitizeHtml_DefaultTrue_EscapesHtml()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "<b>bold</b>")
 		);
 
@@ -119,7 +119,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_SanitizeHtml_False_PreservesHtml()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "<b>bold</b>")
 			.Add(p => p.SanitizeHtml, false)
 		);
@@ -141,7 +141,7 @@ public class HxMarkdownTests : BunitTestBase
 		};
 
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "| A |\n|---|\n| 1 |")
 			.Add(p => p.Settings, settings)
 		);
@@ -160,7 +160,7 @@ public class HxMarkdownTests : BunitTestBase
 		};
 
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "| A |\n|---|\n| 1 |")
 			.Add(p => p.Settings, settings)
 			.Add(p => p.TableCssClass, "custom-table")
@@ -175,7 +175,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_Defaults_ApplyTableClass()
 	{
 		// Act – use default settings (table class = "table")
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "| A |\n|---|\n| 1 |")
 		);
 
@@ -188,7 +188,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_Defaults_ApplyBlockquoteClass()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "> Quote")
 		);
 
@@ -201,7 +201,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_Defaults_ApplyImageClass()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "![Alt](https://example.com/img.png)")
 		);
 
@@ -218,7 +218,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_CodeBlock_RendersPreCode()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "```\nvar x = 1;\n```")
 		);
 
@@ -230,7 +230,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_UnorderedList_RendersUl()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "- Item 1\n- Item 2")
 		);
 
@@ -242,7 +242,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_OrderedList_RendersOl()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "1. First\n2. Second")
 		);
 
@@ -254,7 +254,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_HorizontalRule_RendersHr()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "---")
 		);
 
@@ -266,7 +266,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_InlineBold_RendersStrong()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "This is **bold**")
 		);
 
@@ -278,7 +278,7 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_InlineLink_RendersAnchor()
 	{
 		// Act
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "[Click](https://example.com)")
 		);
 
@@ -296,13 +296,13 @@ public class HxMarkdownTests : BunitTestBase
 	public void HxMarkdown_ContentChange_UpdatesRenderedOutput()
 	{
 		// Arrange
-		var cut = RenderComponent<HxMarkdown>(parameters => parameters
+		var cut = Render<HxMarkdown>(parameters => parameters
 			.Add(p => p.Content, "# First")
 		);
 		Assert.Equal("First", cut.Find("h1").TextContent);
 
 		// Act
-		cut.SetParametersAndRender(parameters => parameters
+		cut.Render(parameters => parameters
 			.Add(p => p.Content, "## Second")
 		);
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxNavTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxNavTests.cs
@@ -9,7 +9,7 @@ public class HxNavTests : BunitTestBase
 	public void HxNav_Render_DisplaysLinks()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxNav>(parameters => parameters
+		var cut = Render<HxNav>(parameters => parameters
 			.AddChildContent<HxNavLink>(link => link
 				.Add(l => l.Text, "Home")
 				.Add(l => l.Href, "/")
@@ -31,10 +31,10 @@ public class HxNavTests : BunitTestBase
 	public void HxNav_ActiveRoute_LinkHasActiveClass()
 	{
 		// Arrange — navigate to /active-page so the matching link becomes active
-		Services.GetRequiredService<Bunit.TestDoubles.FakeNavigationManager>().NavigateTo("http://localhost/active-page");
+		Services.GetRequiredService<Bunit.TestDoubles.BunitNavigationManager>().NavigateTo("http://localhost/active-page");
 
 		// Act
-		var cut = RenderComponent<HxNav>(parameters => parameters
+		var cut = Render<HxNav>(parameters => parameters
 			.AddChildContent<HxNavLink>(link => link
 				.Add(l => l.Text, "Active")
 				.Add(l => l.Href, "/active-page")

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxOffcanvasTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxOffcanvasTests.cs
@@ -8,7 +8,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_RenderModeAlways_RendersStructure()
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.Title, "Test Title")
 			.Add(o => o.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body content"))));
@@ -33,7 +33,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_PlacementStart_HasCorrectCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.Placement, OffcanvasPlacement.Start)
 			.Add(o => o.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body"))));
@@ -51,7 +51,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_Placement_AllDirections(OffcanvasPlacement placement, string expectedCss)
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.Placement, placement)
 			.Add(o => o.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body"))));
@@ -65,7 +65,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_ShowCloseButtonTrue_RendersCloseButton()
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.ShowCloseButton, true)
 			.Add(o => o.Title, "Title")
@@ -81,7 +81,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_ShowCloseButtonFalse_NoCloseButton()
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.ShowCloseButton, false)
 			.Add(o => o.Title, "Title")
@@ -95,7 +95,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_FooterTemplate_RendersFooter()
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body")))
 			.Add(o => o.FooterTemplate, (RenderFragment)(b => b.AddContent(0, "Footer content"))));
@@ -110,7 +110,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_SizeLarge_HasSizeCssClass()
 	{
 		// Act
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.RenderMode, OffcanvasRenderMode.Always)
 			.Add(o => o.Size, OffcanvasSize.Large)
 			.Add(o => o.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body"))));
@@ -124,7 +124,7 @@ public class HxOffcanvasTests : BunitTestBase
 	public void HxOffcanvas_RenderModeOpenOnly_DoesNotRenderContentWhenClosed()
 	{
 		// Act - default RenderMode is OpenOnly
-		var cut = RenderComponent<HxOffcanvas>(p => p
+		var cut = Render<HxOffcanvas>(p => p
 			.Add(o => o.Title, "Title")
 			.Add(o => o.BodyTemplate, (RenderFragment)(b => b.AddContent(0, "Body"))));
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxPlaceholderTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxPlaceholderTests.cs
@@ -6,7 +6,7 @@ public class HxPlaceholderTests : BunitTestBase
 	public void HxPlaceholder_Render_OutputsPlaceholderElement()
 	{
 		// Act
-		var cut = RenderComponent<HxPlaceholder>();
+		var cut = Render<HxPlaceholder>();
 
 		// Assert
 		var element = cut.Find("span");
@@ -17,7 +17,7 @@ public class HxPlaceholderTests : BunitTestBase
 	public void HxPlaceholderContainer_AnimationGlow_AppliesGlowClass()
 	{
 		// Act
-		var cut = RenderComponent<HxPlaceholderContainer>(parameters => parameters
+		var cut = Render<HxPlaceholderContainer>(parameters => parameters
 			.Add(p => p.Animation, PlaceholderAnimation.Glow)
 			.AddChildContent("<span>content</span>"));
 
@@ -30,7 +30,7 @@ public class HxPlaceholderTests : BunitTestBase
 	public void HxPlaceholderContainer_AnimationWave_AppliesWaveClass()
 	{
 		// Act
-		var cut = RenderComponent<HxPlaceholderContainer>(parameters => parameters
+		var cut = Render<HxPlaceholderContainer>(parameters => parameters
 			.Add(p => p.Animation, PlaceholderAnimation.Wave)
 			.AddChildContent("<span>content</span>"));
 
@@ -43,7 +43,7 @@ public class HxPlaceholderTests : BunitTestBase
 	public void HxPlaceholderButton_Render_HasDisabledAppearance()
 	{
 		// Act
-		var cut = RenderComponent<HxPlaceholderButton>();
+		var cut = Render<HxPlaceholderButton>();
 
 		// Assert
 		var button = cut.Find("button");

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxPopoverTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxPopoverTests.cs
@@ -6,7 +6,7 @@ public class HxPopoverTests : BunitTestBase
 	public void HxPopover_Title_RendersDataBsToggle()
 	{
 		// Act
-		var cut = RenderComponent<HxPopover>(p => p
+		var cut = Render<HxPopover>(p => p
 			.Add(po => po.Title, "Popover title")
 			.AddChildContent("Click me"));
 
@@ -19,7 +19,7 @@ public class HxPopoverTests : BunitTestBase
 	public void HxPopover_Title_RendersDataBsTitle()
 	{
 		// Act
-		var cut = RenderComponent<HxPopover>(p => p
+		var cut = Render<HxPopover>(p => p
 			.Add(po => po.Title, "My Title")
 			.AddChildContent("Click me"));
 
@@ -32,7 +32,7 @@ public class HxPopoverTests : BunitTestBase
 	public void HxPopover_Content_RendersDataBsContent()
 	{
 		// Act
-		var cut = RenderComponent<HxPopover>(p => p
+		var cut = Render<HxPopover>(p => p
 			.Add(po => po.Title, "Title")
 			.Add(po => po.Content, "Popover body content")
 			.AddChildContent("Click me"));
@@ -46,7 +46,7 @@ public class HxPopoverTests : BunitTestBase
 	public void HxPopover_Placement_RendersDataBsPlacement()
 	{
 		// Act
-		var cut = RenderComponent<HxPopover>(p => p
+		var cut = Render<HxPopover>(p => p
 			.Add(po => po.Title, "Title")
 			.Add(po => po.Placement, PopoverPlacement.Left)
 			.AddChildContent("Click me"));
@@ -60,7 +60,7 @@ public class HxPopoverTests : BunitTestBase
 	public void HxPopover_ContentOnly_RendersSpan()
 	{
 		// Act - popover with content but no title should still render span
-		var cut = RenderComponent<HxPopover>(p => p
+		var cut = Render<HxPopover>(p => p
 			.Add(po => po.Content, "Just content")
 			.AddChildContent("Click me"));
 
@@ -74,7 +74,7 @@ public class HxPopoverTests : BunitTestBase
 	public void HxPopover_EmptyTitleAndContent_NoSpanWrapper()
 	{
 		// Act
-		var cut = RenderComponent<HxPopover>(p => p
+		var cut = Render<HxPopover>(p => p
 			.AddChildContent("Just content"));
 
 		// Assert - no span wrapper

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxProgressTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxProgressTests.cs
@@ -6,7 +6,7 @@ public class HxProgressTests : BunitTestBase
 	public void HxProgress_Render_OutputsProgressContainer()
 	{
 		// Act
-		var cut = RenderComponent<HxProgress>();
+		var cut = Render<HxProgress>();
 
 		// Assert
 		var progressDiv = cut.Find("div.progress");
@@ -17,7 +17,7 @@ public class HxProgressTests : BunitTestBase
 	public void HxProgressBar_Value_SetsCorrectWidth()
 	{
 		// Act
-		var cut = RenderComponent<HxProgress>(parameters => parameters
+		var cut = Render<HxProgress>(parameters => parameters
 			.AddChildContent<HxProgressBar>(bar => bar
 				.Add(b => b.Value, 50f)
 			)
@@ -32,7 +32,7 @@ public class HxProgressTests : BunitTestBase
 	public void HxProgressBar_Color_AppliesColorClass()
 	{
 		// Act
-		var cut = RenderComponent<HxProgress>(parameters => parameters
+		var cut = Render<HxProgress>(parameters => parameters
 			.AddChildContent<HxProgressBar>(bar => bar
 				.Add(b => b.Color, ThemeColor.Success)
 			)
@@ -47,7 +47,7 @@ public class HxProgressTests : BunitTestBase
 	public void HxProgressBar_Striped_AppliesStripedClass()
 	{
 		// Act
-		var cut = RenderComponent<HxProgress>(parameters => parameters
+		var cut = Render<HxProgress>(parameters => parameters
 			.AddChildContent<HxProgressBar>(bar => bar
 				.Add(b => b.Striped, true)
 			)
@@ -65,7 +65,7 @@ public class HxProgressTests : BunitTestBase
 		const string labelText = "Loading...";
 
 		// Act
-		var cut = RenderComponent<HxProgress>(parameters => parameters
+		var cut = Render<HxProgress>(parameters => parameters
 			.AddChildContent<HxProgressBar>(bar => bar
 				.Add(b => b.Label, labelText)
 			)
@@ -80,7 +80,7 @@ public class HxProgressTests : BunitTestBase
 	public void HxProgressBar_CustomMinMaxRange_CalculatesCorrectWidth()
 	{
 		// Act — regression for #813: HxProgressBar must work with custom MinValue/MaxValue range
-		var cut = RenderComponent<HxProgress>(parameters => parameters
+		var cut = Render<HxProgress>(parameters => parameters
 			.AddChildContent<HxProgressBar>(bar => bar
 				.Add(b => b.Value, 25f)
 				.Add(b => b.MinValue, 0f)

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxSpinnerTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxSpinnerTests.cs
@@ -6,7 +6,7 @@ public class HxSpinnerTests : BunitTestBase
 	public void HxSpinner_Render_DefaultBorderSpinner()
 	{
 		// Act
-		var cut = RenderComponent<HxSpinner>();
+		var cut = Render<HxSpinner>();
 
 		// Assert
 		Assert.True(cut.Find("div").ClassList.Contains("spinner-border"));
@@ -16,7 +16,7 @@ public class HxSpinnerTests : BunitTestBase
 	public void HxSpinner_TypeGrow_RendersGrowClass()
 	{
 		// Act
-		var cut = RenderComponent<HxSpinner>(parameters => parameters
+		var cut = Render<HxSpinner>(parameters => parameters
 			.Add(p => p.Type, SpinnerType.Grow)
 		);
 
@@ -28,7 +28,7 @@ public class HxSpinnerTests : BunitTestBase
 	public void HxSpinner_SizeSmall_RendersSizeClass()
 	{
 		// Act
-		var cut = RenderComponent<HxSpinner>(parameters => parameters
+		var cut = Render<HxSpinner>(parameters => parameters
 			.Add(p => p.Size, SpinnerSize.Small)
 		);
 

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTabPanelTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTabPanelTests.cs
@@ -10,7 +10,7 @@ public class HxTabPanelTests : BunitTestBase
 		string activeTabId = null;
 
 		// Act - Render component with async OnTabDeactivated callback
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, activeTabId)
 			.Add(p => p.ActiveTabIdChanged, newActiveTabId => activeTabId = newActiveTabId)
 			.AddChildContent<HxTab>(tab => tab
@@ -35,7 +35,7 @@ public class HxTabPanelTests : BunitTestBase
 		Assert.NotNull(component);
 
 		// Trigger a tab change to activate the callback
-		component.SetParametersAndRender(parameters => parameters
+		component.Render(parameters => parameters
 			.Add(p => p.ActiveTabId, "2")
 		);
 
@@ -52,7 +52,7 @@ public class HxTabPanelTests : BunitTestBase
 		string activeTabId = "1";
 
 		// Act - Render component
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, activeTabId)
 			.Add(p => p.ActiveTabIdChanged, newActiveTabId => activeTabId = newActiveTabId)
 			.AddChildContent<HxTab>(tab => tab
@@ -73,7 +73,7 @@ public class HxTabPanelTests : BunitTestBase
 		);
 
 		// Set the same parameters again (no actual change to active tab)
-		component.SetParametersAndRender(parameters => parameters
+		component.Render(parameters => parameters
 			.Add(p => p.ActiveTabId, activeTabId)
 		);
 
@@ -87,7 +87,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_Render_DisplaysAllTabHeaders()
 	{
 		// Act
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, "tab1")
 			.AddChildContent<HxTab>(tab => tab
 				.Add(t => t.Id, "tab1")
@@ -120,7 +120,7 @@ public class HxTabPanelTests : BunitTestBase
 		// Arrange
 		string activeTabId = "tab1";
 
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, activeTabId)
 			.Add(p => p.ActiveTabIdChanged, newId => activeTabId = newId)
 			.AddChildContent<HxTab>(tab => tab
@@ -148,7 +148,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_ActiveTab_HasActiveClass()
 	{
 		// Arrange & Act
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, "tab2")
 			.AddChildContent<HxTab>(tab => tab
 				.Add(t => t.Id, "tab1")
@@ -172,7 +172,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_FirstTab_ActiveByDefault()
 	{
 		// Act - Render without specifying ActiveTabId
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.AddChildContent<HxTab>(tab => tab
 				.Add(t => t.Id, "tab1")
 				.Add(t => t.Title, "First")
@@ -199,7 +199,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_AriaAttributes_ActiveTabHasCorrectRolesAndAttributes()
 	{
 		// Arrange & Act
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, "tab1")
 			.AddChildContent<HxTab>(tab => tab
 				.Add(t => t.Id, "tab1")
@@ -232,7 +232,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_AriaAttributes_TabPanelHasCorrectRoleAndLabelledBy()
 	{
 		// Arrange & Act
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, "tab1")
 			.AddChildContent<HxTab>(tab => tab
 				.Add(t => t.Id, "tab1")
@@ -253,7 +253,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_AriaAttributes_TablistRoleOnNav()
 	{
 		// Arrange & Act
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, "tab1")
 			.AddChildContent<HxTab>(tab => tab
 				.Add(t => t.Id, "tab1")
@@ -270,7 +270,7 @@ public class HxTabPanelTests : BunitTestBase
 	public void HxTabPanel_AriaAttributes_ActiveTabOnly_InactiveTabHasNoAriaControls()
 	{
 		// Arrange & Act
-		var component = RenderComponent<HxTabPanel>(parameters => parameters
+		var component = Render<HxTabPanel>(parameters => parameters
 			.Add(p => p.ActiveTabId, "tab1")
 			.Add(p => p.RenderMode, TabPanelRenderMode.ActiveTabOnly)
 			.AddChildContent<HxTab>(tab => tab
@@ -293,4 +293,4 @@ public class HxTabPanelTests : BunitTestBase
 		// Inactive tab should NOT have aria-controls (its panel is not in the DOM)
 		Assert.Null(navLinks[1].GetAttribute("aria-controls"));
 	}
-}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTabPanelTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTabPanelTests.cs
@@ -293,4 +293,4 @@ public class HxTabPanelTests : BunitTestBase
 		// Inactive tab should NOT have aria-controls (its panel is not in the DOM)
 		Assert.Null(navLinks[1].GetAttribute("aria-controls"));
 	}
-}
+}

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTooltipTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTooltipTests.cs
@@ -6,7 +6,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_Text_RendersDataBsToggle()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.Add(t => t.Text, "Tooltip text")
 			.AddChildContent("Hover me"));
 
@@ -19,7 +19,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_Text_RendersDataBsTitle()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.Add(t => t.Text, "My tooltip text")
 			.AddChildContent("Hover me"));
 
@@ -32,7 +32,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_Placement_RendersDataBsPlacement()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.Add(t => t.Text, "Tooltip")
 			.Add(t => t.Placement, TooltipPlacement.Bottom)
 			.AddChildContent("Hover me"));
@@ -46,7 +46,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_EmptyText_DoesNotRenderSpanWrapper()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.AddChildContent("Just content"));
 
 		// Assert - no span wrapper should be rendered, only the child content
@@ -59,7 +59,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_ChildContent_IsRenderedInsideSpan()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.Add(t => t.Text, "Tooltip text")
 			.AddChildContent("<em>Styled content</em>"));
 
@@ -72,7 +72,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_SpanWrapper_HasInlineBlockClass()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.Add(t => t.Text, "Tooltip")
 			.AddChildContent("Content"));
 
@@ -85,7 +85,7 @@ public class HxTooltipTests : BunitTestBase
 	public void HxTooltip_WrapperCssClass_IsApplied()
 	{
 		// Act
-		var cut = RenderComponent<HxTooltip>(p => p
+		var cut = Render<HxTooltip>(p => p
 			.Add(t => t.Text, "Tooltip")
 			.Add(t => t.WrapperCssClass, "my-wrapper")
 			.AddChildContent("Content"));

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTreeViewTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTreeViewTests.cs
@@ -36,7 +36,7 @@ public class HxTreeViewTests : BunitTestBase
 	public void HxTreeView_Render_DisplaysRootNodes()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxTreeView<TreeItem>>(parameters => parameters
+		var cut = Render<HxTreeView<TreeItem>>(parameters => parameters
 			.Add(p => p.Items, CreateTestData())
 			.Add(p => p.ItemTitleSelector, item => item.Title)
 			.Add(p => p.ItemChildrenSelector, item => item.Children)
@@ -59,7 +59,7 @@ public class HxTreeViewTests : BunitTestBase
 	public void HxTreeView_ExpandNode_ShowsChildren()
 	{
 		// Arrange & Act - Use ItemInitialExpandedSelector to expand Root1
-		var cut = RenderComponent<HxTreeView<TreeItem>>(parameters => parameters
+		var cut = Render<HxTreeView<TreeItem>>(parameters => parameters
 			.Add(p => p.Items, CreateTestData())
 			.Add(p => p.ItemTitleSelector, item => item.Title)
 			.Add(p => p.ItemChildrenSelector, item => item.Children)
@@ -81,7 +81,7 @@ public class HxTreeViewTests : BunitTestBase
 	public void HxTreeView_DefaultState_NodesAreCollapsed()
 	{
 		// Arrange & Act - Default state: all nodes collapsed
-		var cut = RenderComponent<HxTreeView<TreeItem>>(parameters => parameters
+		var cut = Render<HxTreeView<TreeItem>>(parameters => parameters
 			.Add(p => p.Items, CreateTestData())
 			.Add(p => p.ItemTitleSelector, item => item.Title)
 			.Add(p => p.ItemChildrenSelector, item => item.Children)
@@ -104,7 +104,7 @@ public class HxTreeViewTests : BunitTestBase
 		var testData = CreateTestData();
 		TreeItem selectedItem = null;
 
-		var cut = RenderComponent<HxTreeView<TreeItem>>(parameters => parameters
+		var cut = Render<HxTreeView<TreeItem>>(parameters => parameters
 			.Add(p => p.Items, testData)
 			.Add(p => p.ItemTitleSelector, item => item.Title)
 			.Add(p => p.ItemChildrenSelector, item => item.Children)
@@ -132,7 +132,7 @@ public class HxTreeViewTests : BunitTestBase
 	public void HxTreeView_NestedExpansion_WorksCorrectly()
 	{
 		// Arrange & Act - Expand all levels
-		var cut = RenderComponent<HxTreeView<TreeItem>>(parameters => parameters
+		var cut = Render<HxTreeView<TreeItem>>(parameters => parameters
 			.Add(p => p.Items, CreateTestData())
 			.Add(p => p.ItemTitleSelector, item => item.Title)
 			.Add(p => p.ItemChildrenSelector, item => item.Children)

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Modals/HxModalTests.CloseButton.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Modals/HxModalTests.CloseButton.cs
@@ -6,7 +6,7 @@ public partial class HxModalTests : BunitTestBase
 	public async Task HxModal_CloseButton_DefaultShouldNotHaveWhiteClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxModal>(parameters => parameters
+		var cut = Render<HxModal>(parameters => parameters
 			.Add(p => p.Title, "Test Modal")
 		);
 
@@ -22,7 +22,7 @@ public partial class HxModalTests : BunitTestBase
 	public async Task HxModal_CloseButtonSettings_WhiteTrue_ShouldAddWhiteClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxModal>(parameters => parameters
+		var cut = Render<HxModal>(parameters => parameters
 			.Add(p => p.Title, "Test Modal")
 			.Add(p => p.CloseButtonSettings, new CloseButtonSettings { White = true })
 		);
@@ -39,7 +39,7 @@ public partial class HxModalTests : BunitTestBase
 	public async Task HxModal_CloseButtonSettings_WhiteFalse_ShouldNotHaveWhiteClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxModal>(parameters => parameters
+		var cut = Render<HxModal>(parameters => parameters
 			.Add(p => p.Title, "Test Modal")
 			.Add(p => p.CloseButtonSettings, new CloseButtonSettings { White = false })
 		);
@@ -56,7 +56,7 @@ public partial class HxModalTests : BunitTestBase
 	public async Task HxModal_CloseButtonSettings_WhiteTrue_ViaSettings_ShouldAddWhiteClass()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxModal>(parameters => parameters
+		var cut = Render<HxModal>(parameters => parameters
 			.Add(p => p.Title, "Test Modal")
 			.Add(p => p.Settings, new ModalSettings
 			{

--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Progress/HxProgressIndicatorTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Progress/HxProgressIndicatorTests.cs
@@ -6,7 +6,7 @@ public class HxProgressIndicatorTests : BunitTestBase
 	public void HxProgressIndicator_InProgressTrue_ShowsOverlay()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxProgressIndicator>(parameters => parameters
+		var cut = Render<HxProgressIndicator>(parameters => parameters
 			.Add(p => p.InProgress, true)
 			.Add(p => p.Delay, 0)
 		);
@@ -20,7 +20,7 @@ public class HxProgressIndicatorTests : BunitTestBase
 	public void HxProgressIndicator_InProgressFalse_HidesOverlay()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxProgressIndicator>(parameters => parameters
+		var cut = Render<HxProgressIndicator>(parameters => parameters
 			.Add(p => p.InProgress, false)
 		);
 
@@ -33,7 +33,7 @@ public class HxProgressIndicatorTests : BunitTestBase
 	public void HxProgressIndicator_Content_RemainsVisibleUnderOverlay()
 	{
 		// Arrange & Act
-		var cut = RenderComponent<HxProgressIndicator>(parameters => parameters
+		var cut = Render<HxProgressIndicator>(parameters => parameters
 			.Add(p => p.InProgress, true)
 			.Add(p => p.Delay, 0)
 			.Add(p => p.ChildContent, builder => builder.AddMarkupContent(0, "<p id=\"test-content\">Content</p>"))

--- a/Havit.Blazor.Components.Web.Tests/BunitTestBase.cs
+++ b/Havit.Blazor.Components.Web.Tests/BunitTestBase.cs
@@ -3,21 +3,15 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Havit.Blazor.Components.Web.Bootstrap.Tests;
 
-public abstract class BunitTestBase : TestContextWrapper, IDisposable
+public abstract class BunitTestBase : BunitContext
 {
 	protected BunitTestBase()
 	{
-		TestContext = new Bunit.TestContext();
 		Services.AddSingleton(TimeProvider.System);
 		Services.AddLocalization();
 		Services.AddLogging();
 		Services.AddHxServices();
 		Services.AddHxMessenger();
 		JSInterop.Mode = JSRuntimeMode.Loose;
-	}
-
-	public void Dispose()
-	{
-		TestContext?.Dispose();
 	}
 }

--- a/Havit.Blazor.Components.Web.Tests/Havit.Blazor.Components.Web.Tests.csproj
+++ b/Havit.Blazor.Components.Web.Tests/Havit.Blazor.Components.Web.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="bunit.web" />
+		<PackageReference Include="bunit" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Havit.Blazor.Components.Web.Tests/HxDynamicElementTests.cs
+++ b/Havit.Blazor.Components.Web.Tests/HxDynamicElementTests.cs
@@ -12,8 +12,6 @@ public class HxDynamicElementTests : BunitTestBase
 	public void HxDynamicElement_OnClickNotSet_ShouldNotSubscribeToClickEvent()
 	{
 		// Arrange
-		var ctx = new Bunit.BunitContext();
-
 		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>
 		{
 			builder.OpenComponent<HxDynamicElement>(0);
@@ -32,7 +30,6 @@ public class HxDynamicElementTests : BunitTestBase
 	public void HxDynamicElement_OnClickIsSet_ShouldRaiseCallbackAndRerender()
 	{
 		// Arrange
-		var ctx = new Bunit.BunitContext();
 		var onClickCallbackCallCounter = 0;
 
 		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>

--- a/Havit.Blazor.Components.Web.Tests/HxDynamicElementTests.cs
+++ b/Havit.Blazor.Components.Web.Tests/HxDynamicElementTests.cs
@@ -12,7 +12,7 @@ public class HxDynamicElementTests : BunitTestBase
 	public void HxDynamicElement_OnClickNotSet_ShouldNotSubscribeToClickEvent()
 	{
 		// Arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 
 		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>
 		{
@@ -32,7 +32,7 @@ public class HxDynamicElementTests : BunitTestBase
 	public void HxDynamicElement_OnClickIsSet_ShouldRaiseCallbackAndRerender()
 	{
 		// Arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 		var onClickCallbackCallCounter = 0;
 
 		RenderFragment componentRenderer = (RenderTreeBuilder builder) =>

--- a/Havit.Blazor.Components.Web.Tests/RenderFragmentBuilderTests.cs
+++ b/Havit.Blazor.Components.Web.Tests/RenderFragmentBuilderTests.cs
@@ -28,7 +28,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_BothSet_RendersContentFirst()
 	{
 		// assert
-		var ctx = new Bunit.BunitContext();
+		using var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom("content", (RenderTreeBuilder builder) => builder.AddContent(0, "template")));
@@ -41,7 +41,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_OnlyContentSet_RendersContent()
 	{
 		// arrange
-		var ctx = new Bunit.BunitContext();
+		using var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom("content", null));
@@ -54,7 +54,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_OnlyTemplateSet_RendersTemplate()
 	{
 		// arrange
-		var ctx = new Bunit.BunitContext();
+		using var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom(null, (RenderTreeBuilder builder) => builder.AddContent(0, "template")));
@@ -67,7 +67,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_EmptyStringContent_ReturnsFragmentWhichRendersStringEmpty()
 	{
 		// arrange
-		var ctx = new Bunit.BunitContext();
+		using var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom(String.Empty, null));

--- a/Havit.Blazor.Components.Web.Tests/RenderFragmentBuilderTests.cs
+++ b/Havit.Blazor.Components.Web.Tests/RenderFragmentBuilderTests.cs
@@ -28,7 +28,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_BothSet_RendersContentFirst()
 	{
 		// assert
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom("content", (RenderTreeBuilder builder) => builder.AddContent(0, "template")));
@@ -41,7 +41,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_OnlyContentSet_RendersContent()
 	{
 		// arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom("content", null));
@@ -54,7 +54,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_OnlyTemplateSet_RendersTemplate()
 	{
 		// arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom(null, (RenderTreeBuilder builder) => builder.AddContent(0, "template")));
@@ -67,7 +67,7 @@ public class RenderFragmentBuilderTests
 	public void RenderFragmentBuilder_CreateFrom_EmptyStringContent_ReturnsFragmentWhichRendersStringEmpty()
 	{
 		// arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 
 		// act
 		var result = ctx.Render(RenderFragmentBuilder.CreateFrom(String.Empty, null));

--- a/Havit.Blazor.Documentation.Tests/DemosSmokeTests.cs
+++ b/Havit.Blazor.Documentation.Tests/DemosSmokeTests.cs
@@ -14,7 +14,7 @@ public class DemosSmokeTests
 	public void DocumentationDemo_SmokeTest(Type demoComponent)
 	{
 		// Arrange
-		var ctx = new Bunit.TestContext();
+		var ctx = new Bunit.BunitContext();
 		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 		ctx.Services.AddLogging();
 		ctx.Services.AddHxServices();

--- a/Havit.Blazor.Documentation.Tests/DemosSmokeTests.cs
+++ b/Havit.Blazor.Documentation.Tests/DemosSmokeTests.cs
@@ -14,7 +14,7 @@ public class DemosSmokeTests
 	public void DocumentationDemo_SmokeTest(Type demoComponent)
 	{
 		// Arrange
-		var ctx = new Bunit.BunitContext();
+		using var ctx = new Bunit.BunitContext();
 		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 		ctx.Services.AddLogging();
 		ctx.Services.AddHxServices();

--- a/Havit.Blazor.Documentation.Tests/Havit.Blazor.Documentation.Tests.csproj
+++ b/Havit.Blazor.Documentation.Tests/Havit.Blazor.Documentation.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="bunit.web" />
+		<PackageReference Include="bunit" />
 		<PackageReference Include="xunit.v3.mtp-v2" />
 		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
- Bumped direct NuGet dependencies to their latest stable versions: `Havit.Core` 2.0.38→2.0.39, `Havit.AspNetCore` 2.0.31→2.0.32, `Microsoft.CodeAnalysis`/`.CSharp` 5.3.0→5.6.0, and the ASP.NET Core shared framework patch versions (8.0.28→8.0.29, 9.0.17→9.0.18, 10.0.9→10.0.10).
- Bumped `github/gh-aw-actions/setup-cli` 0.82.2→0.83.4 in the Copilot setup workflow.
- Migrated `bunit.web`/`bunit.core` 1.40.0 to the unified `bunit` 2.8.6 package. The old package split is permanently pinned to AngleSharp 1.2.0, which has a known moderate-severity vulnerability ([GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg)) — bunit 2.8.6 depends on the patched AngleSharp 1.5.2 instead. This required applying bUnit's [v1→v2 API migration](https://bunit.dev/docs/migrations/1to2.html) across the three affected test projects: `TestContext`→`BunitContext`, `RenderComponent<T>()`→`Render<T>()`, `IRenderedFragment`→`IRenderedComponent<T>`, `SetParametersAndRender()`→`Render()`, `DisposeComponents()`→`await DisposeComponentsAsync()`, `FakeNavigationManager`→`BunitNavigationManager`, and reworked both `BunitTestBase` classes to derive from `BunitContext` directly (v2 dropped `TestContextWrapper`).
- Everything else in `Directory.Packages.props` (Grpc.*, Moq, Playwright, SmartComponents, protobuf-net.Grpc — intentionally still pinned below the delisted 1.2.5 — etc.) was already at latest.

## Test plan
- [x] `dotnet restore` — succeeds cleanly (previously failed with NU1902 on the AngleSharp vulnerability before the bunit migration)
- [x] `dotnet build -c Release -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — all unit test projects pass, including all 462 tests in `Havit.Blazor.Components.Web.Bootstrap.Tests` (same count as before the bunit migration). The Playwright-based E2E test projects fail only because browser binaries aren't installed in this sandbox — pre-existing environment limitation, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)