### PR TITLE
[HxInputBase] Fix ValidationMessageMode XML doc to state the actual default (Floating)

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Forms/HxInputBase.cs
@@ -37,7 +37,7 @@ public abstract class HxInputBase<TValue> : InputBase<TValue>, ICascadeEnabledCo
 
 	/// <summary>
 	/// Specifies how the validation message should be displayed.<br/>
-	/// The default is <see cref="ValidationMessageMode.Regular"/>, you can override the application-wide default for all inputs in <see cref="HxInputBase.Defaults"/>.
+	/// The default is <see cref="ValidationMessageMode.Floating"/>, you can override the application-wide default for all inputs in <see cref="HxInputBase.Defaults"/>.
 	/// </summary>
 	[Parameter] public ValidationMessageMode? ValidationMessageMode { get; set; }
 	protected ValidationMessageMode ValidationMessageModeEffective => ValidationMessageMode ?? GetSettings()?.ValidationMessageMode ?? GetDefaults().ValidationMessageMode ?? HxInputBase.Defaults?.ValidationMessageMode ?? throw new InvalidOperationException(nameof(ValidationMessageMode) + " default for " + nameof(HxInputBase<TValue>) + " has to be set.");

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -4262,7 +4262,7 @@
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBase`1.ValidationMessageMode">
             <summary>
             Specifies how the validation message should be displayed.<br/>
-            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ValidationMessageMode.Regular"/>, you can override the application-wide default for all inputs in <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBase.Defaults"/>.
+            The default is <see cref="F:Havit.Blazor.Components.Web.Bootstrap.ValidationMessageMode.Floating"/>, you can override the application-wide default for all inputs in <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBase.Defaults"/>.
             </summary>
         </member>
         <member name="P:Havit.Blazor.Components.Web.Bootstrap.HxInputBase`1.FormState">

