### PR TITLE
Bump dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,18 +2,18 @@
 	<PropertyGroup>
 <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-<AspNetCoreVersion8>8.0.29</AspNetCoreVersion8>
-<AspNetCoreVersion9>9.0.18</AspNetCoreVersion9>
-<AspNetCoreVersion10>10.0.10</AspNetCoreVersion10>
+<AspNetCoreVersion8>8.0.30</AspNetCoreVersion8>
+<AspNetCoreVersion9>9.0.19</AspNetCoreVersion9>
+<AspNetCoreVersion10>10.0.11</AspNetCoreVersion10>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
 		<PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
 		<PackageVersion Include="bunit" Version="2.9.0" />
 		<PackageVersion Include="Grpc.AspNetCore.Server" Version="2.83.0" />
-		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.80.0" />
-		<PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
-		<PackageVersion Include="Grpc.Net.Client.Web" Version="2.80.0" />
+		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.83.0" />
+		<PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
+		<PackageVersion Include="Grpc.Net.Client.Web" Version="2.83.0" />
 		<PackageVersion Include="Havit.Core" Version="2.0.39" />
 		<PackageVersion Include="Havit.AspNetCore" Version="2.0.32" />
 		<PackageVersion Include="LoxSmoke.DocXml" Version="3.9.0" />
@@ -29,8 +29,8 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion10)" />
 		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(AspNetCoreVersion10)" />
 		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion10)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis" Version="5.6.0" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis" Version="5.9.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion10)" Condition="'$(TargetFramework)' == 'net10.0'" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' != 'net10.0'" />
@@ -48,15 +48,15 @@
 		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(AspNetCoreVersion10)" Condition="'$(TargetFramework)' != 'net9.0' AND '$(TargetFramework)' != 'net8.0'" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(AspNetCoreVersion9)" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageVersion Include="Microsoft.Playwright.Xunit.v3" Version="1.61.0" />
+		<PackageVersion Include="Microsoft.Playwright.Xunit.v3" Version="1.62.0" />
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
-		<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="2.0.0" />
+		<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
 		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-		<PackageVersion Include="protobuf-net" Version="3.2.56" />
-		<PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
-		<PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-		<PackageVersion Include="protobuf-net.Grpc.ClientFactory" Version="1.2.2" />
+		<PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
+		<PackageVersion Include="protobuf-net" Version="3.4.21" />
+		<PackageVersion Include="protobuf-net.Grpc" Version="1.3.14" />
+		<PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.3.14" />
+		<PackageVersion Include="protobuf-net.Grpc.ClientFactory" Version="1.3.14" />
 		<PackageVersion Include="SmartComponents.AspNetCore" Version="0.1.0-preview10148" />
 		<PackageVersion Include="SmartComponents.AspNetCore.Components" Version="0.1.0-preview10148" />
 		<PackageVersion Include="SmartComponents.Inference.OpenAI" Version="0.1.0-preview10148" />


### PR DESCRIPTION
## What changed

Central package version bumps in `Directory.Packages.props`:

- **ASP.NET Core patch versions**: 8.0.29 → 8.0.30, 9.0.18 → 9.0.19, 10.0.10 → 10.0.11 (drives all Components.Web/WebAssembly, EF Core SqlServer, Extensions.*, Mvc.Testing, and System.Text.Json pins)
- **Grpc.AspNetCore.Web / Grpc.Net.Client / Grpc.Net.Client.Web**: 2.80.0 → 2.83.0 (aligns with Grpc.AspNetCore.Server already at 2.83.0)
- **Microsoft.CodeAnalysis + Microsoft.CodeAnalysis.CSharp**: 5.6.0 → 5.9.0
- **ModelContextProtocol.AspNetCore**: 2.0.0 → 2.2.0
- **Microsoft.Playwright.Xunit.v3**: 1.61.0 → 1.62.0
- **xunit.v3.mtp-v2**: 3.2.2 → 4.0.0 (major bump; no source changes needed)
- **protobuf-net**: 3.2.56 → 3.4.21
- **protobuf-net.Grpc / .AspNetCore / .ClientFactory**: 1.2.2 → 1.3.14

## Why

Routine dependency refresh — brings all centrally managed packages to their latest stable versions.

## Verification

- Full solution build succeeded with 0 warnings, 0 errors.
- All 9 unit-test projects pass: 1,885 tests, 0 failures (including under xunit.v3 4.0.0).
- E2E/Playwright projects build; runtime verification left to CI.

## Notes for reviewers

- All remaining packages (Azure.Monitor.OpenTelemetry, Blazored.FluentValidation, Havit.Core/AspNetCore, Moq, bunit, TrxReport, VS Threading Analyzers, …) are already at latest stable; net8.0-pinned Logging.Abstractions 8.0.3 / Logging.Configuration 8.0.1 are the newest 8.0.x releases.
- SmartComponents preview packages are no longer listed on nuget.org, so they stay at 0.1.0-preview10148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)