### PR TITLE
Bump dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,14 +2,14 @@
 	<PropertyGroup>
 <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-<AspNetCoreVersion8>8.0.30</AspNetCoreVersion8>
-<AspNetCoreVersion9>9.0.19</AspNetCoreVersion9>
-<AspNetCoreVersion10>10.0.11</AspNetCoreVersion10>
+<AspNetCoreVersion8>8.0.31</AspNetCoreVersion8>
+<AspNetCoreVersion9>9.0.20</AspNetCoreVersion9>
+<AspNetCoreVersion10>10.0.12</AspNetCoreVersion10>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
 		<PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
-		<PackageVersion Include="bunit" Version="2.9.0" />
+		<PackageVersion Include="bunit" Version="2.10.3" />
 		<PackageVersion Include="Grpc.AspNetCore.Server" Version="2.83.0" />
 		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.83.0" />
 		<PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />

--- a/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
+++ b/Havit.Blazor.Documentation/XmlDoc/Havit.Blazor.Components.Web.Bootstrap.xml
@@ -7795,12 +7795,14 @@
             Requests a data refresh from the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.DataProvider"/>.
             Useful for updating the grid when external data may have changed.
             To reset grid state (e.g., position), use <see cref="M:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.RefreshDataAsync(Havit.Blazor.Components.Web.Bootstrap.GridStateResetOptions)"/> instead.
+            Does nothing (no-op) when the component is already disposed (e.g. when the user navigated away in the meantime).
             </summary>
         </member>
         <member name="M:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.RefreshDataAsync(Havit.Blazor.Components.Web.Bootstrap.GridStateResetOptions)">
             <summary>
             Requests a data refresh from the <see cref="P:Havit.Blazor.Components.Web.Bootstrap.HxGrid`1.DataProvider"/>.
             Useful for updating the grid when external data may have changed.
+            Does nothing (no-op) when the component is already disposed (e.g. when the user navigated away in the meantime).
             </summary>
             <param name="resetOptions">Specifies which aspects of the grid state should be reset before refreshing data (e.g., position).</param>
         </member>


### PR DESCRIPTION
Updates centrally managed NuGet package versions in `Directory.Packages.props` to the latest stable versions:

- **ASP.NET Core / .NET packages**: `AspNetCoreVersion8` 8.0.30 → 8.0.31, `AspNetCoreVersion9` 9.0.19 → 9.0.20, `AspNetCoreVersion10` 10.0.11 → 10.0.12
- **bunit**: 2.9.0 → 2.10.3

All other pinned packages (Grpc 2.83.0, protobuf-net 3.4.21, Playwright 1.62.0, xunit.v3.mtp-v2 4.0.0, ModelContextProtocol.AspNetCore 2.2.0, …) are already at their latest stable versions.

Verified locally: `dotnet build` with 0 warnings (TreatWarningsAsErrors) and all 2110 tests passing (unit + Playwright E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)