### PR TITLE
[HxMarkdown] preserve trailing hashes in ATX headings

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/MarkdownParserTests.cs
@@ -77,11 +77,23 @@ public class MarkdownParserTests
 		Assert.Equal(expected, result);
 	}
 
-	[Fact]
-	public void MarkdownParser_HeadingWithTrailingHashes_Stripped()
+	[Theory]
+	[InlineData("## Heading ##", "<h2>Heading</h2>")]
+	[InlineData("## Heading\t##", "<h2>Heading</h2>")]
+	[InlineData("### ###", "<h3></h3>")]
+	public void MarkdownParser_HeadingWithClosingSequence_Stripped(string markdown, string expected)
 	{
-		var result = MarkdownParser.ToHtml("## Heading ##", DefaultOptions);
-		Assert.Equal("<h2>Heading</h2>", result);
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Equal(expected, result);
+	}
+
+	[Theory]
+	[InlineData("# Learn C#", "<h1>Learn C#</h1>")]
+	[InlineData("## Issue #123#", "<h2>Issue #123#</h2>")]
+	public void MarkdownParser_HeadingWithTrailingHashesWithoutSeparator_Preserved(string markdown, string expected)
+	{
+		var result = MarkdownParser.ToHtml(markdown, DefaultOptions);
+		Assert.Equal(expected, result);
 	}
 
 	[Fact]

--- a/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Markdown/Internal/MarkdownParser.cs
@@ -232,8 +232,18 @@ internal static partial class MarkdownParser
 		}
 
 		var content = trimmed.Substring(level).Trim();
-		// Remove trailing #'s (optional closing)
-		content = content.TrimEnd('#').TrimEnd();
+		// Remove an optional closing sequence only when preceded by whitespace.
+		var closingSequenceStart = content.Length;
+		while (closingSequenceStart > 0 && content[closingSequenceStart - 1] == '#')
+		{
+			closingSequenceStart--;
+		}
+
+		if ((closingSequenceStart < content.Length)
+			&& ((closingSequenceStart == 0) || (content[closingSequenceStart - 1] is ' ' or '\t')))
+		{
+			content = content.Substring(0, closingSequenceStart).TrimEnd();
+		}
 
 		block = new MarkdownBlock
 		{


### PR DESCRIPTION
## summary

- preserve trailing `#` characters in ATX heading content when they are not preceded by whitespace
- continue stripping valid optional closing hash sequences preceded by a space or tab
- add regression coverage for C#-style and issue-number headings

## testing

- `dotnet test --project Havit.Blazor.Components.Web.Bootstrap.Tests/Havit.Blazor.Components.Web.Bootstrap.Tests.csproj --framework net10.0 --configuration Release` — 466 passed
- `dotnet build Havit.Blazor.slnx --configuration Release` — 0 warnings, 0 errors

Fixes #1633