### PR TITLE
[HxGrid] RefreshDataAsync on a disposed grid is a silent no-op instead of throwing

### DIFF
--- a/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Basic_Tests.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap.Tests/Grids/HxGrid_Basic_Tests.cs
@@ -175,12 +175,16 @@ public class HxGrid_Basic_Tests : BunitTestBase
 	}
 
 	[Fact]
-	public async Task HxGrid_RefreshDataAsync_AfterDispose_ThrowsInvalidOperationException()
+	public async Task HxGrid_RefreshDataAsync_AfterDispose_IsNoOp()
 	{
 		// Arrange
 		var items = Enumerable.Range(1, 3).Select(i => new TestItem(i, $"Item {i}")).ToList();
+		var dataProviderCallCount = 0;
 		GridDataProviderDelegate<TestItem> dataProvider = (GridDataProviderRequest<TestItem> request) =>
-			Task.FromResult(request.ApplyTo(items));
+		{
+			dataProviderCallCount++;
+			return Task.FromResult(request.ApplyTo(items));
+		};
 
 		var cut = Render<HxGrid<TestItem>>(parameters => parameters
 			.Add(p => p.DataProvider, dataProvider)
@@ -188,12 +192,17 @@ public class HxGrid_Basic_Tests : BunitTestBase
 				.Add(c => c.HeaderText, "Name")
 				.Add(c => c.ItemTextSelector, item => item.Name)));
 
+		await cut.InvokeAsync(() => cut.Instance.RefreshDataAsync());
+		var dataProviderCallCountBeforeDispose = dataProviderCallCount;
+
 		var grid = cut.Instance;
 		await grid.DisposeAsync();
 
-		// Act + Assert
-		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => cut.InvokeAsync(() => grid.RefreshDataAsync()));
-		Assert.Equal("Cannot call RefreshDataAsync method on disposed component.", exception.Message);
+		// Act — must not throw (disposal during in-flight async work, e.g. navigation away, is a routine scenario)
+		await cut.InvokeAsync(() => grid.RefreshDataAsync());
+
+		// Assert — data provider not invoked after dispose
+		Assert.Equal(dataProviderCallCountBeforeDispose, dataProviderCallCount);
 	}
 
 }

--- a/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
+++ b/Havit.Blazor.Components.Web.Bootstrap/Grids/HxGrid.razor.cs
@@ -663,6 +663,7 @@ public partial class HxGrid<TItem> : ComponentBase, IAsyncDisposable
 	/// Requests a data refresh from the <see cref="DataProvider"/>.
 	/// Useful for updating the grid when external data may have changed.
 	/// To reset grid state (e.g., position), use <see cref="RefreshDataAsync(GridStateResetOptions)"/> instead.
+	/// Does nothing (no-op) when the component is already disposed (e.g. when the user navigated away in the meantime).
 	/// </summary>
 	public async Task RefreshDataAsync()
 	{
@@ -672,11 +673,17 @@ public partial class HxGrid<TItem> : ComponentBase, IAsyncDisposable
 	/// <summary>
 	/// Requests a data refresh from the <see cref="DataProvider"/>.
 	/// Useful for updating the grid when external data may have changed.
+	/// Does nothing (no-op) when the component is already disposed (e.g. when the user navigated away in the meantime).
 	/// </summary>
 	/// <param name="resetOptions">Specifies which aspects of the grid state should be reset before refreshing data (e.g., position).</param>
 	public async Task RefreshDataAsync(GridStateResetOptions resetOptions)
 	{
-		Contract.Requires<InvalidOperationException>(!_isDisposed, "Cannot call RefreshDataAsync method on disposed component.");
+		if (_isDisposed)
+		{
+			// Disposal during an in-flight async operation is a routine scenario (e.g. the user navigates away
+			// while the parent component awaits data and then calls RefreshDataAsync). There is no UI to refresh anymore.
+			return;
+		}
 
 		await ResetGridStateAsync(resetOptions);
 
@@ -695,7 +702,7 @@ public partial class HxGrid<TItem> : ComponentBase, IAsyncDisposable
 	{
 		if (_isDisposed)
 		{
-			return; // NOOP (explicit check in RefreshDataAsync)
+			return; // NOOP (same guard as in RefreshDataAsync, protects internal code paths)
 		}
 
 		switch (ContentNavigationModeEffective)


### PR DESCRIPTION
Fixes #1782

Changes `HxGrid.RefreshDataAsync(GridStateResetOptions)` to be a **silent no-op** when the component is already disposed, instead of throwing `InvalidOperationException` (behavior introduced in #1425).

### Why

Disposal during in-flight async work is a routine Blazor scenario, not caller misuse: a page awaits data in `OnInitializedAsync`, the user navigates away, Blazor disposes the page and the grid, and the awaited continuation then calls `RefreshDataAsync()` on the disposed grid. The caller cannot guard against this reliably (`@ref` is still non-null, disposed state is not exposed, and a check-then-call would be racy anyway).

This matches how other grids handle the same situation — QuickGrid, MudBlazor and Radzen all avoid throwing (cancellation tokens / silent guards), and the Blazor renderer itself silently ignores renders queued by disposed components. See #1782 for the full comparison.

### Changes

- `RefreshDataAsync(GridStateResetOptions)`: `Contract.Requires` throw replaced with an early `return` when `_isDisposed`; XML docs of both overloads document the no-op behavior.
- The existing guard in `RefreshDataCoreAsync` (protecting internal code paths) is kept — the original motivation of #1425 remains covered.
- Test `HxGrid_RefreshDataAsync_AfterDispose_ThrowsInvalidOperationException` replaced with `HxGrid_RefreshDataAsync_AfterDispose_IsNoOp` (verifies no exception and that the data provider is not invoked after dispose).

### Verification

`Havit.Blazor.Components.Web.Bootstrap.Tests`: 1401 passed, 0 failed (net8.0/net9.0/net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
