### PR TITLE
[HxTooltip] Fix empty-string Text failing Bootstrap tooltip initialization

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTooltipTests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/HxTooltipTests.cs
@@ -29,6 +29,22 @@ public class HxTooltipTests : BunitTestBase
 	}
 
 	[Fact]
+	public void HxTooltip_EmptyText_DoesNotRenderDataBsTitle()
+	{
+		// #1541 Bootstrap normalizes an empty data-bs-title ("") to null and fails the config type-check.
+
+		// Act - WrapperCssClass forces the span wrapper to render even with empty Text
+		var cut = Render<HxTooltip>(p => p
+			.Add(t => t.Text, "")
+			.Add(t => t.WrapperCssClass, "my-wrapper")
+			.AddChildContent("Hover me"));
+
+		// Assert
+		var span = cut.Find("span");
+		Assert.False(span.HasAttribute("data-bs-title"));
+	}
+
+	[Fact]
 	public void HxTooltip_Placement_RendersDataBsPlacement()
 	{
 		// Act

--- a/Havit.Blazor.Components.Web.Bootstrap/Tooltips/Internal/HxTooltipInternalBase.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Tooltips/Internal/HxTooltipInternalBase.cs
@@ -141,7 +141,8 @@ public abstract class HxTooltipInternalBase : ComponentBase, IAsyncDisposable
 			{
 				builder.AddAttribute(7, "data-bs-animation", AnimationEffective.ToString().ToLower());
 			}
-			builder.AddAttribute(8, "data-bs-title", TitleInternal);
+			// #1541 An empty data-bs-title ("") gets normalized to null by Bootstrap and fails the config type-check, the attribute must be omitted entirely.
+			builder.AddAttribute(8, "data-bs-title", String.IsNullOrEmpty(TitleInternal) ? null : TitleInternal);
 			if (!String.IsNullOrWhiteSpace(ContentInternal))
 			{
 				// used only by HxPopover

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxPopover.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxPopover.js
@@ -27,7 +27,6 @@ export function enable(element) {
 	const i = bootstrap.Popover.getInstance(element);
 	if (i) {
 		i.enable();
-		console.warn("enabled");
 	}
 }
 
@@ -35,7 +34,6 @@ export function disable(element) {
 	const i = bootstrap.Popover.getInstance(element);
 	if (i) {
 		i.disable();
-		console.warn("disabled");
 	}
 }
 

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxPopover.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxPopover.js
@@ -42,6 +42,10 @@ export function disable(element) {
 export function setContent(element, newContent) {
 	const i = bootstrap.Popover.getInstance(element);
 	if (i) {
+		// #1541 Bootstrap's setContent() does not update the title/content config which drives _isWithContent(),
+		// a popover initialized with an empty title+content would never show (and vice versa).
+		i._config.title = newContent['.popover-header'] ?? '';
+		i._config.content = newContent['.popover-body'] ?? '';
 		i.setContent(newContent);
 	}
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxTooltip.js
+++ b/Havit.Blazor.Components.Web.Bootstrap/wwwroot/HxTooltip.js
@@ -40,6 +40,9 @@ export function disable(element) {
 export function setContent(element, newContent) {
 	const i = bootstrap.Tooltip.getInstance(element);
 	if (i) {
+		// #1541 Bootstrap's setContent() does not update the title config which drives _isWithContent(),
+		// a tooltip initialized with an empty title would never show (and vice versa).
+		i._config.title = newContent['.tooltip-inner'] ?? '';
 		i.setContent(newContent);
 	}
 }

--- a/Havit.Blazor.E2ETests/HxTooltipTests/HxTooltipTests.cs
+++ b/Havit.Blazor.E2ETests/HxTooltipTests/HxTooltipTests.cs
@@ -51,6 +51,49 @@ public class HxTooltipTests : TestAppTestBase
 	}
 
 	[Fact]
+	public async Task HxTooltip_Issue1541_EmptyTextWithWrapperCssClass_DoesNotThrowOnInitialization()
+	{
+		// Arrange - collect page-level JS errors and console errors (a Blazor circuit crash surfaces as a console error)
+		var jsErrors = new List<string>();
+		Page.PageError += (_, error) => jsErrors.Add(error);
+		Page.Console += (_, message) =>
+		{
+			if (message.Type == "error")
+			{
+				jsErrors.Add(message.Text);
+			}
+		};
+
+		// Act - the page initializes a tooltip with Text="" and WrapperCssClass set (issue #1541)
+		await NavigateToTestAppAsync("/HxTooltip_Issue1541_EmptyText");
+
+		var trigger = Page.Locator("[data-testid='empty-text-tooltip-trigger']");
+		await trigger.HoverAsync();
+
+		// Assert - no tooltip should appear for empty text
+		await Expect(Page.Locator(".tooltip")).Not.ToBeVisibleAsync(new() { Timeout = 2_000 });
+
+		// Assert - no JavaScript errors should have occurred
+		Assert.Empty(jsErrors);
+	}
+
+	[Fact]
+	public async Task HxTooltip_Issue1541_TextSetAfterEmptyTextInitialization_ShowsTooltip()
+	{
+		// Arrange - the page initializes a tooltip with Text="" and WrapperCssClass set (issue #1541)
+		await NavigateToTestAppAsync("/HxTooltip_Issue1541_EmptyText");
+
+		// Act - set the tooltip text afterwards and hover over the trigger
+		await Page.Locator("[data-testid='set-text-button']").ClickAsync();
+
+		var trigger = Page.Locator("[data-testid='empty-text-tooltip-trigger']");
+		await trigger.HoverAsync();
+
+		// Assert - tooltip should show the newly set text
+		await Expect(Page.Locator(".tooltip-inner")).ToHaveTextAsync("Tooltip text set later", new() { Timeout = 5_000 });
+	}
+
+	[Fact]
 	public async Task HxTooltip_EmptyText_DoesNotThrow()
 	{
 		// Arrange - collect any page-level JS errors

--- a/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxTooltipTests/HxTooltip_Issue1541_EmptyText_Test.razor
+++ b/Havit.Blazor.TestApp/Havit.Blazor.TestApp.Client/HxTooltipTests/HxTooltip_Issue1541_EmptyText_Test.razor
@@ -1,0 +1,22 @@
+@page "/HxTooltip_Issue1541_EmptyText"
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+
+@* Issue #1541 - HxTooltip does not support empty strings.
+   With nullable reference types enabled, Text is often bound to a non-nullable string property
+   whose "no tooltip" value is an empty string (not null).
+   WrapperCssClass forces the span to render, so the tooltip gets initialized with data-bs-title="",
+   which Bootstrap normalizes to null and throws:
+   TOOLTIP: Option "title" provided type "null" but expected type "(string|element|function)". *@
+
+<HxTooltip Text="@text" WrapperCssClass="issue-1541-wrapper" Animation="false">
+	<span data-testid="empty-text-tooltip-trigger">Element with empty-text tooltip</span>
+</HxTooltip>
+
+<p>
+	<button type="button" data-testid="set-text-button" @onclick="() => text = TooltipText">Set tooltip text</button>
+</p>
+
+@code {
+	private const string TooltipText = "Tooltip text set later";
+	private string text = ""; // empty string, not null (nullable reference types scenario)
+}


### PR DESCRIPTION
Fixes #1541.

## What changed

- `HxTooltipInternalBase.BuildRenderTree` now omits the `data-bs-title` attribute when the title is null **or empty** (previously an empty string rendered `data-bs-title=""`).
- `HxTooltip.js` / `HxPopover.js` `setContent()` now also syncs Bootstrap's internal `title`/`content` config before calling `Tooltip.setContent()`.
- New E2E repro page (`/HxTooltip_Issue1541_EmptyText`) + two Playwright E2E tests, and a bUnit test asserting `data-bs-title` is omitted for empty text.

## Why

When the span wrapper renders with `Text=""` (e.g. a non-nullable string property defaulting to `string.Empty` with nullable reference types enabled, plus `WrapperCssClass` forcing the wrapper to render), Bootstrap's `normalizeData()` converts the empty `data-bs-title` attribute to `null` and the Tooltip constructor's config type-check throws:

```
TOOLTIP: Option "title" provided type "null" but expected type "(string|element|function)".
```

...which crashes the Blazor circuit. Both new E2E tests reproduced this exact error before the fix.

Omitting the attribute alone would trade the crash for a silent bug: Bootstrap gates `show()` on `_isWithContent()`, which reads the config captured at initialization, so a tooltip initialized with empty text would never show even after `Text` was later set. Syncing the config in `setContent()` fixes that (and the reverse transition to empty), for both HxTooltip and HxPopover.

## Notes for review

- The JS fix touches Bootstrap's private `_config` (precedent: `HxToast.js` uses `toast._element`). Bootstrap's public `setContent()` has no supported way to update the title config.
- Verification: both new E2E tests pass, all 9 HxTooltip/HxPopover E2E tests pass, all 1389 unit tests in `Havit.Blazor.Components.Web.Bootstrap.Tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)