--- a/docs/generated/HxAutosuggest.md
+++ b/docs/generated/HxAutosuggest.md
@@ -36,7 +36,7 @@ Component for single item selection with dynamic suggestions (based on typed cha
 | Settings | `AutosuggestSettings` | Set of settings to be applied to the component instance (overrides `Defaults`, overridden by individual parameters). |
 | Spellcheck | `bool?` | Defines whether the input may be checked for spelling errors. Default is `false`. |
 | TextSelector | `Func<TItem, string>` | Selects the text to display from an item. When not set, `ToString()` is used. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxCheckbox.md
+++ b/docs/generated/HxCheckbox.md
@@ -28,7 +28,7 @@ Checkbox input. (Replaces the former `HxInputCheckbox` component which was dropp
 | Text | `string` | Text to display next to the checkbox. |
 | TextCssClass | `string` | CSS class to apply to the text. |
 | TextTemplate | `RenderFragment` | Content to display next to the checkbox. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in `Defaults`. |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in `Defaults`. |
 | Value | `bool` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<bool>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<bool>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxCheckboxList.md
+++ b/docs/generated/HxCheckboxList.md
@@ -35,7 +35,7 @@ Renders a multi-selection list of `HxCheckbox` controls.
 | Outline | `bool?` | Indicates whether to use Bootstrap "outline" buttons. for `CheckboxListRenderMode.ToggleButtons` and `CheckboxListRenderMode.ButtonGroup`. |
 | RenderMode | `CheckboxListRenderMode` | Checkbox render mode. |
 | Settings | `CheckboxListSettings` | Set of settings to be applied to the component instance (overrides `HxInputDate.Defaults`, overridden by individual parameters). |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `List<TValue>` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<List<TValue>>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<List<TValue>>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputDate.md
+++ b/docs/generated/HxInputDate.md
@@ -37,7 +37,7 @@ Date picker. Form input component for entering a date.
 | ShowClearButton | `bool?` | Indicates whether the Clear button in the dropdown calendar should be visible. The default is `true` (configurable in `Defaults`). |
 | ShowPredefinedDates | `bool?` | When enabled (default is `true`), shows predefined days (from `PredefinedDates`, e.g. Today). |
 | TimeProvider | `TimeProvider` | TimeProvider is resolved in the following order: 1. TimeProvider from this parameter 2. Settings TimeProvider (configurable from `Settings`) 3. Defaults TimeProvider (configurable from `Defaults`) |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputDateRange.md
+++ b/docs/generated/HxInputDateRange.md
@@ -36,7 +36,7 @@ Date range picker. Form input component for entering a start date and an end dat
 | ToCalendarDisplayMonth | `DateTime` | The month to display in the to calendar when no end date or start date is selected. It will default to `FromCalendarDisplayMonth`. |
 | ToParsingErrorMessage | `string` | Gets or sets the error message used when displaying a "to" parsing error. Used with `String.Format(...)`, `{0}` is replaced by the Label property, `{1}` is replaced by the name of the bounded property. |
 | ToPlaceholder | `string` | Placeholder for the end-date input. If not set, localized default is used ("End" + localizations). |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in `Defaults`. |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in `Defaults`. |
 | Value | `DateTimeRange` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<DateTimeRange>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<DateTimeRange>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputNumber.md
+++ b/docs/generated/HxInputNumber.md
@@ -34,7 +34,7 @@ Numeric input.
 | SmartKeyboard | `bool?` | When enabled, the input may provide an optimized keyboard experience for numeric entry. Currently, this means whenever a minus key is pressed, the sign of the number is toggled. Default is `true`. |
 | SmartPaste | `bool?` | When enabled, pasted values are normalized to contain only valid numeric characters. Default is `true`. |
 | Type | `InputType?` | Allows switching between textual and numeric input types. Only `InputType.Text` (default) and `InputType.Number` are supported. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputPercent.md
+++ b/docs/generated/HxInputPercent.md
@@ -34,7 +34,7 @@ Numeric input in percentages with value normalization (0% = 0, 100% = 1.0).
 | SmartKeyboard | `bool?` | When enabled, the input may provide an optimized keyboard experience for numeric entry. Currently, this means whenever a minus key is pressed, the sign of the number is toggled. Default is `true`. |
 | SmartPaste | `bool?` | When enabled, pasted values are normalized to contain only valid numeric characters. Default is `true`. |
 | Type | `InputType?` | Allows switching between textual and numeric input types. Only `InputType.Text` (default) and `InputType.Number` are supported. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputRange.md
+++ b/docs/generated/HxInputRange.md
@@ -23,7 +23,7 @@ Allows the user to select a number in a specified range using a slider.
 | LabelTemplate | `RenderFragment` | The label content. |
 | Settings | `InputRangeSettings` | Set of settings to be applied to the component instance (overrides `Defaults`, overridden by individual parameters). |
 | Step | `TValue` | By default, `HxInputRange` snaps to integer values. To change this, you can specify a step value. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputTags.md
+++ b/docs/generated/HxInputTags.md
@@ -37,7 +37,7 @@ Input for entering tags. Does not allow duplicate tags.
 | SuggestDelay | `int?` | The debounce delay in milliseconds. The default is `300 ms`. |
 | SuggestMinimumLength | `int?` | The minimum number of characters to start suggesting. The default is `2`. |
 | TagBadgeSettings | `BadgeSettings` | The settings for the `HxBadge` used to render tags. The default is `Color="ThemeColor.Light`" and `TextColor="ThemeColor.Dark`". |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in `Defaults`. |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in `Defaults`. |
 | Value | `List<string>` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<List<string>>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<List<string>>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputText.md
+++ b/docs/generated/HxInputText.md
@@ -32,7 +32,7 @@ Text input (including password, search, etc.)
 | Settings | `InputTextSettings` | Set of settings to be applied to the component instance (overrides `HxInputText.Defaults`, overridden by individual parameters). |
 | Spellcheck | `bool?` | Defines whether the input may be checked for spelling errors. |
 | Type | `InputType` | Input type. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in `Defaults`. |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in `Defaults`. |
 | Value | `string` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<string>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<string>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxInputTextArea.md
+++ b/docs/generated/HxInputTextArea.md
@@ -32,7 +32,7 @@ Textarea. To set a custom height, do not use the rows attribute. Instead, set an
 | Settings | `InputTextSettings` | Set of settings to be applied to the component instance (overrides `HxInputText.Defaults`, overridden by individual parameters). |
 | Spellcheck | `bool?` | Defines whether the input may be checked for spelling errors. |
 | Type | `InputType` | Input type. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in `Defaults`. |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in `Defaults`. |
 | Value | `string` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<string>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<string>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxMultiSelect.md
+++ b/docs/generated/HxMultiSelect.md
@@ -42,7 +42,7 @@ MultiSelect. Unlike a normal select, multiselect allows the user to select multi
 | Settings | `MultiSelectSettings` | Set of settings to be applied to the component instance (overrides `Defaults`, overridden by individual parameters). |
 | SortKeySelector | `Func<TItem, IComparable>` | Selects value for item sorting. When not set, `TextSelector` property will be used. If you need complex sorting, pre-sort data manually or create a custom comparable property. |
 | TextSelector | `Func<TItem, string>` | Selects text to display from an item. When not set, `ToString()` is used. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `List<TValue>` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<List<TValue>>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<List<TValue>>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxRadioButtonList.md
+++ b/docs/generated/HxRadioButtonList.md
@@ -36,7 +36,7 @@ Data-based list of radio buttons. Consider creating a custom picker derived from
 | Outline | `bool?` | Indicates whether to use Bootstrap "outline" buttons. for `RadioButtonListRenderMode.ToggleButtons` and `RadioButtonListRenderMode.ButtonGroup`. |
 | RenderMode | `RadioButtonListRenderMode` | Radio button list render mode. The default value is `RadioButtonListRenderMode.RadioButtons`. |
 | Settings | `RadioButtonListSettings` | Set of settings to be applied to the component instance (overrides , overridden by individual parameters). |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxSelect.md
+++ b/docs/generated/HxSelect.md
@@ -33,7 +33,7 @@ Select - DropDownList - single-item picker. Consider creating a custom picker de
 | Settings | `SelectSettings` | Set of settings to be applied to the component instance (overrides , overridden by individual parameters). |
 | SortKeySelector | `Func<TItem, IComparable>` | Selects the value to sort items. Uses the `TextSelector` property when not set. When complex sorting is required, sort the data manually and don't let this component sort them. Alternatively, create a custom comparable property. |
 | TextSelector | `Func<TItem, string>` | Selects the text to display from the item. When not set, `ToString()` is used. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in . |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in . |
 | Value | `TValue` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<TValue>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<TValue>>` | An expression that identifies the bound value. |

--- a/docs/generated/HxSwitch.md
+++ b/docs/generated/HxSwitch.md
@@ -25,7 +25,7 @@ Switch input. (Replaces the former `HxInputSwitch` component which was dropped i
 | Text | `string` | Text to display next to the checkbox. |
 | TextCssClass | `string` | CSS class to apply to the text. |
 | TextTemplate | `RenderFragment` | Content to display next to the checkbox. |
-| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Regular`, you can override the application-wide default for all inputs in `Defaults`. |
+| ValidationMessageMode | `ValidationMessageMode?` | Specifies how the validation message should be displayed. The default is `ValidationMessageMode.Floating`, you can override the application-wide default for all inputs in `Defaults`. |
 | Value | `bool` | Value of the input. This should be used with two-way binding. |
 | ValueChanged | `EventCallback<bool>` | A callback that updates the bound value. |
 | ValueExpression | `Expression<Func<bool>>` | An expression that identifies the bound value. |


### PR DESCRIPTION
Fixes #1764

The XML documentation for `HxInputBase<TValue>.ValidationMessageMode` claimed the default is `ValidationMessageMode.Regular`, but the application-wide default set in the static constructor has been `Floating` since the `KeepSpacce` => `Floating` rename in 2022.

Documentation-only change (option 1 from the issue) — no behavioral change:
- Fixed the XML doc comment in `HxInputBase.cs`
- Rebuilt the library to refresh `Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml`
- Regenerated `docs/generated/*.md` via `Havit.Blazor.Documentation.RepoDumpGenerator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)