### PR TITLE
Pin AngleSharp to 1.5.2 to fix NU1902 transitive vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,7 @@
 		<PackageVersion Include="System.Text.Json" Version="$(AspNetCoreVersion10)" />
 		<!-- Transient vulnerabilities -->
 		<PackageVersion Include="System.Formats.Asn1" Version="$(AspNetCoreVersion10)" />
+		<PackageVersion Include="AngleSharp" Version="1.5.2" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(ProjectName.EndsWith(`Tests`))' == 'False'">
 		<GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">


### PR DESCRIPTION
## What changed

Pinned `AngleSharp` to `1.5.2` in `Directory.Packages.props`.

## Why

The build fails with:

> ##[error]Package 'AngleSharp' 1.2.0 has a known vulnerability

`AngleSharp` is not referenced directly — it comes in transitively through `bunit.web` 1.40.0, which depends on `AngleSharp 1.2.0`. That version carries advisory [GHSA-9j36-3cp4-rh4j](https://github.com/advisories/GHSA-9j36-3cp4-rh4j), and the build treats `NU1902` as an error.

The repo already uses Central Package Management with `CentralPackageTransitivePinningEnabled`, so adding a `PackageVersion` overrides the transitive resolution across all projects — the same approach already used for `System.Formats.Asn1` in the "Transient vulnerabilities" section.

## Version choice

- `1.2.0` → `1.3.0` only trades one advisory for another ([GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg), moderate, affects `< 1.5.0`).
- `1.5.2` clears both.
- `bunit.web` only requires `>= 1.2.0`, and it's the same major version, so no API break.

## Verification

`dotnet restore` on all three test projects (`Havit.Blazor.Components.Web.Tests`, `Havit.Blazor.Components.Web.Bootstrap.Tests`, `Havit.Blazor.Documentation.Tests`) now succeeds with no `NU1902`/`NU1903` warnings.

## Note for reviewers

Because the build uses warnings-as-errors for `NU1902`, this class of failure will recur whenever a new AngleSharp advisory lands — the pin will just need bumping again (ideally in step with a future `bunit.web` upgrade that moves off `1.2.0` on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)